### PR TITLE
Add Tisyn specification and conformance suite

### DIFF
--- a/specs/tisyn-agent-specification-1.1.0.md
+++ b/specs/tisyn-agent-specification-1.1.0.md
@@ -1,0 +1,823 @@
+# Tisyn Agent Implementation Specification
+
+**Version:** 1.1.0
+**Complements:** Tisyn Kernel Specification 1.0.0
+**Status:** Normative
+
+---
+
+## 1. Agent Role
+
+### 1.1 What an Agent Is
+
+An agent is a process that executes operations on behalf of the
+Tisyn kernel. It receives effect descriptors, performs work, and
+returns results. An agent is the system's interface to the
+outside world.
+
+### 1.2 Responsibilities
+
+- Receiving Execute requests from the host.
+- Looking up the requested operation in its registry.
+- Executing the operation with the provided arguments.
+- Returning exactly one Result per Execute request.
+- Handling cancellation signals by stopping work.
+- Tolerating duplicate execution of the same operation.
+
+### 1.3 NOT Responsible For
+
+- **Journaling.** The kernel writes journal events. The agent
+  MUST NOT attempt to read, write, or influence the journal.
+- **Replay.** The kernel decides whether to dispatch or replay.
+  The agent does not know which. A request received during
+  replay is indistinguishable from a live request.
+- **Task management.** No knowledge of parent/child, task IDs,
+  or coroutine structure.
+- **Ordering.** The kernel manages effect sequencing.
+- **Durability.** The kernel persists results in the journal.
+
+### 1.4 Side-Effect Responsibility
+
+> The agent is solely responsible for the correctness of
+> external side effects it produces. The kernel does not
+> enforce, validate, observe, or roll back side effects.
+
+If an agent writes to a database, sends an email, or charges
+a credit card, and the operation subsequently fails or is
+cancelled, the kernel records the failure but does NOT undo
+the side effect. The agent MUST manage its own transactional
+boundaries, compensations, and cleanup.
+
+### 1.5 Agent Identity
+
+```
+agentId: string   // MUST match [a-z][a-z0-9-]*, MUST NOT contain dots
+```
+
+Matches the prefix of dotted Eval `id` strings in the IR.
+Agent `"order-service"` handles effects with `id` starting
+with `"order-service."`.
+
+---
+
+## 2. Operation Registration
+
+### 2.1 Operation Identity
+
+An operation is identified by `(agentId, operationName)`. On
+the wire, the host sends `operationName` in Execute's
+`operation` field.
+
+```
+Wire:  { "operation": "fraudCheck" }
+Agent: registry["fraudCheck"] → handler
+```
+
+Operation names MUST match `[a-zA-Z][a-zA-Z0-9]*`. MUST NOT
+contain dots.
+
+### 2.2 The Registry
+
+```
+Registry = Map<string, Handler>
+Handler : (args: Val[]) → Val | Error
+```
+
+Populated at startup. MUST NOT change during the agent's
+lifetime. Adding or removing operations requires restarting
+the agent and re-initializing.
+
+### 2.3 Unknown Operations
+
+If `operation` is not in the registry, the agent MUST respond
+with a protocol error:
+
+```json
+{ "jsonrpc":"2.0", "id":"root:0",
+  "error": { "code": -32601, "message": "Unknown operation: unknownMethod" } }
+```
+
+The agent MUST NOT silently ignore unknown operations. It MUST
+NOT return an application error for this case — unknown
+operations are protocol-level failures.
+
+---
+
+## 3. Execution Contract
+
+### 3.1 Input
+
+```json
+{ "jsonrpc":"2.0", "id":"root.0:2", "method":"execute",
+  "params": {
+    "executionId": "ex-abc-123", "taskId": "root.0",
+    "operation": "fraudCheck",
+    "args": [{ "id": "order-123", "total": 150 }],
+    "progressToken": "root.0:2",
+    "deadline": "2026-03-19T12:05:00Z" }}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Correlation ID (see §3.2) |
+| `executionId` | string | Yes | Workflow execution instance |
+| `taskId` | string | Yes | Coroutine ID |
+| `operation` | string | Yes | Operation name |
+| `args` | Val[] | Yes | JSON arguments (always an array) |
+| `progressToken` | string | No | For progress notifications |
+| `deadline` | string | No | ISO 8601 absolute deadline |
+
+### 3.2 Correlation ID Semantics
+
+The `id` field is the **correlation ID**. It has the format
+`"{taskId}:{yieldIndex}"` and is the primary identifier for
+matching requests to responses.
+
+**Stability guarantee.** The correlation ID is deterministic.
+The same effect in the same workflow execution always produces
+the same correlation ID, even across:
+
+- Host restarts
+- Transport reconnections
+- Re-dispatches after crash
+
+This stability makes the correlation ID the correct key for
+deduplication (§4). When the host re-dispatches an effect after
+crash, it sends an Execute with the **same** `id` as the
+original dispatch.
+
+**Uniqueness guarantee.** Within a single execution
+(`executionId`), each correlation ID is unique. No two Execute
+requests from the same execution will have the same `id` unless
+one is a re-dispatch of the other.
+
+### 3.3 Output
+
+**Success:**
+
+```json
+{ "jsonrpc":"2.0", "id":"root.0:2",
+  "result": { "ok": true, "value": true } }
+```
+
+**Application error:**
+
+```json
+{ "jsonrpc":"2.0", "id":"root.0:2",
+  "result": { "ok": false,
+    "error": { "message": "service unavailable", "name": "ServiceError" } } }
+```
+
+**Protocol error:**
+
+```json
+{ "jsonrpc":"2.0", "id":"root.0:2",
+  "error": { "code": -32601, "message": "Unknown operation" } }
+```
+
+The response `id` MUST match the request `id`.
+
+### 3.4 Exactly One Response
+
+The agent MUST send exactly one response per Execute request.
+
+- Zero responses: the host will time out and MAY re-dispatch
+  the effect, cancel the task, or fail the workflow. The
+  timeout behavior is host-configured, not agent-controlled.
+- Multiple responses: the host discards all responses after the
+  first. The agent MUST NOT rely on the host processing a
+  second response.
+
+### 3.5 No Streaming
+
+An operation returns a single result. There is no streaming
+response mechanism. Use Progress (§10) for intermediate updates
+and a single Result for the final value.
+
+### 3.6 Result Constraints
+
+The `value` field MUST be a valid Val:
+
+- JSON primitives (string, number, boolean, null)
+- JSON arrays (containing only valid Vals)
+- JSON objects (containing only valid Vals as values)
+- Objects with `tisyn` fields are valid — they are opaque data
+  from the agent's perspective, not IR nodes
+
+The `value` field MUST NOT contain: `undefined`, `NaN`,
+`Infinity`, `-Infinity`, functions, class instances, `Symbol`,
+`BigInt`, `Date` objects, `RegExp`, `Map`, `Set`, circular
+structures, `ArrayBuffer`, or `TypedArray`.
+
+If `value` is absent when `ok` is `true`, it is treated as
+`null`.
+
+### 3.7 Deadline Semantics
+
+If `deadline` is present:
+
+- The agent SHOULD attempt to complete before it.
+- If the agent determines the deadline will be or has been
+  exceeded, it SHOULD return an application error:
+  `{ ok: false, error: { message: "deadline exceeded", name: "DeadlineExceeded" } }`
+- The agent MUST NOT silently ignore deadlines indefinitely.
+  It SHOULD implement a check, even if approximate.
+
+If `deadline` is absent, there is no time constraint from the
+host. The agent MAY still impose its own internal timeout.
+
+The host MAY independently cancel requests that exceed
+deadlines. The agent MAY receive a Cancel (§5) after a deadline
+passes, whether or not it has sent a Result.
+
+Deadline enforcement is **best-effort on both sides.** Neither
+the agent nor the host guarantees precise deadline adherence.
+
+---
+
+## 4. Idempotency
+
+### 4.1 At-Least-Once Dispatch
+
+The kernel guarantees at-least-once dispatch, NOT exactly-once.
+An effect MAY be dispatched to the agent more than once because:
+
+- The host crashed after dispatching but before writing the
+  Yield event to the journal.
+- The transport dropped after the agent sent the Result but
+  before the host received it.
+- The host timed out and re-dispatched.
+
+**The agent MUST tolerate at-least-once execution.** This is not
+optional. It is a fundamental property of the system.
+
+When a duplicate Execute arrives, it will have the **same
+correlation ID** (`id` field), the same `executionId`, the same
+`taskId`, and the same `args`. The correlation ID is the
+primary key for detecting duplicates.
+
+### 4.2 Three Strategies
+
+Every operation MUST use one of the following strategies:
+
+**Strategy A — Naturally idempotent.** The operation produces
+the same observable result regardless of execution count.
+Executing it twice has the same external effect as executing
+it once. Examples: read-only queries, pure computations,
+HTTP GET requests, lookups by ID.
+
+**Strategy B — Deduplication.** The agent tracks which
+correlation IDs it has already processed and returns the stored
+result for duplicates:
+
+```
+key = executionId + ":" + correlationId
+if key in dedup_store:
+  return dedup_store[key]
+else:
+  result = execute_operation(args)
+  dedup_store[key] = result
+  return result
+```
+
+The correlation ID is **stable across re-dispatches** — the
+same effect always produces the same ID. This is what makes
+deduplication reliable.
+
+The dedup store MUST persist across agent restarts (database,
+cache with TTL). An in-memory-only store loses entries on agent
+restart, which is precisely when re-dispatches occur.
+
+**Strategy C — Idempotency keys.** The operation's arguments
+include a key that the downstream service uses for
+deduplication. The agent passes the key through:
+
+```typescript
+*chargeCard(payment, idempotencyKey): Operation<Receipt> {
+  return yield* call(() =>
+    stripe.charges.create({
+      ...payment,
+      idempotency_key: idempotencyKey
+    }));
+}
+```
+
+The workflow provides a deterministic key (derived from order
+ID, execution ID, etc.). The downstream service deduplicates.
+
+### 4.3 Non-Idempotent Operations
+
+Operations with side effects that are NOT safe under retry
+MUST use Strategy B or C. Examples:
+
+- Sending an email (duplicate sends are visible to the user)
+- Incrementing a counter (duplicate increments corrupt data)
+- Creating a record without a dedup key (duplicates created)
+- Triggering a webhook (duplicate triggers confuse receivers)
+
+If an operation cannot implement any strategy (no dedup store
+available, no idempotency key supported by the downstream
+service), this limitation MUST be documented. The workflow
+developer MUST account for it — for example, by treating the
+operation as best-effort and handling duplicate side effects
+in the business logic.
+
+### 4.4 Documentation Requirement
+
+Each agent MUST document, for every operation:
+
+1. Whether the operation is naturally idempotent (Strategy A).
+2. If not, which mitigation strategy is used (B or C).
+3. Any conditions under which idempotency breaks (e.g., dedup
+   store TTL expired, downstream service does not honor key).
+4. What side effects the operation produces and whether they
+   are safe under retry.
+
+---
+
+## 5. Cancellation
+
+### 5.1 Delivery
+
+```json
+{ "jsonrpc":"2.0", "method":"cancel",
+  "params": { "id": "root.0:2", "reason": "parent_cancelled" } }
+```
+
+Cancel is a JSON-RPC **notification** — no `id` field at the
+JSON-RPC level, no response expected. `params.id` is the
+correlation ID of the Execute being cancelled. `reason` is
+optional and human-readable.
+
+### 5.2 Best-Effort Semantics
+
+Cancellation is **best-effort, not guaranteed.** The agent
+SHOULD:
+
+1. Look up the in-flight operation by correlation ID.
+2. Stop ongoing work (abort HTTP requests, close database
+   cursors, release resources).
+3. NOT send a Result for the cancelled operation.
+
+The agent MAY:
+
+- Ignore the Cancel if the operation has already completed
+  and a Result was already sent.
+- Take a reasonable amount of time to clean up before
+  ceasing work.
+
+The agent MUST NOT:
+
+- Crash or enter an error state due to a Cancel.
+- Treat Cancel as a protocol error.
+- Send an error response to the Cancel notification.
+
+### 5.3 Cancel Racing with Completion
+
+When cancellation races with operation completion, two outcomes
+are possible:
+
+**Agent completes first.** The agent sends a Result before
+receiving the Cancel (or ignoring it because the operation is
+done). The host receives the Result. Whether the host uses it
+depends on the host's internal state — if the host has already
+set the task's `cancelling` flag, it discards the Result.
+
+**Cancel arrives first.** The agent receives the Cancel before
+completing. The agent stops work and does not send a Result.
+The host writes Close(cancelled) for the task.
+
+In both cases, the agent's behavior is correct. The agent does
+not need to know which outcome the host chose. The agent's
+obligation is: attempt to stop work on Cancel, and send at most
+one Result per Execute.
+
+### 5.4 Late Results
+
+If the agent sends a Result after the host has cancelled the
+task (host set `cancelling = true`, wrote Close(cancelled)),
+the host silently discards the Result. No Yield event is written.
+This is normal operation, not an error. The agent does not
+receive any indication that its Result was discarded.
+
+### 5.5 Cancel for Unknown Correlation ID
+
+If the agent receives a Cancel with a correlation ID it does not
+recognize (e.g., the Execute was processed on a previous
+connection, or the Cancel arrived before the Execute due to
+transport reordering), the agent MUST silently discard the
+Cancel. It MUST NOT treat this as an error.
+
+### 5.6 Cancel + Re-dispatch
+
+If a cancelled operation is re-dispatched after a host crash,
+the agent receives a fresh Execute with the same correlation ID
+as before. The agent MUST execute it normally — it MUST NOT
+refuse because it previously received a Cancel for that ID.
+
+---
+
+## 6. Concurrency
+
+### 6.1 Declaration
+
+```json
+{ "capabilities": { "concurrency": 10 } }
+```
+
+The agent declares the maximum number of Execute requests it
+can process simultaneously on a single connection. Default: 1.
+
+### 6.2 Host Obligation
+
+The host MUST NOT send more concurrent Execute requests than
+the agent's declared concurrency limit. "Concurrent" means
+Execute requests for which the host has not yet received a
+Result.
+
+### 6.3 Exceeding the Limit
+
+If the agent receives more concurrent Execute requests than
+its declared limit (host bug or race condition):
+
+- The agent SHOULD reject the excess request with a protocol
+  error: `{ "error": { "code": -32003, "message": "Concurrency limit exceeded" } }`
+- The agent MAY queue the excess request and process it when
+  a slot opens.
+- The agent MUST NOT silently drop the request.
+- The agent MUST NOT crash.
+
+### 6.4 No Ordering Guarantees
+
+When multiple Execute requests are in-flight simultaneously,
+the agent MAY process and respond to them in any order. The
+agent MUST NOT:
+
+- Assume any ordering relationship between concurrent requests.
+- Assume concurrent requests are related (they may be from
+  different tasks, different workflows, or the same task).
+- Block one request waiting for another's result.
+- Deadlock due to ordering assumptions.
+- Require a specific completion order.
+
+The agent MAY: execute requests in parallel, queue and execute
+sequentially, or mix strategies.
+
+---
+
+## 7. Error Handling
+
+### 7.1 Two Categories
+
+Errors are strictly divided into two categories with different
+lifecycle implications:
+
+**Application errors** — the operation ran (or attempted to run)
+but could not produce a successful result. These are returned
+via `result.ok = false`. The host **journals** application
+errors as Yield(err) events. They **participate in replay** —
+on replay, the same error is delivered to the kernel.
+
+**Protocol errors** — the request was malformed, the operation
+is unknown, or the agent is misconfigured. These are returned
+via the JSON-RPC `error` field. The host does NOT journal
+protocol errors. They indicate bugs or misconfiguration and
+cause the task to fail without a replay record.
+
+### 7.2 Classification Rules
+
+| Situation | Category | Reason |
+|-----------|----------|--------|
+| Database query failed | Application | Operation attempted, infrastructure failed |
+| External API returned 500 | Application | Operation attempted, dependency failed |
+| Input validation failed | Application | Operation rejected input |
+| Timeout waiting for response | Application | Operation could not complete in time |
+| Business rule violation | Application | Operation logic rejected request |
+| Unknown operation name | Protocol | Agent misconfigured or host sent wrong name |
+| Missing required field | Protocol | Malformed Execute message |
+| Invalid JSON | Protocol | Transport or serialization bug |
+| Agent not initialized | Protocol | Lifecycle violation |
+
+**Rule of thumb:** if the operation handler was invoked, the
+error is application. If the error occurred before the handler
+could be invoked, it is protocol.
+
+### 7.3 Error Structure
+
+```typescript
+interface ApplicationError {
+  message: string;    // MUST be non-empty
+  name?: string;      // SHOULD be CamelCase error class name
+}
+```
+
+Both fields MUST be strings. `message` MUST be non-empty.
+`name` is optional and is used for programmatic error
+classification on the host side.
+
+The error object MUST NOT contain additional fields beyond
+`message` and `name`. Agents that need to convey structured
+error data SHOULD encode it in the `message` string.
+
+### 7.4 Unhandled Exceptions
+
+If the operation handler throws an uncaught exception, the
+agent runtime MUST catch it and convert to an application error:
+
+```json
+{ "ok": false, "error": { "message": "Internal error: <exception message>", "name": "InternalError" } }
+```
+
+The agent MUST NOT crash due to an unhandled exception in an
+operation handler. It MUST remain available for subsequent
+requests on the same connection.
+
+### 7.5 Partial Failure and Side Effects
+
+If the operation partially completed before failing (e.g.,
+wrote to a database then failed on a subsequent step):
+
+1. The agent returns an application error.
+2. The host records a Yield(err) event.
+3. The committed side effects **are not rolled back** by the
+   kernel. The kernel has no mechanism for rollback.
+4. If the effect is re-dispatched (crash + retry), the agent
+   receives the same request. Its idempotency strategy (§4)
+   MUST handle the partially-completed state.
+
+---
+
+## 8. Serialization Contract
+
+### 8.1 JSON Only
+
+All data crossing the agent boundary MUST be JSON-serializable
+per RFC 8259. This applies to:
+
+- `args` (host → agent)
+- `result.value` (agent → host)
+- `result.error` (agent → host)
+- `progress.value` (agent → host)
+
+### 8.2 Prohibited Values
+
+The following MUST NOT appear in any data crossing the boundary:
+
+`undefined`, `NaN`, `Infinity`, `-Infinity`, functions, class
+instances, `Symbol`, `BigInt`, `Date` (serializes lossily),
+`RegExp` (serializes to `{}`), `Map`, `Set`, `WeakMap`,
+`WeakSet`, `ArrayBuffer`, `TypedArray`, circular structures.
+
+The agent MUST validate that its return values satisfy this
+constraint. A value that passes `JSON.parse(JSON.stringify(v))`
+without change satisfies the constraint.
+
+### 8.3 Numbers
+
+All numbers MUST be IEEE 754 binary64. Integers are exact up
+to 2^53 - 1. The agent MUST NOT return numbers requiring
+greater precision (use strings for large IDs, BigDecimal
+amounts, etc.).
+
+### 8.4 Opaque Arguments
+
+Arguments MAY contain objects with `tisyn` fields. These are
+**opaque data**, not IR nodes. The agent MUST:
+
+- Treat all arguments as plain JSON data.
+- NOT interpret `tisyn` fields as evaluation instructions.
+- NOT attempt to evaluate, execute, or dispatch based on
+  `tisyn` field values.
+- NOT modify, strip, or rename `tisyn` fields.
+
+An agent that wishes to interpret Fn nodes (as a Tisyn
+evaluator) MAY do so, but this is opt-in behavior outside
+the standard agent contract.
+
+---
+
+## 9. Reconnect and Duplicates
+
+### 9.1 Fresh Session on Reconnect
+
+If the transport connection drops and the agent reconnects,
+it MUST send Initialize again. There is no session resumption
+at the protocol level.
+
+The host re-dispatches all effects that were pending on the
+lost connection. The re-dispatched Execute requests have the
+**same correlation IDs** as the original dispatches.
+
+### 9.2 Duplicate Execution
+
+The agent MAY receive an Execute with the same correlation ID
+as a request it already processed (on the current or a previous
+connection). The agent MUST handle this per §4 (idempotency).
+
+If the agent uses Strategy B (deduplication), it looks up the
+correlation ID in its dedup store. If found, it returns the
+stored result without re-executing. If not found (store expired,
+agent restarted without persistent store), it re-executes.
+
+### 9.3 Stale Connections
+
+The host MAY close connections it considers stale (agent
+unresponsive, heartbeat missed). The agent MUST NOT assume
+connection longevity. Long-running operations SHOULD:
+
+- Implement internal checkpointing.
+- Use keep-alive mechanisms if the transport supports them.
+- Be prepared for abrupt disconnection.
+
+### 9.4 Multiple Instances
+
+Multiple agent instances with the same `agentId` MAY connect
+simultaneously. The host load-balances Execute requests across
+connections. The host MUST NOT send the same correlation ID to
+multiple connections simultaneously.
+
+If one instance disconnects, its pending effects are
+re-dispatched to a remaining instance (which may receive a
+correlation ID it has never seen — this is normal, handle per
+§4).
+
+---
+
+## 10. Progress Reporting
+
+### 10.1 Capability Declaration
+
+```json
+{ "capabilities": { "progress": true } }
+```
+
+If `progress` is not declared or is `false`, the agent MUST NOT
+send Progress notifications.
+
+### 10.2 Message
+
+```json
+{ "jsonrpc":"2.0", "method":"progress",
+  "params": { "token": "root.0:2",
+    "value": { "phase": "downloading", "percent": 45 } } }
+```
+
+`token` MUST match the `progressToken` from the Execute request.
+`value` is agent-defined JSON (any valid Val).
+
+### 10.3 Durability and Replay
+
+Progress notifications are **NOT durable**:
+
+- They are NOT written to the journal.
+- They are NOT replayed during crash recovery.
+- They are NOT guaranteed to be delivered to observers.
+- They MAY be lost if the transport disconnects.
+- They MAY be lost if no observer is connected.
+
+Progress is ephemeral. It exists only for real-time observation
+of in-flight operations.
+
+### 10.4 Ordering
+
+Progress notifications for a single token are delivered in the
+order the agent sent them, within a single connection. If the
+connection drops and reconnects, progress from the previous
+connection is lost — there is no replay of missed progress.
+
+There is no ordering guarantee between progress from different
+tokens (different operations).
+
+### 10.5 Lifecycle
+
+Progress is valid only between Execute dispatch and Result
+response:
+
+```
+Execute sent → [progress valid] → Result received
+```
+
+Progress sent after the Result is silently discarded by the
+host. Progress sent after a Cancel is silently discarded.
+
+### 10.6 No Token = No Progress
+
+If the Execute request has no `progressToken` (field absent or
+`null`), the agent MUST NOT send Progress notifications for
+that request.
+
+---
+
+## 11. Implementation Guide
+
+### 11.1 Minimal Agent
+
+1. Connect to host.
+2. Send Initialize with `agentId` and `capabilities`.
+3. Receive Execute → look up `operation` → call handler →
+   send Result.
+4. Handle Cancel by aborting in-flight work.
+5. On Shutdown, complete or cancel in-flight work and close.
+
+### 11.2 Effection Runtime
+
+Operations are Effection generators. Agent runtime creates an
+Effection scope per operation:
+
+```typescript
+async function handleExecute(msg: ExecuteMessage) {
+  const handler = registry[msg.params.operation];
+  if (!handler) return protocolError(-32601);
+  const scope = createScope();
+  activeScopesByCorrelationId.set(msg.id, scope);
+  try {
+    const value = await scope.run(() =>
+      handler(...msg.params.args));
+    return { ok: true, value };
+  } catch (error) {
+    return { ok: false, error: {
+      message: error.message, name: error.name } };
+  } finally {
+    activeScopesByCorrelationId.delete(msg.id);
+  }
+}
+```
+
+Cancel destroys the scope:
+
+```typescript
+function handleCancel(msg: CancelMessage) {
+  const scope = activeScopesByCorrelationId.get(msg.params.id);
+  if (scope) scope.destroy();
+  // No response. Silently ignore if not found.
+}
+```
+
+### 11.3 Internal `yield*`
+
+Inside operations, `yield*` is Effection structured concurrency
+— NOT durable, NOT journaled. From the kernel's perspective,
+the entire operation is one atomic effect. One Yield event
+covers the whole operation, regardless of how many internal
+`yield*` calls occur.
+
+### 11.4 Agent-Side Validation
+
+The agent SHOULD validate arguments before executing:
+
+```typescript
+*fraudCheck(order: Order): Operation<boolean> {
+  if (!order || typeof order.total !== 'number')
+    throw new Error("Invalid order: missing or non-numeric total");
+  // ... execute
+}
+```
+
+Validation failures become application errors (§7.4).
+
+---
+
+## 12. Transport Bindings
+
+### 12.1 Supported
+
+| Binding | Framing | Direction |
+|---------|---------|-----------|
+| WebSocket | WS messages | Bidirectional |
+| Stdio | NDJSON | Bidirectional |
+| SSE + POST | SSE↓ POST↑ | Asymmetric |
+| In-process | Object passing | Bidirectional |
+
+### 12.2 Requirements
+
+All transports MUST:
+
+- Deliver messages in order per direction.
+- Deliver complete messages (no partial JSON).
+- Support the full message catalog (Initialize, Execute,
+  Result, Progress, Cancel, Shutdown).
+
+---
+
+## 13. Conformance Checklist
+
+| # | Requirement | § |
+|---|-------------|---|
+| 1 | Initialize as first message | 3.1 |
+| 2 | Declare `agentId` and capabilities | 1.5, 6.1 |
+| 3 | Exactly one Result per Execute | 3.4 |
+| 4 | Protocol error for unknown operations | 2.3 |
+| 5 | Result values are JSON-serializable | 3.6 |
+| 6 | Tolerate duplicate Execute (at-least-once) | 4.1 |
+| 7 | Handle Cancel best-effort | 5.2 |
+| 8 | No crash on Cancel for unknown ID | 5.5 |
+| 9 | No crash on unhandled exception | 7.4 |
+| 10 | Respect declared concurrency limit | 6.1 |
+| 11 | Progress only when declared + token | 10.1, 10.6 |
+| 12 | Initialize on reconnect (fresh session) | 9.1 |
+| 13 | Treat arguments as opaque JSON | 8.4 |
+| 14 | Document idempotency per operation | 4.4 |
+| 15 | Handle Shutdown gracefully | 11.1 |
+| 16 | Side effects are agent's responsibility | 1.4 |
+| 17 | Do not interpret `tisyn` fields | 8.4 |
+| 18 | Application vs protocol error distinction | 7.1 |

--- a/specs/tisyn-architecture.md
+++ b/specs/tisyn-architecture.md
@@ -1,0 +1,926 @@
+# Tisyn: Architecture and Design Rationale
+
+**Document type:** Technical architecture
+**Audience:** Engineers, architects, and system designers
+
+---
+
+## 1. Introduction
+
+### 1.1 The Problem
+
+Modern software systems are distributed. A business operation
+that once lived inside a single process — place an order, check
+for fraud, charge a card, send a confirmation — now spans
+multiple services, each with independent failure modes. The
+operation takes seconds or hours. It must survive server crashes,
+network partitions, and service outages. And when something fails
+partway through, the system must know what happened and what to
+do next.
+
+The standard approaches each solve part of the problem: retry
+loops handle transient failures but not crashes; message queues
+survive crashes but scatter workflow logic across consumer
+definitions; the saga pattern handles partial failure but
+requires every operation to have a compensating inverse;
+database-backed state machines survive crashes but encode logic
+as state tables. Each approach forces the developer to write
+infrastructure alongside business logic.
+
+### 1.2 The Insight
+
+If you can replay a computation from a log of its external
+interactions, you don't need to serialize its internal state. A
+workflow that made three remote calls and received three results
+can be reconstructed by creating a fresh instance and feeding it
+the same three results. It will follow the same code path, create
+the same local variables, make the same branching decisions, and
+arrive at the same suspension point.
+
+This requires two properties: **determinism** (same external
+results → same path) and **effect isolation** (all external
+interactions go through a recordable boundary). Traditional
+programming languages violate both — JavaScript has
+nondeterministic APIs and implicit side effects everywhere.
+
+### 1.3 The Solution
+
+Tisyn addresses this by separating programs into three concerns:
+
+**Structure.** The workflow's logic is represented as an immutable
+JSON document (the IR). It contains no nondeterminism, no side
+effects, and no closures.
+
+**Effects.** External interactions are represented as named
+operations with serializable arguments. The kernel yields
+descriptors to the execution layer, which dispatches them to
+agents, records the results, and feeds them back.
+
+**Journal.** Every effect result is appended to a durable log
+before the kernel sees it. On crash, a new kernel reads the log,
+replays stored results into a fresh evaluation, and resumes from
+the crash point.
+
+The developer writes generator functions in a restricted
+TypeScript subset. A compiler transforms them into the IR. The
+runtime evaluates the IR, dispatches effects, and manages the
+journal. The developer never sees the IR, the journal, or the
+replay mechanism.
+
+---
+
+## 2. Architectural Overview
+
+### 2.1 The Pipeline
+
+```
+                    ┌────────────────────────────────────────────────┐
+                    │                  Host Process                  │
+User Code ──▶ Compiler ──▶ IR (JSON) ──▶ Validation                 │
+                                              │                     │
+                                        ┌─────▼──────┐             │
+                                        │   Kernel   │◀── resume ─┐│
+                                        │ (evaluator)│            ││
+                                        └─────┬──────┘            ││
+                                              │ EffectDescriptor  ││
+                                        ┌─────▼───────────────┐   ││
+                                        │  Execution Layer    │   ││
+                                        │  ┌────────┐ ┌─────┐│───┘│
+                                        │  │Replay  │ │Route││    │
+                                        │  │Index   │ │     ││    │
+                                        │  └───┬────┘ └──┬──┘│    │
+                                        │      │         │   │    │
+                                        │  ┌───▼───┐ ┌───▼─┐│    │
+                                        │  │Journal│ │Trans││    │
+                                        │  │(Durable│ │port ││    │
+                                        │  │Stream) │ │Pool ││    │
+                                        │  └───────┘ └──┬──┘│    │
+                                        └───────────────┼───┘    │
+                                        └───────────────┼────────┘
+                                                        │ JSON-RPC 2.0
+                              ┌──────────────────┼──────────────────┐
+                              ▼                  ▼                  ▼
+                        ┌──────────┐       ┌──────────┐       ┌──────────┐
+                        │ Agent A  │       │ Agent B  │       │ Agent C  │
+                        └────┬─────┘       └────┬─────┘       └────┬─────┘
+                             ▼                  ▼                  ▼
+                        External            External            External
+                        Systems             Systems             Systems
+```
+
+### 2.2 Layer Responsibilities
+
+| Layer | Input | Output | Responsibility | MUST NOT |
+|-------|-------|--------|---------------|----------|
+| **Compiler** | TypeScript generators | IR (JSON) | Transform code to serializable tree | Emit non-JSON, depend on runtime state |
+| **Validation** | IR (JSON) | Validated IR | Verify grammar, single-Quote rule, scope | Change the IR |
+| **Kernel** | IR + Environment | Val or Suspend | Evaluate expressions, yield effects | Know about agents, journal, transport |
+| **Execution Layer** | Effect descriptors | Results | Replay or dispatch, journal, task mgmt | Evaluate IR (delegates to kernel) |
+| **Agent** | Execute message | Result message | Perform external work, return JSON | Access journal, know about replay |
+| **Transport** | JSON-RPC messages | JSON-RPC messages | Deliver messages host ↔ agents | Affect semantics |
+| **Journal** | Yield/Close events | Stored events | Durable append-only log | Lose acknowledged events |
+
+### 2.3 Boundaries
+
+Three hard boundaries separate the layers:
+
+**Compiler → Kernel.** The IR is JSON. No TypeScript types, no
+closures, no functions, no prototypes. Between compilation and
+evaluation, the IR is validated: grammar conformance, single-Quote
+rule at every evaluation position, all Refs bound by enclosing
+Let or Fn. Invalid IR is rejected before evaluation begins.
+
+**Kernel → Execution Layer.** Effect descriptors are
+`{ id: string, data: Val }` for standard effects and
+`{ id: string, data: { exprs: Expr[] } }` for compound effects.
+The kernel does not know how effects are dispatched, whether
+results come from agents or from the journal, or how many agents
+exist. The execution layer does not evaluate IR — it delegates
+evaluation to the kernel.
+
+**Execution Layer → Agent.** JSON-RPC 2.0 messages over a
+transport. The agent does not know about the journal, replay,
+task structure, or the IR. It receives a request and returns a
+result. The agent is solely responsible for the correctness of
+its external side effects — the kernel does not enforce, validate,
+or roll back side effects.
+
+---
+
+## 3. Execution Flow
+
+### 3.1 End-to-End: One Effect
+
+The path of a single agent method call through the entire system:
+
+```
+Step  Component          Action
+────  ─────────          ──────
+ 1    Developer          writes: const order = yield* OrderService().fetchOrder(id)
+ 2    Compiler           transforms to: Let("order", Eval("order-service.fetchOrder",
+                                              [Ref("id")]), ...)
+ 3    Validation         checks: Eval data not quoted (external), Ref("id") bound
+ 4    Kernel             evaluates the Let, reaches the Eval node
+ 5    Kernel             classifies "order-service.fetchOrder" → EXTERNAL
+ 6    Kernel             calls resolve([Ref("id")], E) → ["order-123"]
+ 7    Kernel             yields Suspend({ id:"order-service.fetchOrder",
+                                         data:["order-123"] })
+ 8    Execution Layer    checks ReplayIndex for coroutine "root", cursor 0
+ 9a   (replay)           entry found, description matches → feed stored result → step 13
+ 9b   (live)             no entry → continue to step 10
+10    Execution Layer    parses id → type:"order-service", name:"fetchOrder"
+11    Execution Layer    routes to Agent A, sends Execute message:
+                           { id:"root:0", operation:"fetchOrder",
+                             args:["order-123"] }
+12    Agent A            executes fetchOrder, returns Result:
+                           { ok:true, value:{ id:"order-123", total:150, ... } }
+13    Execution Layer    constructs Yield event:
+                           { type:"yield", coroutineId:"root",
+                             description:{ type:"order-service", name:"fetchOrder" },
+                             result:{ status:"ok", value:{ id:"order-123", ... } } }
+14    Execution Layer    appends Yield to journal, awaits durable ack
+15    Execution Layer    resumes kernel with the value
+16    Kernel             binds "order" → { id:"order-123", total:150, ... }
+17    Kernel             continues evaluating the Let body
+```
+
+**Steps 8-9** are the replay/live decision point. The kernel is
+identical in both paths — it does not know which path was taken.
+
+**Steps 13-15** are the persist-before-resume sequence. The Yield
+is durably acknowledged before the kernel sees the result.
+
+### 3.2 Correlation ID Flow
+
+Each effect dispatch carries a correlation ID that flows through
+the entire system:
+
+```
+Kernel yields effect              →  correlationId = "root:0"
+                                      (taskId "root" + yieldIndex 0)
+Execution Layer sends Execute     →  { "id": "root:0", ... }
+Agent processes and responds      →  { "id": "root:0", "result": ... }
+Execution Layer matches response  →  looks up "root:0" in pending set
+Execution Layer writes Yield      →  event includes coroutineId "root"
+```
+
+The correlation ID is **deterministic**: the same effect in the
+same workflow always produces the same ID (same taskId, same
+yieldIndex). This stability across crashes and re-dispatches
+enables agent-side deduplication.
+
+### 3.3 Concurrency Flow
+
+When the kernel encounters an `all` node:
+
+```
+Step  Component          Action
+────  ─────────          ──────
+ 1    Kernel             reaches Eval("all", Q({exprs:[E1, E2]}))
+ 2    Kernel             classifies "all" → EXTERNAL (compound)
+ 3    Kernel             calls unquote(data, E) — NOT resolve
+ 4    Kernel             yields Suspend({ id:"all", data:{exprs:[E1,E2]} })
+                         (child expressions preserved unevaluated)
+ 5    Execution Layer    creates child task "root.0" for E1
+ 6    Execution Layer    creates child task "root.1" for E2
+ 7    Execution Layer    each child receives parent's environment (pointer copy)
+ 8    Child root.0       evaluates E1, crosses its own effect boundaries
+ 9    Child root.1       evaluates E2, crosses its own effect boundaries
+10    Execution Layer    collects results [R0, R1] in exprs order
+11    Execution Layer    resumes parent kernel with [R0, R1]
+```
+
+**Step 3** is critical: `unquote` preserves child expressions.
+If `resolve` were used, children would evaluate in the parent
+task — no child tasks, no concurrent execution, wrong journal.
+
+---
+
+## 4. Intermediate Representation
+
+### 4.1 Why an AST?
+
+Most workflow engines execute workflows by running native code.
+Temporal replays native functions; Azure Durable Functions
+re-executes orchestrator code. Tisyn takes a different approach:
+the workflow is data. The compiler transforms the developer's
+code into a JSON tree, and the kernel evaluates that tree.
+
+This has three consequences. **Determinism by construction:**
+the tree contains no nondeterministic operations. The only
+nondeterminism is external effects, captured by the journal.
+**Inspectability:** the tree is JSON, serializable, diffable,
+and visualizable. **Portability:** any language can evaluate
+the same JSON tree.
+
+### 4.2 The Five Node Types
+
+```
+Literal  — JSON values (numbers, strings, objects, arrays)
+Eval     — a computation: { tisyn: "eval", id, data }
+Quote    — a delayed expression: { tisyn: "quote", expr }
+Ref      — a variable reference: { tisyn: "ref", name }
+Fn       — a function value: { tisyn: "fn", params, body }
+```
+
+Every computation — from integer addition to cross-network agent
+calls — is an `Eval` node. The kernel's classification function
+determines whether an `Eval` is structural (evaluated locally)
+or external (yielded to the execution layer).
+
+### 4.3 Val vs Expr: Context-Based Classification
+
+A fundamental design choice: the same JSON object can be either
+an expression or a value, depending on where it appears.
+
+- An **Expr** when the kernel encounters it during tree traversal.
+- A **Val** when returned by `lookup()`, `eval()`, or received
+  from an agent.
+
+There is no structural `is_val` predicate. The origin determines
+classification. This means agents can return any JSON data —
+including objects that happen to contain `tisyn` fields — without
+the system re-interpreting them as IR nodes.
+
+### 4.4 Quote: The Delay Mechanism
+
+Structural operations like `if` need their branches to be
+unevaluated until the condition is checked. `Quote` prevents
+evaluation, providing explicit call-by-name semantics.
+
+**The single-Quote invariant:** structural operation data uses
+exactly one Quote layer. The sub-expressions at positions the
+operation evaluates must not be Quotes. The positions are defined
+exhaustively per operation (a table in the language spec covers
+all 18 structural operations). This invariant eliminates nested-
+evaluation ambiguity — the kernel never needs to decide whether
+a result needs another evaluation step.
+
+### 4.5 Validation
+
+Between compilation and evaluation, the IR is validated:
+
+1. Every node conforms to the grammar (correct `tisyn`
+   discriminant, required fields present and correctly typed).
+2. Every structural Eval's `data` is a Quote.
+3. No Quote node at any evaluation position (single-Quote rule).
+4. Every Ref is bound by an enclosing Let or Fn (scope
+   consistency).
+5. Fn params are non-empty strings with no duplicates.
+6. Malformed nodes (matching `tisyn` but missing fields) are
+   errors, never treated as Literals.
+
+Validation runs before evaluation begins. Invalid IR is rejected
+with a diagnostic.
+
+### 4.6 Related Work
+
+Programs-as-data traces from **Lisp (1958)** through **free
+monads** (computations as syntax trees with external handlers)
+to **Unison's** content-addressed code. Tisyn's IR is
+conceptually a free monad: the tree describes a computation,
+the kernel provides the interpretation. Compared to Temporal,
+which trusts the developer to be deterministic, Tisyn's tree
+is deterministic by construction.
+
+---
+
+## 5. Kernel and Evaluation Model
+
+### 5.1 The Kernel as Interpreter
+
+The kernel implements a recursive evaluation function:
+
+```
+eval : (Expr, Env) → Val | Error | Suspend(EffectDescriptor)
+```
+
+The three-outcome signature makes the evaluator a coroutine: it
+yields control at effect boundaries and resumes with results. In
+implementation, the kernel is a JavaScript generator. `Suspend`
+maps to `yield`. The Effection structured concurrency library
+manages the generator's lifecycle.
+
+### 5.2 The Environment
+
+The kernel maintains an environment — a linked list of immutable
+frames mapping names to values (Abelson and Sussman, SICP §3.2).
+Immutability guarantees determinism (no mutation from concurrent
+tasks or external events) and concurrency safety (child tasks
+receive pointers to the same frame chain — no cloning, no
+locking). Only Vals may enter the environment. Eval, Quote, and
+Ref nodes must be fully evaluated before storage.
+
+### 5.3 Two Data Preparation Functions
+
+**`unquote(node, E)`** strips one Quote layer, returning raw Expr
+fields. Used by structural operations to access their data
+without evaluating it. The result may contain unevaluated
+expressions that the operation evaluates selectively.
+
+**`resolve(node, E)`** recursively resolves all Expr nodes to
+produce a fully resolved Val. Used exclusively at the external
+effect boundary for standard (non-compound) effects. The **opaque
+value rule** ensures `resolve` never re-enters values returned by
+`lookup` or `eval`, preventing agent-returned data from being
+re-interpreted as code.
+
+**Compound external operations** (`all`, `race`, `spawn`) use
+`unquote` instead of `resolve`, preserving child expressions for
+the execution layer to spawn as separate tasks.
+
+### 5.4 Call-Site Resolution
+
+Tisyn functions have no closures. A `Fn` body evaluates in the
+caller's environment extended with parameter bindings, not the
+definer's environment. This is dynamic scoping for free variables.
+
+This design enables two critical patterns:
+
+1. **Recursive loops.** The compiler transforms while-with-return
+   into a Fn that references itself via `Ref`, resolved in the
+   caller's environment where the `Let` binding holds the Fn.
+
+2. **Fn bodies with effects.** The `call` structural operation
+   invokes `eval(F.body, E')`. If the body contains external Eval
+   nodes, they cross the execution boundary normally — the kernel
+   suspends and resumes transparently. This is what makes
+   recursive loops and sub-workflow calls work with durable
+   effects inside function bodies.
+
+### 5.5 Related Work
+
+**CESK machines** (Felleisen and Friedman, 1986): the kernel is
+a CESK machine without the Store (no mutation) and with the
+Kontinuation implicit in the generator stack. **Algebraic
+effects** (Plotkin and Power, 2002; Plotkin and Pretnar, 2009):
+external Eval nodes are effect operations; the execution layer
+is the handler.
+
+---
+
+## 6. Effects and Journaling
+
+### 6.1 Why Effects Are Externalized
+
+In Tisyn, external interactions are effect declarations, not
+function calls. The kernel yields a descriptor; the execution
+layer decides what to do with it. The kernel does not know
+whether a result came from an agent or from the journal. This is
+the dependency inversion principle applied to I/O.
+
+### 6.2 The Journal
+
+The journal is an append-only sequence of events stored in a
+Durable Stream. Two event types:
+
+**Yield** — records an effect's description and result:
+
+```json
+{ "type": "yield", "coroutineId": "root",
+  "description": { "type": "order-service", "name": "fetchOrder" },
+  "result": { "status": "ok", "value": { "id": "123", "total": 150 } } }
+```
+
+**Close** — records a task's terminal state:
+
+```json
+{ "type": "close", "coroutineId": "root",
+  "result": { "status": "ok", "value": { "receiptId": "r-456" } } }
+```
+
+**Event result** has three possible statuses:
+
+- `{ status: "ok", value: Val }` — success
+- `{ status: "err", error: { message, name? } }` — failure
+- `{ status: "cancelled" }` — task was cancelled
+
+### 6.3 Persist-Before-Resume
+
+The most important invariant:
+
+> A Yield event must be durably acknowledged before the kernel
+> resumes with the result.
+
+The kernel never sees a result that isn't in the journal. If the
+host crashes after agent response but before journal write, the
+effect is re-dispatched (at-least-once delivery). If it crashes
+after journal write but before resume, replay feeds the stored
+result.
+
+This is **write-ahead logging** (Mohan et al., ARIES, 1992)
+applied to workflow effects.
+
+### 6.4 Durability Guarantees
+
+Six guarantees define the journal's behavior:
+
+**G1 — Persistence.** Acknowledged events survive crashes.
+
+**G2 — Non-persistence.** Unacknowledged events may not persist.
+
+**G3 — Persist-before-resume.** Yield acknowledged before kernel
+resumes.
+
+**G4 — Close-after-children.** Parent's Close after all
+children's Closes.
+
+**G5 — Causal ordering.** If event A depends on event B, B
+precedes A in the stream.
+
+**G6 — Single writer.** Epoch fencing ensures at most one host
+instance writes to a stream at any time. If a host crashes and a
+new host starts with a higher epoch, the old host's subsequent
+writes are rejected (403 Forbidden).
+
+### 6.5 Event Ordering
+
+1. Events within a stream are totally ordered.
+2. A child's Close precedes the parent's Yield consuming it.
+3. Yields for a coroutine appear in yield order.
+4. Close appears after all Yields for that coroutine.
+5. Parent's Close appears after all children's Closes.
+
+### 6.6 Cleanup Effects
+
+When a task's scope is destroyed (completion, error, or
+cancellation), `finally` blocks may yield effects. These cleanup
+effects continue the same yield index sequence as normal effects
+— the index does NOT reset. Cleanup effects use the same
+correlation ID scheme and are journaled identically.
+
+```
+Task root.0:
+  [0] yield agent.acquire ok            (id: "root.0:0")
+  [1] yield agent.riskyOp err "boom"    (id: "root.0:1")
+  [2] yield agent.release ok            (cleanup, id: "root.0:2")
+  [3] close root.0 err "boom"
+```
+
+The ReplayIndex does not distinguish cleanup effects from normal
+effects. On replay, cleanup effects replay from journal like any
+other. Cleanup effects during cancellation are best-effort — if
+they complete before the parent's teardown, they are journaled.
+
+### 6.7 Related Work
+
+**Event sourcing** (Fowler, 2005): state reconstructed from
+event replay. **Kafka** (2011): append-only commit log. Tisyn's
+journal is conceptually similar but per-workflow, not distributed.
+
+---
+
+## 7. Deterministic Replay
+
+### 7.1 What Determinism Means
+
+Given the same IR tree, arguments, effect result sequence, and
+classification function, the kernel produces the same effect
+descriptors, final value, and task tree. This is execution
+determinism conditioned on effect results — not global
+determinism, since agents may return different values on
+re-dispatch.
+
+### 7.2 How Replay Works
+
+On restart after a crash:
+
+```
+1. Read journal from Durable Stream.
+2. Build ReplayIndex: per-coroutine arrays of (description, result)
+   with cursor positions.
+3. Create fresh evaluation from the IR tree.
+4. Evaluate. At each external Eval:
+   a. Check ReplayIndex for the coroutine's current cursor.
+   b. If entry exists → compare description.
+      Match compares ONLY type and name (not arguments).
+      If match: return stored result synchronously (REPLAY).
+      If mismatch: DIVERGENCE error.
+   c. If no entry and no Close: dispatch to agent (LIVE — transition).
+   d. If no entry but Close exists: DIVERGENCE error.
+```
+
+**Description matching** compares only `type` and `name`, not
+arguments. This allows argument values to change between code
+versions without breaking replay of in-flight workflows — as
+long as the effect identity (which agent, which method) remains
+the same.
+
+Replay is synchronous: stored results are fed to the kernel
+without I/O. After replay, the kernel reaches the first
+un-journaled effect and transitions to live execution.
+
+**Divergence** means the replayed code produces a different
+effect sequence than the stored journal. Divergence is fatal:
+the kernel halts. Partial replay with mismatched effects is
+indistinguishable from data corruption.
+
+### 7.3 Structural Determinism
+
+The IR provides determinism structurally. The types that cause
+nondeterminism in JavaScript simply don't exist in the IR:
+
+- No `Math.random()` — no random number primitive
+- No `Date.now()` — no time primitive (time is an effect)
+- No `Map`/`Set` iteration — no Map/Set types
+- No `for...in` — no property enumeration
+- No `Symbol` — no non-string keys
+- No async scheduling — kernel is synchronous between effects
+
+Additional structural guarantees:
+
+- `construct` evaluates fields in lexicographic key order,
+  ensuring identical effect ordering across languages.
+- Arithmetic and comparison operators are numeric-only.
+- `and`/`or` return operand values, not booleans.
+- `eq` uses canonical encoding (lexicographic key sort) for
+  structural comparison of complex values.
+
+### 7.4 Canonical Encoding
+
+For byte-equal comparison of IR trees, journal events, and
+values, the system defines a canonical JSON encoding:
+lexicographic key sorting at every nesting level, no whitespace,
+numbers in shortest round-trip form. All implementations must
+use IEEE 754 binary64 for numeric computation and JSON number
+parsing.
+
+Canonical encoding is used for `eq` comparison, interoperability
+testing, and hashing. Wire messages and journal storage may use
+non-canonical encoding.
+
+### 7.5 Related Work
+
+**Temporal** (2020): replays functions with injected results.
+**Restate** (2023): bidirectional journal protocol. **Azure
+Durable Functions** (2017): history-table replay. All share
+persist-before-resume; they differ in execution model.
+
+---
+
+## 8. Concurrency Model
+
+### 8.1 Structured Concurrency
+
+Tisyn uses structured concurrency (Smith, 2018): every child has
+a parent, no child outlives its parent, cancellation propagates
+downward. Concurrency is not a language feature — it is an
+execution-layer interpretation of specific effect descriptors.
+
+### 8.2 `all` and `race`
+
+**`all`:** Spawn N child tasks, each evaluating one expression.
+Wait for all to complete. Return results in expression order (not
+completion order). If any child fails, cancel the rest and
+propagate the error.
+
+**`race`:** Spawn N child tasks. Return the first to complete
+successfully. Cancel the rest. A failing child does not win — the
+race continues with remaining children. If all fail, propagate
+the last error. Return value is the winner's result (not an
+array).
+
+### 8.3 Why Concurrency Is External
+
+Concurrency is external to the IR (not a structural operation)
+for two reasons:
+
+1. **Single-threaded evaluator.** The kernel never has two things
+   executing simultaneously. No race conditions in evaluation.
+2. **Journal interaction.** Each child task produces its own Yield
+   events with its own coroutine ID. The execution layer manages
+   ID assignment, per-coroutine cursors, and cancellation
+   coordination. Embedding this in the evaluator would couple
+   evaluation rules with journaling logic.
+
+The **compound external exception** enables this: `unquote` (not
+`resolve`) preserves child expressions. Each child receives the
+parent's immutable environment — a pointer copy, no cloning.
+
+### 8.4 Related Work
+
+**Nurseries** (Trio, Smith, 2018): `all` is semantically a
+nursery with N children. **Fork/join** (Cilk, 1995): `all` is
+join-all; `race` is join-any.
+
+---
+
+## 9. Agent Model
+
+### 9.1 Agents as Effect Handlers
+
+Agents are handlers for external effects. They receive JSON,
+perform work, return JSON. They have no knowledge of journals,
+replay, task structure, or the IR. They can be written in any
+language with JSON-RPC 2.0 support.
+
+The `Agent()` primitive produces both client stubs (constructing
+IR nodes or DurableEffect wrappers on the host) and
+implementation registries (on the agent). One definition, two
+roles — eliminating contract mismatches.
+
+### 9.2 The Initialize Handshake
+
+On connection, the agent declares itself:
+
+- `agentId` — unique identifier matching the IR's dotted `Eval.id`
+  prefix
+- `capabilities.methods` — the list of operation names it handles
+- `capabilities.concurrency` — max concurrent Execute requests
+- `capabilities.progress` — whether it emits Progress
+  notifications
+
+The host validates compatibility and rejects agents with
+incompatible protocol versions.
+
+### 9.3 Idempotency and At-Least-Once Delivery
+
+The system provides at-least-once delivery, not exactly-once.
+Effects may execute more than once if the host crashes after
+dispatch but before journaling. Agents must handle this via:
+
+- **Natural idempotency** (read-only operations)
+- **Deduplication** via the correlation ID — which is
+  deterministic and stable across re-dispatches
+- **Downstream idempotency keys** (e.g., Stripe's
+  `idempotency_key`)
+
+The agent is solely responsible for the correctness of external
+side effects. The kernel does not enforce, validate, or roll back
+side effects. Non-idempotent operations must implement a
+mitigation strategy, documented per operation.
+
+### 9.4 Two Error Categories
+
+**Application errors** (`result.ok = false`) — the operation ran
+but failed. These are journaled as Yield(err) events and
+participate in replay. On replay, the same error is re-delivered.
+
+**Protocol errors** (JSON-RPC `error` field) — the request was
+malformed or the operation is unknown. These are NOT journaled.
+They indicate bugs and cause task failure without a replay record.
+
+### 9.5 Progress: Ephemeral Observation
+
+Agents may emit Progress notifications during effect execution.
+Progress is ephemeral: not journaled, not replayed, not
+guaranteed to be delivered. It may be lost on disconnect. It
+exists only for real-time observation of in-flight operations.
+
+### 9.6 Related Work
+
+Agents combine aspects of the **actor model** (Hewitt, 1973) —
+isolated message-passing processes — with **RPC services** —
+registered methods accepting serialized input. They are
+stateless, unlike actors.
+
+---
+
+## 10. Error and Cancellation Flow
+
+### 10.1 Error Propagation Across Layers
+
+```
+Agent error         → application error { ok:false, error:{message,name} }
+                         ↓
+Execution Layer     → writes Yield(err) to journal, awaits ack
+                         ↓
+Kernel              → receives error via resume path
+                    → propagates upward through structural operations
+                       (each operation stops, remaining sub-expressions skipped)
+                    → if uncaught: reaches task boundary
+                         ↓
+Execution Layer     → writes Close(err) for the task
+                    → if task is child of all: cancels siblings
+                    → if task is child of race: race continues with rest
+```
+
+### 10.2 Cancellation Flow
+
+Cancellation propagates downward (parent → children), never
+upward:
+
+```
+Host decides to cancel root task
+  ↓
+Execution Layer sets root.cancelling = true   (point of no return)
+  ↓
+Cancel child root.1 (reverse creation order):
+  root.1.cancelling = true
+  Send Cancel to Agent B (best-effort, notification, no response expected)
+  Destroy root.1's evaluation scope (generator.return(), finally blocks run)
+  If finally blocks yield effects: journaled with continuing yield index
+  Write Close(cancelled) for root.1
+  ↓
+Cancel child root.0:
+  (same sequence)
+  ↓
+Destroy root's evaluation scope
+Write Close(cancelled) for root
+```
+
+**Point-of-no-return.** Once `cancelling` is set, any agent
+result for that task's pending effect is discarded. No Yield is
+written. Cancellation is irrevocable.
+
+**Cancellation is not an error.** It propagates via
+`generator.return()` (not `throw()`), triggering `finally` blocks
+for cleanup. A parent's `catch` does not catch cancellation.
+
+**Cancel is best-effort.** The agent may not receive it (lost in
+transit), may receive it after completing, or may take time to
+stop. The host does not wait for acknowledgment.
+
+---
+
+## 11. Transport Layer
+
+### 11.1 Transport Independence
+
+The wire protocol (JSON-RPC 2.0) is transport-agnostic. Six
+message types: Initialize, Execute, Result, Progress, Cancel,
+Shutdown. Four transport bindings:
+
+- **WebSocket:** Bidirectional, persistent. Natural fit for
+  long-running workflows.
+- **Stdio (NDJSON):** Newline-delimited JSON. For subprocess
+  agents.
+- **SSE + POST:** Works through HTTP proxies and load balancers.
+- **In-process:** Direct object passing. For testing.
+
+### 11.2 Transport Does Not Affect Semantics
+
+Switching from WebSocket to stdio does not change the journal,
+the evaluation path, the replay behavior, or the determinism
+guarantees. The only observable differences are latency and
+connection lifecycle behavior. All transports must deliver
+messages in order per direction and deliver complete messages.
+
+### 11.3 Reconnection
+
+Reconnection is a fresh session — no protocol-level session
+resumption. The agent sends Initialize again. The host
+re-dispatches pending effects (same correlation IDs). This
+simplicity is deliberate: session resumption adds protocol
+complexity for marginal benefit, since the journal already
+handles crash recovery.
+
+---
+
+## 12. The Compiler
+
+### 12.1 What the Compiler Does
+
+The compiler transforms TypeScript generator functions into Tisyn
+IR. It accepts a restricted authoring subset (no mutation, no
+nondeterministic APIs, no closures) and produces a Fn node — a
+JSON document. The compilation is deterministic: same source →
+byte-identical JSON.
+
+### 12.2 Three `yield*` Cases
+
+| Case | Source | IR Output | Data shape |
+|------|--------|-----------|------------|
+| Agent effect | `yield* Agent().method(args)` | External Eval | Unquoted array |
+| Concurrency | `yield* all/race([...])` | Compound Eval | Quoted `{exprs:[...]}` |
+| Built-in | `yield* sleep(ms)` | External Eval | Unquoted array |
+
+The quoting difference is critical: agent effects use unquoted
+data (resolved by `resolve()` at runtime), while concurrency
+nodes use quoted data (preserved by `unquote()` for the execution
+layer to spawn).
+
+### 12.3 Control Flow Transformations
+
+- **Sequential statements** → nested `let` chains
+- **Early return** → code after `if`-with-return moves into
+  the `else` branch
+- **While without return** → `while` IR node directly
+- **While with return** → recursive Fn + Call (the IR's `while`
+  has no early-exit mechanism — the compiler transforms the
+  loop into a Fn that calls itself, terminating when a branch
+  produces a value instead of recursing; call-site resolution
+  enables the self-reference)
+- **Discarded effects** → `let` with synthetic discard name
+  (preserving evaluation order) or `seq` when no bindings are
+  referenced
+
+---
+
+## 13. Comparison to Existing Systems
+
+| Aspect | Async/retry | Queues | Temporal | Tisyn |
+|--------|------------|--------|---------|-------|
+| Crash recovery | No | Partial | Full | Full |
+| Determinism | None | None | Developer discipline | Construction |
+| Workflow structure | Code | Scattered | Code | Serializable tree |
+| Effect isolation | None | Message boundaries | SDK boundary | Eval nodes |
+| Concurrency | Language-level | Consumer count | SDK primitives | `all`/`race` |
+| Inspection | Debugger | Queue monitoring | Replay debugger | Static tree analysis |
+| Language lock-in | Yes | No | Per-SDK | No (IR is JSON) |
+| Side-effect safety | None | At-least-once/step | At-least-once | At-least-once |
+
+The fundamental difference from Temporal: Temporal re-executes
+native code with stored results; Tisyn evaluates a deterministic
+tree with stored results. Temporal trusts the developer; Tisyn
+trusts the compiler.
+
+---
+
+## 14. Design Trade-offs
+
+**Verbosity vs determinism.** The IR is verbose. The verbosity
+buys determinism, inspectability, and serializability. The
+developer never sees the IR.
+
+**No mutation.** Variables are bound once. No race conditions on
+shared state, but loop patterns require recursion.
+
+**Explicit control flow.** No implicit fallthrough, no
+`break`/`continue`. The compiler restructures early returns as
+nested `if`/`else` and while-with-return as recursive Fn + Call.
+
+**Replay cost vs reliability.** Replay is linear in effect count.
+Checkpointing is a future optimization.
+
+**At-least-once, not exactly-once.** Effects may execute more
+than once. Agents bear the idempotency responsibility. Exactly-
+once is impossible in the general case (Fischer, Lynch, and
+Paterson, 1985).
+
+---
+
+## 15. Future Directions
+
+**Static analysis.** The IR is JSON — tools can verify scope
+consistency, detect dead code, estimate effect counts, and
+identify invariant loops without execution.
+
+**Optimization.** Common sub-expression elimination, dead code
+elimination, effect batching.
+
+**Error recovery.** A `try/catch` structural operation, deferred
+until its journal interaction semantics are resolved.
+
+**Multi-language.** The IR is language-agnostic. Compilers in
+other languages could produce the same JSON trees.
+
+---
+
+## References
+
+- Abelson, H. and Sussman, G.J. *Structure and Interpretation of Computer Programs*, MIT Press, 1996.
+- Blumofe, R.D. et al. "Cilk: An efficient multithreaded runtime system," PPoPP, 1995.
+- Felleisen, M. and Friedman, D.P. "Control operators, the SECD machine, and the λ-calculus," 1986.
+- Fischer, M.J., Lynch, N.A., and Paterson, M.S. "Impossibility of distributed consensus with one faulty process," JACM, 1985.
+- Fowler, M. "Event Sourcing," 2005.
+- Garcia-Molina, H. and Salem, K. "Sagas," SIGMOD, 1987.
+- Hohpe, G. and Woolf, B. *Enterprise Integration Patterns*, Addison-Wesley, 2003.
+- Mohan, C. et al. "ARIES: A transaction recovery method," TODS, 1992.
+- Plotkin, G.D. and Power, J. "Notions of computation determine monads," FoSSaCS, 2002.
+- Plotkin, G.D. and Pretnar, M. "Handlers of algebraic effects," ESOP, 2009.
+- Smith, N.J. "Notes on structured concurrency," 2018.
+- Temporal. https://temporal.io
+- Restate. https://restate.dev
+- Unison. https://unison-lang.org
+- Effection. https://frontside.com/effection

--- a/specs/tisyn-compiler-specification-1.1.0.md
+++ b/specs/tisyn-compiler-specification-1.1.0.md
@@ -1,0 +1,791 @@
+# Tisyn Compiler Specification
+
+**Version:** 1.1.0
+**Target:** Tisyn System Specification 1.0.0
+**Status:** Normative
+
+---
+
+## 1. Overview
+
+This document specifies a compiler that transforms a restricted subset of JavaScript generator functions into Tisyn IR. The output is a Tisyn `Fn` node — a JSON document — that, when interpreted by the Tisyn evaluator, produces the same journal as executing the original generator in the Effection runtime.
+
+### 1.1 Correctness Criterion
+
+```
+∀R: journal(interpret(compile(G), R)) = journal(run(G, R))
+```
+
+### 1.2 Guarantee Hierarchy
+
+**Level 1 — Structural validity.** Output conforms to grammar, passes all validation rules. Always guaranteed.
+
+**Level 2 — Scope consistency.** Every Ref bound by enclosing Let or Fn. Always guaranteed.
+
+**Level 3 — Journal equivalence.** Guaranteed for source within the authoring subset.
+
+---
+
+## 2. Authoring Model
+
+### 2.1 Allowed Constructs
+
+| Construct | Authoring form | IR |
+|-----------|---------------|-----|
+| Effect | `yield* Agent().method(args)` | External Eval |
+| Concurrency | `yield* all([...])` / `yield* race([...])` | Compound Eval |
+| Sleep | `yield* sleep(ms)` | External Eval |
+| Sub-workflow | `yield* otherWorkflow(args)` | Inlined or `call` |
+| Variable | `const x = <expr>` | `let` |
+| Conditional | `if / else` | `if` |
+| While | `while (cond) { ... }` | `while` or recursive Fn |
+| Return | `return <expr>` | Final expression |
+| Throw | `throw new Error(msg)` | `throw` |
+| Property | `obj.prop` / `obj["literal"]` | `get` |
+| Arithmetic | `+`, `-`, `*`, `/`, `%`, unary `-` | `add`, `sub`, `mul`, `div`, `mod`, `neg` |
+| Comparison | `>`, `>=`, `<`, `<=`, `===`, `!==` | `gt`, `gte`, `lt`, `lte`, `eq`, `neq` |
+| Logical | `&&`, `\|\|`, `!` | `and`, `or`, `not` |
+| String template | `` `hello ${name}` `` | `concat` |
+| Object literal | `{ a: 1, b: x }` | `construct` |
+| Array literal | `[a, b, c]` | `array` |
+| Arrow function | `(x) => pureExpr` | `fn` |
+
+### 2.2 Effects and the Durability Boundary
+
+An **effect** is a `yield*` targeting an Agent method, `all`, `race`, `sleep`, or a sub-workflow containing effects. Each agent method call produces one Yield event.
+
+**Rule:** `yield*` MUST appear only in statement position — as the RHS of `const x = yield* ...` or as a bare statement. It MUST NOT appear in condition expressions, short-circuit operands, function arguments, or array/object literals.
+
+---
+
+## 3. Compilation Pipeline
+
+### 3.1 Four Phases
+
+```
+Source (.ts) → [Parse] → AST → [Discover] → AnnotatedAST
+                                                   ↓
+           Tisyn IR (JSON) ← [Emit] ← TransformedAST ← [Transform]
+```
+
+### 3.2 Determinism
+
+Same source → byte-identical JSON. Monotonic counter for synthetic names. Canonical JSON encoding. Source-order traversal.
+
+### 3.3 Naming
+
+Compiler names: `__discard_0`, `__all_0`, `__loop_0`, `__sub_0`. User variables MUST NOT start with `__`.
+
+---
+
+## 4. The `yield*` Desugaring
+
+### 4.1 Three Cases
+
+| Case | Target | IR |
+|------|--------|----|
+| Agent effect | `yield* Agent().method(args)` | External Eval (unquoted data) |
+| Concurrency | `yield* all/race([...])` | Compound Eval (quoted data) |
+| Built-in | `yield* sleep(ms)` | External Eval (unquoted data) |
+
+### 4.2 Agent Effect
+
+```typescript
+yield* OrderService().fetchOrder(orderId)
+```
+
+```json
+{ "tisyn": "eval", "id": "order-service.fetchOrder",
+  "data": [{ "tisyn": "ref", "name": "orderId" }] }
+```
+
+**ID:** `Agent.id + "." + methodName`. **Data:** plain array (NOT quoted). `resolve()` traverses at runtime.
+
+### 4.3 Concurrency
+
+```typescript
+yield* all([() => A().step1(x), () => B().step2(y)])
+```
+
+```json
+{ "tisyn": "eval", "id": "all",
+  "data": { "tisyn": "quote", "expr": { "exprs": [
+    { "tisyn": "eval", "id": "a.step1", "data": [{ "tisyn": "ref", "name": "x" }] },
+    { "tisyn": "eval", "id": "b.step2", "data": [{ "tisyn": "ref", "name": "y" }] }
+  ]}}}
+```
+
+**Data:** Quote wrapping `{ exprs: [...] }`. Children remain unevaluated. Execution layer uses `unquote()`, NOT `resolve()`. Arrow functions are unwrapped — body extracted into `exprs`.
+
+### 4.4 Built-in Effect
+
+```
+yield* sleep(5000) → { tisyn: "eval", id: "sleep", data: [5000] }
+```
+
+### 4.5 Sub-Workflow Composition
+
+```typescript
+function* sub(x: string): Workflow<number> { ... }
+function* main(): Workflow<string> {
+  const n = yield* sub("hello");
+}
+```
+
+**Strategy A — Inline** (small workflows):
+
+```
+⟦ yield* sub("hello") ⟧ = Let("x", "hello", ⟦sub.body⟧)
+```
+
+**Strategy B — Call** (large or recursive workflows):
+
+```
+Let("__sub_0", ⟦compile(sub)⟧, Let("n", Call(Ref("__sub_0"), "hello"), ...))
+```
+
+---
+
+## 5. Sequential Statement Compilation
+
+### 5.1 Block-to-Let Transformation
+
+```
+transform_block([]):
+  return null
+
+transform_block([return expr]):
+  return ⟦expr⟧
+
+transform_block([const x = expr, ...rest]):
+  return Let("x", ⟦expr⟧, transform_block(rest))
+
+transform_block([yield* effect, ...rest]):
+  return Let("__discard_N", ⟦effect⟧, transform_block(rest))
+
+transform_block([if (cond) { return A }, ...rest]):
+  return If(⟦cond⟧, ⟦A⟧, transform_block(rest))
+
+transform_block([while ..., ...rest]):
+  return Let("__while_N", ⟦while⟧, transform_block(rest))
+
+transform_block([throw new Error(msg)]):
+  return Throw(⟦msg⟧)
+```
+
+### 5.2 Implicit Return
+
+Workflows with no explicit `return` emit `null` as terminal value.
+
+---
+
+## 6. Control Flow
+
+### 6.1 Conditional
+
+```
+⟦ if (cond) { A } else { B } ⟧
+= If(⟦cond⟧, ⟦A⟧, ⟦B⟧)
+```
+
+With early return:
+
+```typescript
+if (x < 0) { return "negative"; }
+const result = yield* Agent().process(x);
+return result;
+```
+
+```
+If(Lt(Ref("x"), 0), "negative",
+  Let("result", Eval("agent.process", [Ref("x")]), Ref("result")))
+```
+
+Code after `if`-with-return becomes the `else` branch.
+
+### 6.2 While Loop — Two Compilation Strategies
+
+The Tisyn `while` node has **no early-exit mechanism**. Its body expressions evaluate, the result is stored, the condition is re-checked, and the loop continues. A value returned from the body is just the iteration's result — the loop does not terminate.
+
+This means `while` with `return` inside the body CANNOT compile to a `while` IR node. The compiler MUST distinguish two cases:
+
+**Case A: No return in body.** Compile to `while` IR node directly.
+
+```typescript
+while (true) {
+  yield* Agent().tick();
+}
+```
+
+```
+While(true, [Eval("agent.tick", [])])
+```
+
+This loop terminates only via error, cancellation, or the condition becoming falsy via effect in a future iteration. For `while(true)` with no return, this typically runs until cancellation.
+
+**Case B: Return in body.** Compile to recursive Fn + Call.
+
+```typescript
+while (true) {
+  const status = yield* JobService().checkStatus(jobId);
+  if (status.state === "complete") {
+    return yield* JobService().getResult(jobId);
+  }
+  yield* sleep(1000);
+}
+```
+
+The compiler transforms this into:
+
+```
+Let("__loop_0", Fn([],
+  Let("status", Eval("job-service.checkStatus", [Ref("jobId")]),
+    If(Eq(Get(Ref("status"), "state"), "complete"),
+      Eval("job-service.getResult", [Ref("jobId")]),
+      Let("__discard_0", Eval("sleep", [1000]),
+        Call(Ref("__loop_0")))))),
+  Call(Ref("__loop_0")))
+```
+
+**How this works:**
+
+1. `__loop_0` is bound to a Fn with no params.
+2. The outer `Call(Ref("__loop_0"))` starts the first iteration.
+3. Inside the body: if status is "complete", return the result (the `If`'s then-branch value propagates out through the Call as the result).
+4. If not complete: sleep, then `Call(Ref("__loop_0"))` recurses.
+5. Tisyn uses call-site resolution — `Ref("__loop_0")` inside the body resolves in the caller's environment, which contains the `__loop_0 → Fn(...)` binding.
+6. Free variables from the enclosing scope (`jobId`) resolve correctly via call-site resolution — the caller's environment includes them.
+
+**Detection:** The compiler walks the while body's AST. If any `return` statement exists (at any nesting depth within the body), use Case B. Otherwise, use Case A.
+
+**Throw in body:** `throw` inside a while body works with both strategies. Errors propagate upward through `while` (Case A) and through `call` (Case B) identically.
+
+### 6.3 While with Invariant Condition
+
+```typescript
+const limit = 10;
+while (count < limit) { ... }
+```
+
+If `count` is an immutable `const`, the condition is invariant. The compiler SHOULD emit warning W001.
+
+### 6.4 Break/Continue
+
+DISALLOWED. No IR equivalent. Loops terminate via return (Case B), throw, or condition.
+
+---
+
+## 7. Expression Compilation
+
+### 7.1 Structural Operations
+
+All pure expressions compile to structural Eval nodes with quoted data:
+
+```
+⟦ a + b ⟧ = { tisyn:"eval", id:"add", data:Q({ a:⟦a⟧, b:⟦b⟧ }) }
+⟦ a > b ⟧ = { tisyn:"eval", id:"gt",  data:Q({ a:⟦a⟧, b:⟦b⟧ }) }
+⟦ !a    ⟧ = { tisyn:"eval", id:"not", data:Q({ a:⟦a⟧ }) }
+⟦ -a    ⟧ = { tisyn:"eval", id:"neg", data:Q({ a:⟦a⟧ }) }
+```
+
+### 7.2 Type Constraints
+
+| Operator | Operands | Note |
+|----------|----------|------|
+| `add/sub/mul/div/mod/neg` | number only | TypeError on non-number |
+| `gt/gte/lt/lte` | number only | TypeError on non-number |
+| `eq/neq` | any | Structural comparison via canonical encoding |
+| `and/or` | any | Returns operand values, not booleans |
+| `not` | any | Returns boolean |
+
+### 7.3 `+` Disambiguation
+
+JavaScript `+` is addition or concatenation. The compiler MUST disambiguate:
+
+- Both operands statically typed `number` → `add`
+- String context (template literal) → `concat`
+- Ambiguous → compile error E011
+
+### 7.4 Short-Circuit
+
+`&&` → `and`, `||` → `or`. Return operand values (Tisyn Spec §6.7). This works correctly as conditions because `if` uses truthiness.
+
+### 7.5 Property Access
+
+```
+⟦ obj.prop ⟧ = Get(⟦obj⟧, "prop")
+⟦ obj.a.b ⟧ = Get(Get(⟦obj⟧, "a"), "b")
+```
+
+Computed access (`obj[expr]`) DISALLOWED.
+
+### 7.6 Object Literals
+
+```
+⟦ { a: e1, b: e2 } ⟧ = Construct({ a: ⟦e1⟧, b: ⟦e2⟧ })
+```
+
+Evaluator sorts keys lexicographically at runtime (Spec §6.10).
+
+### 7.7 Array Literals
+
+```
+⟦ [a, b, c] ⟧ = Array([⟦a⟧, ⟦b⟧, ⟦c⟧])
+```
+
+### 7.8 Template Literals
+
+```
+⟦ `Hello ${name}` ⟧ = Concat(["Hello ", ⟦name⟧])
+```
+
+### 7.9 Throw
+
+```
+⟦ throw new Error(msgExpr) ⟧ = Throw(⟦msgExpr⟧)
+```
+
+`msgExpr` may be string, template, or variable. Non-Error throws DISALLOWED.
+
+---
+
+## 8. Concurrency
+
+### 8.1 `all` with Simple Children
+
+```typescript
+yield* all([
+  () => A().step(x),
+  () => B().step(y),
+])
+```
+
+Arrow functions unwrapped. Bodies placed in `exprs`:
+
+```json
+{ "tisyn": "eval", "id": "all",
+  "data": { "tisyn": "quote", "expr": { "exprs": [
+    { "tisyn": "eval", "id": "a.step", "data": [{ "tisyn": "ref", "name": "x" }] },
+    { "tisyn": "eval", "id": "b.step", "data": [{ "tisyn": "ref", "name": "y" }] }
+  ]}}}
+```
+
+### 8.2 `all` with Multi-Step Children
+
+Generator functions compiled as inline expression trees:
+
+```typescript
+yield* all([
+  function* () {
+    const order = yield* OrderService().fetchOrder("123");
+    return yield* Processor().process(order);
+  },
+  () => FastService().quick(),
+])
+```
+
+```json
+{ "exprs": [
+  { "tisyn": "eval", "id": "let",
+    "data": { "tisyn": "quote", "expr": {
+      "name": "order",
+      "value": { "tisyn": "eval", "id": "order-service.fetchOrder", "data": ["123"] },
+      "body": { "tisyn": "eval", "id": "processor.process",
+                "data": [{ "tisyn": "ref", "name": "order" }] }
+    }}},
+  { "tisyn": "eval", "id": "fast-service.quick", "data": [] }
+]}
+```
+
+Generator children are inlined, NOT compiled as Fn nodes.
+
+### 8.3 `race`
+
+Same structure, `id: "race"`. Winner's result returned (not array).
+
+### 8.4 Destructured Results
+
+```typescript
+const [a, b] = yield* all([...]);
+```
+
+```
+Let("__all_0", Eval("all", Q({exprs:[...]})),
+  Let("a", Get(Ref("__all_0"), "0"),
+    Let("b", Get(Ref("__all_0"), "1"), ...)))
+```
+
+### 8.5 Free Variables in Children
+
+Children may reference parent-scope variables via Ref. Correct — execution layer evaluates children in parent's environment. Compiler MUST verify all free variables are in scope at the call site.
+
+---
+
+## 9. Function Semantics
+
+### 9.1 Arrow Functions → Fn
+
+```typescript
+const double = (x: number) => x * 2;
+```
+
+```json
+{ "tisyn": "fn", "params": ["x"],
+  "body": { "tisyn": "eval", "id": "mul",
+            "data": { "tisyn": "quote", "expr": {
+              "a": { "tisyn": "ref", "name": "x" }, "b": 2 }}}}
+```
+
+### 9.2 Arrow Function Bodies
+
+Arrow function bodies MUST be **single pure expressions**. No block bodies, no `yield*`, no statements. This is a JavaScript language constraint — arrow functions cannot use `yield*`.
+
+Arrow functions passed to `all`/`race` as thunks `() => expr` are unwrapped (§8.1), not compiled as Fn nodes.
+
+### 9.3 Fn Bodies CAN Contain Effects
+
+A Fn called via Tisyn `call` evaluates its body using the full evaluator. If the body contains external Evals, they cross the execution boundary normally. The `call` structural operation invokes `eval(body, E')`, and `eval` handles suspension/resumption transparently.
+
+This is relevant for sub-workflow composition (§4.5 Strategy B) and the recursive loop pattern (§6.2 Case B), where the Fn body contains agent method calls.
+
+### 9.4 Closure Restriction
+
+Tisyn Fn has no closures. The compiler MUST ensure:
+
+**Condition A:** No free variables. **Condition B:** All free variables in scope at every call site.
+
+**Substitution** (replace free Refs with values) is MANDATORY when a Fn crosses the execution boundary as an agent argument.
+
+### 9.5 Calling
+
+```
+⟦ f(a, b) ⟧ = Call(⟦f⟧, [⟦a⟧, ⟦b⟧])
+```
+
+---
+
+## 10. Environment and Scope
+
+### 10.1 Variables → Let
+
+Every `const` → `let` binding. Scoped by nesting:
+
+```
+⟦ const a = e1; const b = e2; return a + b ⟧
+= Let("a", ⟦e1⟧, Let("b", ⟦e2⟧, Add(Ref("a"), Ref("b"))))
+```
+
+### 10.2 Block Scoping
+
+Variables in `if` branches scoped to branch body. Not visible outside.
+
+### 10.3 Shadowing
+
+Inner bindings shadow outer with same name. Outer restored after inner scope.
+
+### 10.4 No Mutation
+
+`const` only. `let`/`var`/reassignment → compile error.
+
+---
+
+## 11. Unsupported Constructs
+
+| Construct | Code | Error |
+|-----------|------|-------|
+| Mutable binding | `let x = ...` | E001: Use "const" |
+| Var | `var x = ...` | E002: Use "const" |
+| Reassignment | `x = v` | E003 |
+| Property mutation | `obj.p = v` | E004 |
+| Computed property | `obj[expr]` | E005 |
+| `Math.random()` | | E006 |
+| `Date.now()` | | E007 |
+| `new Map/Set()` | | E008 |
+| `async/await` | | E009 |
+| `yield*` in expr position | `if (yield* ...)` | E010 |
+| Ambiguous `+` | | E011 |
+| `for...in` | | E013 |
+| `eval()/new Function()` | | E014 |
+| `try/catch` | | E015 |
+| `class/this` | | E016 |
+| `yield` (no `*`) | | E017 |
+| `call(() => ...)` | | E018 |
+| `typeof/instanceof` | | E019 |
+| `break/continue` | | E020 |
+| `Promise` | | E021 |
+| Non-Error throw | `throw "string"` | E023 |
+| Arrow block body | `(x) => { ... }` | E024 |
+| `delete`/`Symbol` | | E029/E030 |
+| User var `__` prefix | `const __x` | E028 |
+
+---
+
+## 12. End-to-End Examples
+
+### 12.1 Simple Sequential Workflow
+
+**Source:**
+
+```typescript
+function* processOrder(orderId: string): Workflow<Receipt> {
+  const order = yield* OrderService().fetchOrder(orderId);
+  const receipt = yield* PaymentService().chargeCard(order.payment);
+  return receipt;
+}
+```
+
+**IR:**
+
+```json
+{
+  "tisyn": "fn", "params": ["orderId"],
+  "body": {
+    "tisyn": "eval", "id": "let",
+    "data": { "tisyn": "quote", "expr": {
+      "name": "order",
+      "value": { "tisyn": "eval", "id": "order-service.fetchOrder",
+                 "data": [{ "tisyn": "ref", "name": "orderId" }] },
+      "body": {
+        "tisyn": "eval", "id": "let",
+        "data": { "tisyn": "quote", "expr": {
+          "name": "receipt",
+          "value": { "tisyn": "eval", "id": "payment-service.chargeCard",
+                     "data": [{ "tisyn": "eval", "id": "get",
+                                "data": { "tisyn": "quote", "expr": {
+                                  "obj": { "tisyn": "ref", "name": "order" },
+                                  "key": "payment" }}}] },
+          "body": { "tisyn": "ref", "name": "receipt" }
+        }}}
+    }}}
+}
+```
+
+**Key:** Two external Evals with unquoted data arrays. Two Lets with quoted data. All Refs bound. ✓
+
+### 12.2 Effect-Driven Loop with Early Return
+
+**Source:**
+
+```typescript
+function* pollJob(jobId: string): Workflow<Result> {
+  const config = yield* ConfigService().getRetryConfig();
+
+  while (true) {
+    const status = yield* JobService().checkStatus(jobId);
+
+    if (status.state === "complete") {
+      return yield* JobService().getResult(jobId);
+    }
+
+    if (status.state === "failed") {
+      throw new Error("Job failed");
+    }
+
+    yield* sleep(config.intervalMs);
+  }
+}
+```
+
+**Analysis:** Body contains `return` → Case B (recursive Fn + Call).
+
+**IR:**
+
+```json
+{
+  "tisyn": "fn", "params": ["jobId"],
+  "body": {
+    "tisyn": "eval", "id": "let",
+    "data": { "tisyn": "quote", "expr": {
+      "name": "config",
+      "value": { "tisyn": "eval", "id": "config-service.getRetryConfig", "data": [] },
+      "body": {
+        "tisyn": "eval", "id": "let",
+        "data": { "tisyn": "quote", "expr": {
+          "name": "__loop_0",
+          "value": {
+            "tisyn": "fn", "params": [],
+            "body": {
+              "tisyn": "eval", "id": "let",
+              "data": { "tisyn": "quote", "expr": {
+                "name": "status",
+                "value": { "tisyn": "eval", "id": "job-service.checkStatus",
+                           "data": [{ "tisyn": "ref", "name": "jobId" }] },
+                "body": {
+                  "tisyn": "eval", "id": "if",
+                  "data": { "tisyn": "quote", "expr": {
+                    "condition": { "tisyn": "eval", "id": "eq",
+                      "data": { "tisyn": "quote", "expr": {
+                        "a": { "tisyn": "eval", "id": "get",
+                          "data": { "tisyn": "quote", "expr": {
+                            "obj": { "tisyn": "ref", "name": "status" },
+                            "key": "state" }}},
+                        "b": "complete" }}},
+                    "then": { "tisyn": "eval", "id": "job-service.getResult",
+                              "data": [{ "tisyn": "ref", "name": "jobId" }] },
+                    "else": {
+                      "tisyn": "eval", "id": "if",
+                      "data": { "tisyn": "quote", "expr": {
+                        "condition": { "tisyn": "eval", "id": "eq",
+                          "data": { "tisyn": "quote", "expr": {
+                            "a": { "tisyn": "eval", "id": "get",
+                              "data": { "tisyn": "quote", "expr": {
+                                "obj": { "tisyn": "ref", "name": "status" },
+                                "key": "state" }}},
+                            "b": "failed" }}},
+                        "then": { "tisyn": "eval", "id": "throw",
+                          "data": { "tisyn": "quote", "expr": {
+                            "message": "Job failed" }}},
+                        "else": {
+                          "tisyn": "eval", "id": "let",
+                          "data": { "tisyn": "quote", "expr": {
+                            "name": "__discard_0",
+                            "value": { "tisyn": "eval", "id": "sleep",
+                              "data": [{ "tisyn": "eval", "id": "get",
+                                "data": { "tisyn": "quote", "expr": {
+                                  "obj": { "tisyn": "ref", "name": "config" },
+                                  "key": "intervalMs" }}}] },
+                            "body": { "tisyn": "eval", "id": "call",
+                              "data": { "tisyn": "quote", "expr": {
+                                "fn": { "tisyn": "ref", "name": "__loop_0" },
+                                "args": [] }}}
+                          }}}
+                      }}}
+                  }}}
+              }}}
+          },
+          "body": { "tisyn": "eval", "id": "call",
+            "data": { "tisyn": "quote", "expr": {
+              "fn": { "tisyn": "ref", "name": "__loop_0" },
+              "args": [] }}}
+        }}}
+    }}}
+}
+```
+
+**How the recursion works:**
+
+1. `__loop_0` is bound to a nullary Fn.
+2. Outer `Call(Ref("__loop_0"))` starts the first iteration.
+3. Each iteration: checks status, returns on complete, throws on failed, or sleeps and calls `__loop_0` again.
+4. `Ref("__loop_0")` resolves via call-site resolution — the caller's env contains the binding.
+5. `Ref("jobId")` and `Ref("config")` resolve in the caller's env, which includes the outer Let chain.
+6. When the "complete" branch fires, the getResult value propagates out through the Call → Let → Fn return chain.
+
+**Journal** (assuming checkStatus returns "pending", "pending", "complete"):
+
+```
+[0] yield root config-service.getRetryConfig ok {intervalMs:1000}
+[1] yield root job-service.checkStatus ok {state:"pending"}
+[2] yield root sleep ok null
+[3] yield root job-service.checkStatus ok {state:"pending"}
+[4] yield root sleep ok null
+[5] yield root job-service.checkStatus ok {state:"complete"}
+[6] yield root job-service.getResult ok {data:"result-data"}
+[7] close root ok {data:"result-data"}
+```
+
+### 12.3 Concurrency with `all`
+
+**Source:**
+
+```typescript
+function* parallelProcess(id1: string, id2: string): Workflow<string> {
+  const orderA = yield* OrderService().fetchOrder(id1);
+  const orderB = yield* OrderService().fetchOrder(id2);
+
+  const results = yield* all([
+    () => Processor().process(orderA),
+    () => Processor().process(orderB),
+  ]);
+
+  return yield* Aggregator().combine(results);
+}
+```
+
+**IR:**
+
+```json
+{
+  "tisyn": "fn", "params": ["id1", "id2"],
+  "body": {
+    "tisyn": "eval", "id": "let",
+    "data": { "tisyn": "quote", "expr": {
+      "name": "orderA",
+      "value": { "tisyn": "eval", "id": "order-service.fetchOrder",
+                 "data": [{ "tisyn": "ref", "name": "id1" }] },
+      "body": {
+        "tisyn": "eval", "id": "let",
+        "data": { "tisyn": "quote", "expr": {
+          "name": "orderB",
+          "value": { "tisyn": "eval", "id": "order-service.fetchOrder",
+                     "data": [{ "tisyn": "ref", "name": "id2" }] },
+          "body": {
+            "tisyn": "eval", "id": "let",
+            "data": { "tisyn": "quote", "expr": {
+              "name": "results",
+              "value": { "tisyn": "eval", "id": "all",
+                "data": { "tisyn": "quote", "expr": { "exprs": [
+                  { "tisyn": "eval", "id": "processor.process",
+                    "data": [{ "tisyn": "ref", "name": "orderA" }] },
+                  { "tisyn": "eval", "id": "processor.process",
+                    "data": [{ "tisyn": "ref", "name": "orderB" }] }
+                ]}}},
+              "body": { "tisyn": "eval", "id": "aggregator.combine",
+                        "data": [{ "tisyn": "ref", "name": "results" }] }
+            }}}
+        }}}
+    }}}
+}
+```
+
+**Key observations:**
+
+- `all` data is **quoted** — children stay unevaluated for execution layer.
+- Arrow functions unwrapped — body expressions in `exprs`.
+- `Ref("orderA")` and `Ref("orderB")` inside children are free variables resolved in parent's env at child task spawn time.
+- `processor.process` data arrays are unquoted — `resolve()` handles them per-child.
+- `all` result bound to `results`, passed directly to `aggregator.combine`.
+
+**Journal:**
+
+```
+[0] yield root order-service.fetchOrder ok {id:"1",...}
+[1] yield root order-service.fetchOrder ok {id:"2",...}
+[2] yield root.0 processor.process ok "processed-1"
+[3] yield root.1 processor.process ok "processed-2"
+[4] close root.0 ok "processed-1"
+[5] close root.1 ok "processed-2"
+[6] yield root aggregator.combine ok "final-result"
+[7] close root ok "final-result"
+```
+
+Note child task IDs `root.0` and `root.1` for the `all` children.
+
+### 12.4 Validation Checklist
+
+Every compiled IR MUST:
+
+1. Pass Tisyn grammar validation (§10 of Spec).
+2. Use exactly one Quote per structural operation data.
+3. Have no Quote at any evaluation position (positions table).
+4. Have all Refs bound by enclosing Let or Fn.
+5. Use unquoted data for standard external Evals.
+6. Use quoted data for `all`/`race`/`spawn`.
+7. Produce the same journal as the source generator.
+
+---
+
+## 13. Compiler Interface
+
+```
+tisyn compile <input.ts> [--output <output.json>] [--validate] [--pretty]
+```
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Compilation error |
+| 2 | Validation error |
+| 3 | Internal error |
+
+Errors include source locations. Partial compilation: failing workflows produce errors; remaining workflows compile and output.

--- a/specs/tisyn-conformance-suite.md
+++ b/specs/tisyn-conformance-suite.md
@@ -1,0 +1,1272 @@
+# Tisyn Conformance Test Suite Specification
+
+**Version:** 1.1.0
+**Suite version field:** `"suite_version": "2.0.0"`
+**Tests against:** Language Spec 1.0.0, Compiler Spec 1.1.0,
+Kernel Spec 1.0.0, Agent Spec 1.1.0
+**Status:** Normative
+
+---
+
+## 1. Purpose and Scope
+
+### 1.1 What Conformance Means
+
+A Tisyn implementation is conforming if and only if:
+
+1. Its observable outputs match this specification for ALL
+   applicable test cases at its claimed level.
+2. Two conforming implementations at the same level produce
+   identical observable outputs when substituted for each
+   other at any layer boundary.
+
+### 1.2 Observable Outputs
+
+The ONLY outputs tested are:
+
+- Final result value (canonical JSON).
+- Journal event sequence (canonical JSON, ordered).
+- Wire message transcripts (structural JSON).
+- Error type (exact string from §4.1).
+
+Error message text is NEVER compared.
+
+### 1.3 Out of Scope
+
+Performance, transport internals, internal data structures,
+error message wording, agent operation logic.
+
+---
+
+## 2. Conformance Levels and Tiers
+
+### 2.1 Levels
+
+| Level | Name | Covers |
+|-------|------|--------|
+| 1 | IR | Validation, malformed IR rejection |
+| 2 | Compiler | Deterministic compilation, correct lowering |
+| 3 | Kernel | Evaluation, resolve, replay, concurrency, cancellation, journaling |
+| 4 | Agent | Protocol compliance, error handling, cancellation |
+
+Level 3 implies Level 1. All others independent.
+
+### 2.2 Tiers
+
+**Core:** MUST pass for conformance at the test's level.
+
+**Extended:** Failure MUST be reported but does not prevent
+a conformance claim. Extended tests cover edge cases and
+cross-implementation traps.
+
+### 2.3 Interoperability
+
+Requires Level 3 + Level 4 Core from two implementations.
+
+---
+
+### 2.4 Terminology
+
+| Canonical term | Definition |
+|---------------|-----------|
+| **event** | A single journal entry (Yield or Close) |
+| **effect** | An external operation the kernel yields to the execution layer |
+| **result** | The EventResult of an event or the final value of an execution |
+| **execution** | A complete run: validation → evaluation → journal |
+| **coroutine** | A unit of concurrent evaluation with its own event stream |
+| **descriptor** | The `{id, data}` object the kernel yields when suspending |
+| **description** | The `{type, name}` object stored in journal Yield events |
+| **fixture** | A complete test case JSON file |
+
+---
+
+## 3. Execution Model
+
+### 3.1 What an Execution Is
+
+An **execution** is the complete processing of one IR tree:
+
+```
+1. Validate(IR)     → accept or MalformedIR
+2. Evaluate(IR, env) → result + journal
+```
+
+Step 1 MUST complete before step 2 begins. If step 1 fails,
+step 2 MUST NOT occur and no journal is produced.
+
+### 3.2 Coroutine State Machine
+
+Each coroutine has exactly one state at any point:
+
+```
+CREATED → RUNNING → COMPLETED
+                  → FAILED
+                  → CANCELLED
+            ↕
+         SUSPENDED
+```
+
+**Transitions:**
+
+| From | To | Trigger | Event emitted |
+|------|----|---------|--------------|
+| CREATED | RUNNING | Coroutine begins evaluation | (none) |
+| RUNNING | SUSPENDED | Kernel yields external effect | (none — Yield emitted on resume) |
+| SUSPENDED | RUNNING | Effect result received | Yield event |
+| RUNNING | COMPLETED | Evaluation finishes with value | Close(ok) |
+| RUNNING | FAILED | Runtime error | Close(err) |
+| RUNNING | CANCELLED | Cancel signal received | Close(cancelled) |
+| SUSPENDED | CANCELLED | Cancel signal while waiting | Close(cancelled) — NO Yield |
+
+**Invalid transitions (MUST NOT occur):**
+
+- Any transition FROM a terminal state (COMPLETED, FAILED,
+  CANCELLED).
+- SUSPENDED → COMPLETED (must resume first).
+- CREATED → any terminal state (must run first).
+- Emitting any event after Close.
+
+### 3.3 Effect Evaluation
+
+When the kernel encounters an external Eval node:
+
+```
+1. Resolve arguments via resolve(data, env).
+2. Construct descriptor: { id, data: resolved }.
+3. Coroutine → SUSPENDED.
+4. Execution layer dispatches to agent (or feeds replay result).
+5. Result received → coroutine → RUNNING.
+6. Yield event emitted (persist-before-resume).
+7. Evaluation continues with result value.
+```
+
+### 3.4 Journal Emission Rule
+
+Events are emitted at exactly these points:
+
+- **Yield:** emitted when a SUSPENDED coroutine resumes
+  (transition SUSPENDED → RUNNING). Contains the effect's
+  description and the result received.
+- **Close:** emitted when a coroutine enters a terminal state
+  (RUNNING → COMPLETED/FAILED/CANCELLED).
+
+No other events exist. No events are emitted during CREATED
+or during RUNNING between yields.
+
+---
+
+## 4. Normative Definitions
+
+### 4.1 Error Taxonomy
+
+| Error type | Cause | When | Close? | Replay behavior |
+|-----------|-------|------|--------|----------------|
+| `MalformedIR` | Invalid IR structure | Validation | NO journal | N/A |
+| `UnboundVariable` | Ref lookup failed | Runtime | Close(err) | Re-raised from stored result |
+| `NotCallable` | Call on non-Fn | Runtime | Close(err) | Re-raised from stored result |
+| `ArityMismatch` | Wrong arg count | Runtime | Close(err) | Re-raised from stored result |
+| `TypeError` | Invalid operand type | Runtime | Close(err) | Re-raised from stored result |
+| `DivisionByZero` | div/mod by zero | Runtime | Close(err) | Re-raised from stored result |
+| `ExplicitThrow` | throw node evaluated | Runtime | Close(err) | Re-raised from stored result |
+| `EffectError` | Agent returned error | Runtime | Close(err) | Stored Yield(err) re-delivered |
+| `DivergenceError` | Replay mismatch | Runtime (replay) | Close(err) | N/A (is the replay failure) |
+
+**Normative constraints:**
+
+- Implementations MUST map to these exact strings.
+- `MalformedIR` MUST occur at validation; all others MUST
+  occur at runtime.
+- Every runtime error MUST produce exactly one Close(err).
+- `MalformedIR` MUST NOT produce any events.
+
+**Partial journal before error:** Zero or more Yield events
+MAY precede Close(err). If effects executed successfully before
+the error, their Yield events MUST appear in the journal.
+
+**Kernel error `name`:** MUST match the canonical type from
+this table. Agent errors copy `name` verbatim from agent
+response. Kernel MUST NOT modify agent error `name`.
+
+### 4.2 IR Validation Model
+
+Two phases, both MUST complete before evaluation begins.
+
+**Phase 1 — Structural:** Grammar conformance. Missing fields,
+wrong types, extra fields on IR nodes → MalformedIR.
+
+**Phase 2 — Semantic:** Single-Quote rule, positions table.
+
+**NOT validated:** Ref binding. Unbound Refs → UnboundVariable
+at runtime. Implementations MUST NOT reject IR for unbound Refs.
+
+**Scope:** Recursive over entire tree. MUST NOT skip subtrees.
+
+**Boundary enforcement:** Implementations MUST NOT defer Phase 1
+or Phase 2 checks to runtime. Implementations MUST NOT perform
+runtime checks (Ref binding, type checks) during validation.
+
+**Failure:** Either phase fails → entire IR rejected. No
+evaluation. No journal.
+
+### 4.3 Canonical Encoding
+
+These rules define a single deterministic encoding for every
+JSON value. Two values are **canonically equal** if and only
+if their canonical encodings produce byte-identical UTF-8
+sequences.
+
+No normalization, re-parsing, or transformation is permitted
+before comparison. Comparison is raw byte equality.
+
+**Rules:**
+
+1. Lexicographic key order (Unicode code point), every level.
+2. No whitespace between any tokens.
+3. Numbers per §4.7.
+4. Strings: shortest RFC 8259 escapes for control characters,
+   literal UTF-8 for all others. `/` MUST NOT be escaped.
+   Non-ASCII MUST NOT use `\uXXXX` escapes.
+5. IR nodes: only specified fields. Extra fields → MalformedIR.
+
+Unless explicitly overridden, ALL comparisons in this spec
+use canonical equality.
+
+### 4.4 Coroutine Identity
+
+Root: `"root"`. Child N of parent P: `P + "." + N` (0-indexed).
+MUST match `^root(\.\d+)*$`. Never reused. Spawn order = `exprs`
+array order.
+
+### 4.5 Journal Event Schema
+
+Events MUST contain exactly the specified fields. Events MUST
+be emitted in canonical key order. The harness compares emitted
+bytes directly with no normalization.
+
+**Yield:** `{"coroutineId":"…","description":{"name":"…","type":"…"},"result":{…},"type":"yield"}`
+
+**Close:** `{"coroutineId":"…","result":{…},"type":"close"}`
+
+**Success result:** `{"status":"ok","value":<Val>}` — `value`
+MUST always be present. Void → `null`.
+
+**Error result:** `{"error":{"message":"…"},"status":"err"}` —
+`message` MUST be a non-empty string. MAY include `"name"`
+(string, also non-empty). MUST NOT include other fields.
+
+**Cancelled result:** `{"status":"cancelled"}` — no other fields.
+
+### 4.6 Effect Descriptor Mapping
+
+`parseEffectId(id)`: split on first dot. `"a.b.c"` → type
+`"a"`, name `"b.c"`. Undotted → both equal full ID. Total,
+deterministic, one-way.
+
+### 4.7 Canonical Numbers
+
+Reference: ECMAScript `Number.prototype.toString()`. Shortest
+round-trip form. Integers without decimal/exponent. Negative
+zero → `0`. Exponents: lowercase `e`, explicit sign, no leading
+zeros. NaN and Infinity MUST NOT appear.
+
+### 4.8 Correlation IDs
+
+Format: `"{taskId}:{yieldIndex}"`. Byte-equal comparison. No
+normalization.
+
+### 4.9 Object Traversal
+
+ALL key iteration MUST use lexicographic order (Unicode code
+point). Implementations MUST NOT rely on host-language iteration
+order.
+
+---
+
+## 5. Determinism Guarantees
+
+### 5.1 Core Invariant
+
+> Given identical IR and identical effect results, the kernel
+> MUST produce identical journal events in identical order and
+> an identical final result. Every time. Across implementations.
+
+This is the foundational guarantee. All other guarantees derive
+from it.
+
+### 5.2 What This Requires
+
+- No randomness in evaluation.
+- No timing-dependent behavior.
+- No host-language-dependent ordering.
+- No uninitialized state.
+- Deterministic object key traversal (§4.9).
+- Deterministic coroutine ID generation (§4.4).
+- Deterministic cancellation ordering (§8.3).
+
+### 5.3 Replay Corollary
+
+> Given identical IR and a stored journal, replay MUST produce
+> identical results and an identical final journal (stored events
+> + any new events). The replay cursor advances deterministically.
+
+### 5.4 Compiler Corollary
+
+> `compile(source)` MUST produce byte-identical canonical JSON
+> on every invocation for the same source.
+
+---
+
+## 6. Global Invariants
+
+The following invariants MUST hold for every conforming
+execution. Each is independently testable.
+
+**I1.** Every coroutine produces exactly one Close event.
+
+**I2.** No events are emitted for a coroutine after its Close.
+
+**I3.** Every Yield event corresponds to exactly one effect
+that was dispatched and resolved.
+
+**I4.** Coroutine IDs are unique within an execution and
+match `^root(\.\d+)*$`.
+
+**I5.** Journal events are append-only. Never modified,
+deleted, or reordered after emission.
+
+**I6.** Yield events are durably persisted before the kernel
+resumes (persist-before-resume).
+
+**I7.** Replay consumes stored events in positional order per
+coroutine. No search, no reordering.
+
+**I8.** The journal is the sole source of truth for execution
+history. No side channel exists.
+
+---
+
+## 7. Formal Test Case Schemas
+
+Every fixture is a JSON object conforming to one of the schemas
+below. Harness implementations MUST validate fixtures against
+these schemas before execution.
+
+### 7.1 Common Fields
+
+```
+{
+  "id":            string,              // REQUIRED. Unique. Stable.
+  "suite_version": "2.0.0",            // REQUIRED. Must match spec.
+  "tier":          "core"|"extended",   // REQUIRED.
+  "level":         1|2|3|4,            // REQUIRED.
+  "category":      string,              // REQUIRED. Dot-separated.
+  "spec_ref":      string,              // REQUIRED. E.g. "kernel.5.1".
+  "description":   string,              // REQUIRED. One sentence.
+  "timeout_ms":    integer              // OPTIONAL. Default: 30000.
+}
+```
+
+**`suite_version` handling:** If the fixture's `suite_version`
+is a higher MAJOR than the runner supports, the runner MUST
+skip the fixture and report "unsupported version." If the
+MAJOR matches but MINOR is higher, the runner MUST attempt
+execution (forward-compatible within a major version). Unknown
+fields in fixtures MUST be ignored by the runner.
+
+### 7.2 Evaluation Test
+
+```
+{
+  …common,
+  "type": "evaluation",
+  "ir":   <Expr>,                    // REQUIRED.
+  "env":  { string: Val },           // REQUIRED. Values only.
+  "expected_result": EventResult,    // REQUIRED.
+  "expected_journal": [ Event, … ]   // REQUIRED. ≥1 Close.
+}
+```
+
+**Normative:** Implementations MUST produce the exact
+`expected_result` and `expected_journal` for this fixture.
+
+### 7.3 Effect Test
+
+```
+{
+  …common,
+  "type": "effect",
+  "ir":   <Expr>,
+  "env":  { string: Val },
+  "effects": [
+    { "descriptor": { "id": string, "data": <Val> },
+      "result": EventResult,
+      "coroutineId": string              // OPTIONAL. If present,
+    }, …                                 // harness verifies coroutine.
+  ],                                 // REQUIRED. Ordered.
+  "expected_result": EventResult,    // REQUIRED.
+  "expected_journal": [ Event, … ]   // REQUIRED.
+}
+```
+
+For concurrent fixtures, the `effects` array lists effects in
+spawn-order scheduling order (§8.4). If `coroutineId` is
+present on an effect entry, the harness MUST verify that the
+suspension occurred on that coroutine; mismatch → FAIL.
+
+### 7.4 Replay Test
+
+```
+{
+  …common,
+  "type": "replay",
+  "ir":   <Expr>,
+  "env":  { string: Val },
+  "stored_journal": [ Event, … ],   // REQUIRED. May be empty.
+  "live_effects": [
+    { "descriptor": {…}, "result": EventResult }, …
+  ],                                 // REQUIRED. May be empty.
+  "expected_result": EventResult,    // REQUIRED.
+  "expected_journal": [ Event, … ]   // REQUIRED. Full journal.
+}
+```
+
+### 7.5 Negative Test
+
+**Validation error** (no journal):
+
+```
+{
+  …common,
+  "type": "negative_validation",
+  "ir":   <MalformedExpr>,           // REQUIRED.
+  "expected_error": "MalformedIR"    // REQUIRED. Always this.
+}
+```
+
+No `env`, `effects`, or `expected_journal`. Absence is normative.
+
+**Runtime error** (journal produced):
+
+```
+{
+  …common,
+  "type": "negative_runtime",
+  "ir":   <Expr>,
+  "env":  { string: Val },           // REQUIRED.
+  "effects": [ … ],                 // REQUIRED. May be empty.
+  "expected_error": "<ErrorType>",   // REQUIRED. From §4.1.
+  "expected_journal": [ Event, … ]   // REQUIRED. Ends with Close(err).
+}
+```
+
+### 7.6 Protocol Test
+
+```
+{
+  …common,
+  "type": "protocol",
+  "transcript": [ { "direction": "agent→host"|"host→agent",
+                     "message": <JSON-RPC> }, … ],
+  "expected_outcome": string
+}
+```
+
+### 7.7 Compiler Test
+
+```
+{
+  …common,
+  "type": "compiler",
+  "source": string,
+  "expected_ir": <Expr>              // Canonical JSON. Byte match.
+}
+```
+
+### 7.8 The `"<any>"` Sentinel
+
+When `error.message` in an expected event is `"<any>"`, the
+harness MUST accept any non-empty string. Applies ONLY to
+`error.message`. MUST NOT appear in any other field.
+
+**Harness implementation rule:** The harness MUST apply
+sentinel logic ONLY when comparing the `error.message` field
+of an expected event AND the expected value is exactly the
+5-character string `<any>`. The harness MUST NOT apply sentinel
+logic to any other field. If the actual output's `error.message`
+is the literal string `"<any>"`, the harness MUST accept it
+(it is a valid non-empty string).
+
+---
+
+## 8. Concurrency Ordering
+
+### 8.1 Within a Coroutine
+
+Totally ordered. Yields in emission order. Close after all
+Yields. Exactly one Close per coroutine (invariant I1).
+
+### 8.2 Across Coroutines (Normal Execution)
+
+Sibling events MAY interleave. Causal constraints:
+
+**C1.** Child C's Close MUST precede parent P's Close.
+
+**C2.** For `all`: child C's Close MUST precede parent P's
+Yield that reports the `all` result.
+
+**C3.** Within a coroutine: emission order preserved.
+
+A total ordering is **valid** iff it satisfies C1, C2, C3.
+Any violation is a conformance FAIL.
+
+### 8.3 Cancellation (Deterministic)
+
+`Close(cancelled)` events in reverse creation order. This is
+deterministic (§5.2). Cancellation fixtures use exact ordering.
+
+### 8.4 Scheduling Order (Normative)
+
+For conformance testing, the execution layer MUST evaluate
+concurrent children in **spawn order** (child 0 first, child 1
+second, etc.). Each child runs until it suspends or completes
+before the next child begins its first evaluation step.
+
+After all children have completed their initial evaluation
+step, subsequent scheduling rounds continue in spawn order:
+child 0 resumes first, runs until it suspends or completes,
+then child 1, etc.
+
+This defines a deterministic round-robin schedule. The
+consequence: given identical IR and identical effect results,
+the journal event ordering is fully deterministic, including
+for concurrent fixtures. Implementations MAY use different
+scheduling internally, but their observable output MUST match
+the output that spawn-order scheduling would produce.
+
+---
+
+## 9. Conformance Runner
+
+### 9.1 Architecture
+
+```
+Fixture → Runner → Implementation Under Test → Output → Comparator → PASS/FAIL
+```
+
+### 9.2 Execution Procedures
+
+**Evaluation test:**
+
+```
+1. Parse fixture. Validate against §7.2.
+2. Provide IR and env to kernel.
+3. Kernel evaluates. No suspensions expected.
+4. If kernel suspends: FAIL ("unexpected effect").
+5. Collect: result, journal.
+6. Compare result: canonical equality with expected_result.
+7. Compare journal: per §9.4.
+```
+
+**Effect test:**
+
+```
+1. Parse fixture. Validate against §7.3.
+2. Provide IR and env to kernel.
+3. Let N = 0.
+4. On each kernel suspension:
+   a. If N ≥ len(effects): FAIL ("more effects than expected").
+   b. Compare descriptor: canonical equality on "id" AND "data".
+   c. If mismatch: FAIL ("unexpected descriptor at N").
+   d. Feed effects[N].result to kernel.
+   e. N = N + 1.
+5. After completion:
+   a. If N < len(effects): FAIL ("fewer effects than expected").
+   b. Compare result.
+   c. Compare journal: per §9.4.
+```
+
+**Replay test:**
+
+```
+1. Parse fixture. Validate against §7.4.
+2. Provide IR to validator. Validator MUST accept (the
+   fixture IR is well-formed). If validator rejects: FAIL
+   ("replay fixture IR is malformed").
+3. Initialize replay state per §10.1.
+4. Provide IR, env, and replay state to kernel.
+   The kernel MUST validate IR before evaluation, exactly
+   as in live execution (§3.1). Replay MUST NOT exempt
+   IR from validation.
+5. Kernel drives replay internally (§10.1 algorithm).
+6. For live effects post-replay: harness feeds from
+   live_effects using same descriptor matching as effect test.
+7. Collect result, full journal.
+8. Compare result. Compare journal: per §9.4.
+```
+
+**Negative validation test:**
+
+```
+1. Parse fixture. Validate against §7.5.
+2. Provide IR to validator.
+3. Validator MUST reject with expected_error type.
+4. MUST NOT produce any events.
+5. If accepts, wrong type, or events emitted: FAIL.
+```
+
+**Negative runtime test:**
+
+```
+1. Parse fixture. IR passes validation.
+2. Provide IR and env to kernel.
+3. Feed effects as in effect test.
+4. Kernel MUST raise expected_error.
+5. Compare journal (MUST end with Close(err) for root).
+```
+
+**Protocol test:**
+
+```
+1. Parse fixture.
+2. Execute transcript entries in order.
+3. Compare implementation messages (structural equality).
+4. Verify expected_outcome.
+```
+
+### 9.3 Timeout
+
+No output within `timeout_ms` (default 30000) → FAIL.
+
+### 9.4 Journal Comparison
+
+Mode selection from fixture:
+
+- Flat `expected_journal` array, category NOT "cancellation"
+  → **sequential mode**.
+- `expected_journal` has `"partial_order": true`
+  → **concurrent mode**.
+- Category contains "cancellation"
+  → **cancellation mode** (exact sequential).
+
+**Sequential mode:**
+
+```
+compare_sequential(actual, expected):
+  1. len(actual) ≠ len(expected) → FAIL.
+  2. For i = 0 .. len(expected)-1:
+     a. A = canonical(actual[i]).
+     b. E = canonical(expected[i]).
+     c. Apply "<any>" sentinel (§7.8).
+     d. A ≠ E → FAIL at position i.
+  3. PASS.
+```
+
+**Concurrent mode:**
+
+```
+compare_concurrent(actual, expected_po):
+  PO = expected_po.per_coroutine  // {coroutineId: [Event]}
+  C  = expected_po.causal         // [[before_ref, after_ref]]
+
+  1. Partition actual by coroutineId → groups.
+  2. For each K in PO:
+     a. K not in groups → FAIL ("missing coroutine").
+     b. compare_sequential(groups[K], PO[K]).
+     c. Remove K from groups.
+  3. groups not empty → FAIL ("unexpected coroutine").
+  4. For each [A_ref, B_ref] in C:
+     a. Resolve refs to global positions in actual.
+     b. position(A) ≥ position(B) → FAIL ("causal violation").
+  5. PASS.
+```
+
+### 9.5 Runner Edge Cases
+
+- **Extra events:** FAIL. MUST NOT silently ignore.
+- **Fewer events:** FAIL.
+- **Event after Close:** FAIL ("event after Close for C").
+- **Multiple Close:** FAIL ("duplicate Close for C").
+
+### 9.6 Runner Invariant Checks
+
+Before journal comparison, the runner MUST independently verify
+on the ACTUAL journal:
+
+- **I1 check:** Every coroutineId that appears in the journal
+  has exactly one Close event.
+- **I2 check:** No events appear for a coroutineId after that
+  coroutine's Close event.
+
+Violation of either is FAIL, regardless of whether the actual
+journal matches the expected journal. This prevents a buggy
+fixture from masking non-conformant behavior.
+
+---
+
+## 10. Replay Conformance
+
+### 10.1 Replay Algorithm
+
+Replay is **per-coroutine** and **positional**.
+
+```
+STATE:
+  cursors: { coroutineId → integer }  // 0-indexed per coroutine
+  closes:  { coroutineId → bool }
+
+INITIALIZE(stored_journal):
+  For each event in stored_journal:
+    If Yield: append to per-coroutine yield list, preserving order.
+    If Close: set closes[coroutineId] = true.
+  Set all cursors to 0.
+
+ON_KERNEL_YIELD(coroutine C, descriptor D):
+  Let cursor = cursors[C]  (default 0 if absent)
+  Let yields_C = stored yields for C (empty if absent)
+
+  IF cursor < len(yields_C):                         // CASE 1
+    Let stored = yields_C[cursor]
+    Let yielded = parseEffectId(D.id)
+    IF yielded.type = stored.description.type
+       AND yielded.name = stored.description.name:
+      Feed stored.result to kernel.
+      cursors[C] = cursor + 1.
+      Emit Yield event with stored.description and stored.result.
+    ELSE:
+      RAISE DivergenceError.                         // D1
+
+  ELSE IF closes[C] exists:                          // CASE 2
+    RAISE DivergenceError.                           // D2
+
+  ELSE:                                              // CASE 3
+    Transition to live dispatch for coroutine C.
+    (Harness feeds from live_effects.)
+```
+
+Coroutine C absent from stored_journal → cursor=0, yields
+empty, closes absent → immediate CASE 3 (live dispatch).
+
+**ON_COROUTINE_CANCEL during replay:** Cancellation during
+replay follows live execution rules (§3.2). The coroutine
+transitions to CANCELLED and emits Close(cancelled).
+Unconsumed stored Yields for C are abandoned — NOT a
+divergence. The cursor for C is never advanced further.
+
+**Close events during replay:** Close events are NOT replayed
+from the stored journal. They are emitted by the coroutine
+state machine (§3.2) independently. Stored Close events
+serve ONLY as sentinels for D2 divergence detection. They
+are never "consumed" or "replayed."
+
+**Replay Yield description source:** In CASE 1, the emitted
+Yield event MUST use the stored event's `description` and
+`result` fields byte-for-byte. Implementations MUST NOT
+recompute the description from the current descriptor
+during replay.
+
+### 10.2 Description Matching
+
+Compares ONLY `type` and `name`. Arguments are NOT compared.
+This is normative.
+
+**Rationale:** Code evolves between original execution and
+replay. Arguments change; effect identity stays the same.
+
+**Consequence:** Same type+name, different data → match
+succeeds, stored result returned. NOT a divergence. Tested
+by REPLAY-050.
+
+### 10.3 Positional Matching
+
+Per-coroutine cursor. Starts at 0. Advances by 1. NO search.
+
+Two identical `(a.op, a.op)` → first stored feeds first
+yielded, second feeds second. Tested by REPLAY-053.
+
+### 10.4 Exhaustive Divergence Conditions
+
+ALL conditions that produce DivergenceError:
+
+| ID | Condition | Trigger |
+|----|-----------|---------|
+| D1 | Description mismatch | Stored Yield at cursor has different type or name |
+| D2 | Continue past Close | All stored Yields consumed AND Close exists for C |
+
+NOT a divergence:
+
+| Condition | Why |
+|-----------|-----|
+| Argument difference | §10.2: only type+name compared |
+| Fewer effects than stored | Execution simply shorter; journal contains only produced events |
+| Unknown coroutine | Treated as fresh (CASE 3) |
+
+**End-of-execution rule:** When a coroutine reaches a terminal
+state during replay, any unconsumed stored Yields for that
+coroutine are silently abandoned. The implementation MUST NOT
+treat unconsumed stored Yields as an error or divergence.
+Stored Yields for coroutine IDs the kernel never spawns are
+silently ignored.
+
+---
+
+## 11. Journal Conformance
+
+### 11.1 Allowed Event Sequences
+
+For each coroutine, the event sequence MUST match:
+
+```
+Yield* Close
+```
+
+Zero or more Yields followed by exactly one Close. No events
+after Close. No Close without a coroutine having started.
+
+### 11.2 Ordering Invariants
+
+**O1.** Events totally ordered by global position.
+**O2.** Per-coroutine Yields in emission order.
+**O3.** Per-coroutine Close after all Yields.
+**O4.** Child Close before parent's consuming event.
+**O5.** Parent Close after all children's Closes.
+
+### 11.3 Yield-Effect Correspondence
+
+Every Yield event corresponds to exactly one effect that was:
+dispatched to an agent (live execution) OR fed from the stored
+journal (replay). No Yield exists without a corresponding
+effect evaluation.
+
+### 11.4 Append-Only
+
+Events are appended. Never modified, deleted, or reordered.
+
+---
+
+## 12. Test Suite: Core Fixtures
+
+All fixtures are **Core** unless marked [Extended]. Each is a
+complete, machine-readable JSON object. All fixtures are
+**normative**: implementations MUST produce the exact
+`expected_result` and `expected_journal` specified.
+
+### 12.1 KERN-001: Integer literal
+
+```json
+{
+  "id": "KERN-001", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.evaluation.literal",
+  "spec_ref": "kernel.1.4", "type": "evaluation",
+  "description": "Integer literal evaluates to itself",
+  "ir": 42,
+  "env": {},
+  "expected_result": {"status":"ok","value":42},
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"ok","value":42},"type":"close"}
+  ]
+}
+```
+
+### 12.2 KERN-020: Let binding
+
+```json
+{
+  "id": "KERN-020", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.evaluation.let",
+  "spec_ref": "kernel.5.1", "type": "evaluation",
+  "description": "Let binds value and makes it available in body",
+  "ir": {"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+    "body":{"tisyn":"ref","name":"x"},"name":"x","value":1}}},
+  "env": {},
+  "expected_result": {"status":"ok","value":1},
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"ok","value":1},"type":"close"}
+  ]
+}
+```
+
+### 12.3 KERN-034: Call-site resolution
+
+```json
+{
+  "id": "KERN-034", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.evaluation.call",
+  "spec_ref": "kernel.5.5", "type": "evaluation",
+  "description": "Free variable resolves at call site, not definition site",
+  "ir": {"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+    "body":{"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+      "body":{"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+        "body":{"tisyn":"eval","id":"call","data":{"tisyn":"quote","expr":{
+          "args":[],"fn":{"tisyn":"ref","name":"f"}}}},
+        "name":"x","value":2}}},
+      "name":"f","value":{"tisyn":"fn","params":[],"body":{"tisyn":"ref","name":"x"}}}}},
+    "name":"x","value":1}}},
+  "env": {},
+  "expected_result": {"status":"ok","value":2},
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"ok","value":2},"type":"close"}
+  ]
+}
+```
+
+### 12.4 KERN-080: Sequential effects
+
+```json
+{
+  "id": "KERN-080", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.effects.sequential",
+  "spec_ref": "kernel.4.3", "type": "effect",
+  "description": "Two effects in let chain, second uses first result",
+  "ir": {"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+    "body":{"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+      "body":{"tisyn":"ref","name":"b"},
+      "name":"b",
+      "value":{"tisyn":"eval","id":"x.step2","data":[{"tisyn":"ref","name":"a"}]}}}},
+    "name":"a",
+    "value":{"tisyn":"eval","id":"x.step1","data":[]}}}},
+  "env": {},
+  "effects": [
+    {"descriptor":{"id":"x.step1","data":[]},"result":{"status":"ok","value":10}},
+    {"descriptor":{"id":"x.step2","data":[10]},"result":{"status":"ok","value":20}}
+  ],
+  "expected_result": {"status":"ok","value":20},
+  "expected_journal": [
+    {"coroutineId":"root","description":{"name":"step1","type":"x"},"result":{"status":"ok","value":10},"type":"yield"},
+    {"coroutineId":"root","description":{"name":"step2","type":"x"},"result":{"status":"ok","value":20},"type":"yield"},
+    {"coroutineId":"root","result":{"status":"ok","value":20},"type":"close"}
+  ]
+}
+```
+
+### 12.5 KERN-071: Opaque value rule
+
+```json
+{
+  "id": "KERN-071", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.resolve.opaque",
+  "spec_ref": "kernel.3.2", "type": "effect",
+  "description": "Value resembling Ref in env not resolved further",
+  "ir": {"tisyn":"eval","id":"x.check","data":[{"tisyn":"ref","name":"v"}]},
+  "env": {"v": {"tisyn":"ref","name":"y"}},
+  "effects": [
+    {"descriptor":{"id":"x.check","data":[{"tisyn":"ref","name":"y"}]},"result":{"status":"ok","value":true}}
+  ],
+  "expected_result": {"status":"ok","value":true},
+  "expected_journal": [
+    {"coroutineId":"root","description":{"name":"check","type":"x"},"result":{"status":"ok","value":true},"type":"yield"},
+    {"coroutineId":"root","result":{"status":"ok","value":true},"type":"close"}
+  ]
+}
+```
+
+### 12.6 REPLAY-010: Partial replay to live
+
+```json
+{
+  "id": "REPLAY-010", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.replay.partial",
+  "spec_ref": "kernel.10.2", "type": "replay",
+  "description": "First two effects replayed, third dispatched live",
+  "ir": {"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+    "body":{"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+      "body":{"tisyn":"eval","id":"let","data":{"tisyn":"quote","expr":{
+        "body":{"tisyn":"ref","name":"c"},
+        "name":"c",
+        "value":{"tisyn":"eval","id":"x.step3","data":[{"tisyn":"ref","name":"b"}]}}}},
+      "name":"b",
+      "value":{"tisyn":"eval","id":"x.step2","data":[{"tisyn":"ref","name":"a"}]}}}},
+    "name":"a",
+    "value":{"tisyn":"eval","id":"x.step1","data":[]}}}},
+  "env": {},
+  "stored_journal": [
+    {"coroutineId":"root","description":{"name":"step1","type":"x"},"result":{"status":"ok","value":10},"type":"yield"},
+    {"coroutineId":"root","description":{"name":"step2","type":"x"},"result":{"status":"ok","value":20},"type":"yield"}
+  ],
+  "live_effects": [
+    {"descriptor":{"id":"x.step3","data":[20]},"result":{"status":"ok","value":30}}
+  ],
+  "expected_result": {"status":"ok","value":30},
+  "expected_journal": [
+    {"coroutineId":"root","description":{"name":"step1","type":"x"},"result":{"status":"ok","value":10},"type":"yield"},
+    {"coroutineId":"root","description":{"name":"step2","type":"x"},"result":{"status":"ok","value":20},"type":"yield"},
+    {"coroutineId":"root","description":{"name":"step3","type":"x"},"result":{"status":"ok","value":30},"type":"yield"},
+    {"coroutineId":"root","result":{"status":"ok","value":30},"type":"close"}
+  ]
+}
+```
+
+### 12.7 REPLAY-020: Divergence detection
+
+```json
+{
+  "id": "REPLAY-020", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.replay.divergence",
+  "spec_ref": "kernel.10.4", "type": "replay",
+  "description": "Different effect type than stored produces DivergenceError",
+  "ir": {"tisyn":"eval","id":"b.op2","data":[]},
+  "env": {},
+  "stored_journal": [
+    {"coroutineId":"root","description":{"name":"op1","type":"a"},"result":{"status":"ok","value":1},"type":"yield"}
+  ],
+  "live_effects": [],
+  "expected_result": {"status":"err","error":{"message":"<any>","name":"DivergenceError"}},
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"err","error":{"message":"<any>","name":"DivergenceError"}},"type":"close"}
+  ]
+}
+```
+
+### 12.8 NEG-020: Validation error
+
+```json
+{
+  "id": "NEG-020", "suite_version": "2.0.0",
+  "tier": "core", "level": 1,
+  "category": "ir.validation.malformed",
+  "spec_ref": "kernel.12.1", "type": "negative_validation",
+  "description": "Eval node with numeric id is malformed",
+  "ir": {"tisyn":"eval","id":42,"data":1},
+  "expected_error": "MalformedIR"
+}
+```
+
+### 12.9 NEG-001: Runtime error
+
+```json
+{
+  "id": "NEG-001", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.negative.unbound",
+  "spec_ref": "kernel.2.4", "type": "negative_runtime",
+  "description": "Ref to unbound name produces UnboundVariable",
+  "ir": {"tisyn":"ref","name":"unbound"},
+  "env": {},
+  "effects": [],
+  "expected_error": "UnboundVariable",
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"err","error":{"message":"<any>","name":"UnboundVariable"}},"type":"close"}
+  ]
+}
+```
+
+### 12.10 DET-005: Float serialization
+
+```json
+{
+  "id": "DET-005", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.determinism.numbers",
+  "spec_ref": "kernel.11.5", "type": "evaluation",
+  "description": "0.1 + 0.2 serialized as 0.30000000000000004",
+  "ir": {"tisyn":"eval","id":"add","data":{"tisyn":"quote","expr":{"a":0.1,"b":0.2}}},
+  "env": {},
+  "expected_result": {"status":"ok","value":0.30000000000000004},
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"ok","value":0.30000000000000004},"type":"close"}
+  ]
+}
+```
+
+### 12.11 KERN-014: Short-circuit suppression
+
+```json
+{
+  "id": "KERN-014", "suite_version": "2.0.0",
+  "tier": "core", "level": 3,
+  "category": "kernel.evaluation.shortcircuit",
+  "spec_ref": "kernel.5.10", "type": "evaluation",
+  "description": "And with falsy left does not dispatch right-side effect",
+  "ir": {"tisyn":"eval","id":"and","data":{"tisyn":"quote","expr":{
+    "a":false,
+    "b":{"tisyn":"eval","id":"a.op","data":[]}}}},
+  "env": {},
+  "expected_result": {"status":"ok","value":false},
+  "expected_journal": [
+    {"coroutineId":"root","result":{"status":"ok","value":false},"type":"close"}
+  ]
+}
+```
+
+---
+
+## 13. Test Index
+
+Tests marked [E] are Extended; all others Core.
+
+| Category | IDs | Tier |
+|----------|-----|------|
+| IR validation | IR-001–051 | Core (IR-041 [E]) |
+| Compiler | COMP-001–033, COMP-ERR-001–007 | Core |
+| Kernel evaluation | KERN-001–015, 020–035, 040–047 | Core |
+| Kernel construct/types | KERN-050, 060–064 | Core |
+| Kernel resolve | KERN-070–072 | Core |
+| Kernel effects | KERN-080–081 | Core |
+| Replay | REPLAY-001–053 | Core |
+| Concurrency | CONC-001–023 | Core |
+| Agent protocol | PROTO-001–033 | Core |
+| Agent extended | PROTO-040–051 | [E] |
+| Determinism | DET-001–007 | Core |
+| Negative | NEG-001–032 | Core |
+| Journal ordering | JOUR-001–004 | Core |
+| Journal extended | JOUR-005 | [E] |
+
+---
+
+## 14. Canonical Comparison
+
+### 14.1 Single Rule
+
+ALL comparisons use canonical byte equality (§4.3) unless
+explicitly stated otherwise. Compute canonical encoding, compare
+bytes. Identical → equal. Any difference → not equal.
+
+No normalization permitted.
+
+### 14.2 Exception
+
+Wire messages (§7.6): structural JSON equality. This is the
+ONLY exception in the entire specification.
+
+---
+
+## 15. Pass/Fail
+
+### 15.1 Pass
+
+ALL of: result matches, journal matches (per §9.4), protocol
+messages match (structural), negative tests produce expected
+error, no edge case violations (§9.5).
+
+### 15.2 Fail
+
+ANY of: different result, different journal, unexpected
+descriptor, wrong error type, error when none expected, no
+error when expected, extra events, fewer events, event after
+Close, duplicate Close, timeout.
+
+### 15.3 No Partial Credit
+
+All Core tests at level N → conformant at N.
+
+---
+
+## 16. Agent Transport Independence
+
+Protocol tests MUST NOT depend on timing, batching, or chunk
+boundaries.
+
+**Cancellation race invariant:** if `cancelling` set before
+Yield written → NO Yield emitted. Only Close(cancelled).
+
+---
+
+## 17. Compiler Conformance
+
+`compile(source)` N times → N byte-identical canonical JSON.
+Output MUST satisfy §4.2 and §4.3.
+
+---
+
+## 18. Interoperability
+
+```
+1. Compile S with A → IR_A. Compile S with B → IR_B.
+2. canonical(IR_A) === canonical(IR_B).
+3. Evaluate IR_A with Kernel A, effects R → J_AA.
+4. Evaluate IR_A with Kernel B, effects R → J_AB.
+5. J_AA === J_AB (per §9.4).
+```
+
+---
+
+## 19. Versioning and Compatibility
+
+### 19.1 Spec Version
+
+Every fixture MUST include `"suite_version": "2.0.0"`.
+
+### 19.2 Compatibility Rules
+
+**Backward:** Fixtures from version X.Y.Z MUST pass on any
+runner supporting version X.*.* where * ≥ Y (within same
+major).
+
+**Forward:** Runners MUST skip fixtures with higher MAJOR.
+Runners MUST attempt fixtures with same MAJOR, higher MINOR
+(ignoring unknown fields).
+
+### 19.3 Fixture Immutability
+
+Published fixtures are immutable. Corrections add new fixtures
+with new IDs; old fixtures marked `deprecated: true` but MUST
+still pass.
+
+---
+
+## 20. Harness Requirements
+
+1. Parse fixtures. Validate against schemas (§7).
+2. Check `suite_version` compatibility (§19).
+3. Execute per procedure (§9.2).
+4. Compare per mode (§9.4).
+5. Detect edge cases (§9.5).
+6. Verify invariants (§9.6).
+7. Support `"<any>"` sentinel in `error.message` only.
+8. Report pass/fail per test with comparison detail.
+9. Report Core vs Extended separately.
+10. Enforce timeouts.
+11. Support all seven test types.
+
+---
+
+## 21. Non-Conformance Examples
+
+The following describe incorrect implementations that might
+appear to pass. Each is non-conforming.
+
+**NC-1: Lexical scoping.** Resolves Fn free variables at
+definition site instead of call site. Fails KERN-034 (expects
+2, lexical produces 1).
+
+**NC-2: Runtime validation.** Checks single-Quote rule during
+evaluation instead of validation. May produce journal events
+before rejecting malformed IR. Any journal event from a
+validation error is non-conforming.
+
+**NC-3: Search-based replay.** Scans stored journal for
+matching Yield instead of positional cursor. Fails REPLAY-053
+(two identical effects get nondeterministic result assignment).
+
+**NC-4: Argument-dependent replay.** Compares effect arguments
+during replay. Fails REPLAY-050 (same type+name, different
+args must match).
+
+**NC-5: Non-canonical key order.** Emits events with keys in
+insertion order. Byte-different from canonical. All journal
+comparison fails.
+
+**NC-6: Host-language iteration.** Uses Go's random map order
+or unsorted object keys. Non-deterministic construct field
+evaluation. Fails KERN-050, DET-002.
+
+**NC-7: Forward cancellation order.** Cancels children 0→N
+instead of N→0. Wrong Close(cancelled) order. Fails CONC-021.
+
+**NC-8: Missing null for void.** Omits `value` field on void
+success: `{"status":"ok"}` instead of `{"status":"ok","value":null}`.
+Byte-different. All void-result tests fail.
+
+**NC-9: Agent error name injection.** Adds `"name":"EffectError"`
+to agent errors that didn't include name. Byte-different Yield
+events.
+
+**NC-10: Replay skips validation.** Bypasses IR validation
+during replay. Accepts malformed IR on restart after code
+change.

--- a/specs/tisyn-kernel-specification.md
+++ b/specs/tisyn-kernel-specification.md
@@ -1,0 +1,1301 @@
+# Tisyn Kernel Specification
+
+**Version:** 1.0.0
+**Implements:** Tisyn System Specification 1.0.0
+**Status:** Normative
+
+---
+
+## 1. Evaluation Model
+
+### 1.1 The Kernel's Job
+
+The kernel accepts a Tisyn IR tree and evaluates it. During
+evaluation, it encounters external operations that require I/O
+with remote agents. Each such operation is recorded in a journal.
+On crash, the kernel replays the journal into a fresh evaluation,
+reconstructing the same execution state without re-executing
+effects.
+
+### 1.2 Signature
+
+```
+eval : (Expr, Env) → Val | Error | Suspend(EffectDescriptor)
+```
+
+The kernel's evaluation function takes an expression and an
+environment and produces one of three outcomes:
+
+- **Val** — a JSON-serializable value. Evaluation complete.
+- **Error** — an exception. Propagates upward.
+- **Suspend** — an effect descriptor yielded to the execution
+  layer. The kernel pauses; the execution layer provides a result;
+  the kernel resumes.
+
+### 1.3 Values vs Expressions
+
+An **Expr** is any Tisyn IR node — a JSON document that
+describes a computation. Five types: Literal, Eval, Quote, Ref, Fn.
+
+A **Val** is the result of evaluating an expression:
+
+```
+Val = JsonPrimitive | JsonArray | JsonObject | FnVal
+```
+
+Every Val is also a valid Expr. But Eval, Quote, and Ref are
+Expr but NOT Val — they must be evaluated to produce a Val.
+
+Context determines classification: a JSON object with
+`tisyn: "eval"` is an Expr when encountered during tree traversal,
+and a Val when returned by `lookup()` or `eval()`.
+
+### 1.4 Evaluation Rules
+
+**LITERAL.** A value without a matching `tisyn` field evaluates
+to itself.
+
+```
+eval(literal, E) = literal
+```
+
+**REF.** A reference resolves in the environment.
+
+```
+eval({ tisyn: "ref", name: N }, E) = lookup(N, E)
+```
+
+**QUOTE.** Returns the inner expression without evaluating it.
+
+```
+eval({ tisyn: "quote", expr: X }, E) = X
+```
+
+This is the ONLY rule that may return a non-Val. Its output is
+consumed exclusively by `unquote` and `resolve`, never by
+application code.
+
+**FN.** A function evaluates to itself. No environment is captured.
+
+```
+eval({ tisyn: "fn", params: P, body: B }, E) =
+  { tisyn: "fn", params: P, body: B }
+```
+
+**EVAL.** A computation node. Classified and dispatched.
+
+```
+eval({ tisyn: "eval", id: ID, data: D }, E):
+  if classify(ID) = STRUCTURAL:
+    return eval_structural(ID, D, E)
+  if classify(ID) = EXTERNAL:
+    return eval_external(ID, D, E)
+```
+
+### 1.5 Classification
+
+```
+classify : string → STRUCTURAL | EXTERNAL
+```
+
+The structural set:
+
+```
+STRUCTURAL = {
+  "let", "seq", "if", "while", "call", "get",
+  "gt", "gte", "lt", "lte", "eq", "neq",
+  "add", "sub", "mul", "div", "mod",
+  "and", "or", "not", "neg",
+  "construct", "array", "concat", "throw"
+}
+
+classify(id) = STRUCTURAL  if id ∈ STRUCTURAL
+classify(id) = EXTERNAL    otherwise
+```
+
+Classification MUST be fixed at kernel initialization and MUST
+NOT change during execution. It MUST be identical between
+original execution and any replay.
+
+---
+
+## 2. Environment Model
+
+### 2.1 Structure
+
+An environment is a linked list of frames:
+
+```
+Env   = (Frame, Env) | ∅
+Frame = Map<string, Val>
+```
+
+### 2.2 Operations
+
+**Lookup:**
+
+```
+lookup(name, ∅)             = ERROR UnboundVariable(name)
+lookup(name, (frame, rest)) = frame[name]           if name ∈ frame
+                            = lookup(name, rest)     otherwise
+```
+
+**Extend:**
+
+```
+extend(E, name, val) = ({ name → val }, E)
+extend(E, names[], vals[]) = ({ n₁→v₁, ..., nₖ→vₖ }, E)
+  REQUIRES |names| = |vals|, else ArityMismatch
+```
+
+### 2.3 Invariants
+
+**I1.** Only Val may be stored in an environment. The kernel MUST
+fully evaluate an expression before placing its result in a binding.
+
+**I2.** Environments are immutable. No mutation operation exists.
+A binding set at frame creation never changes.
+
+**I3.** Environments do NOT cross process boundaries. They are
+kernel-internal state — not serialized, not journaled, not sent
+to agents.
+
+**I4.** Inner bindings shadow outer bindings with the same name.
+The outer binding is not modified.
+
+### 2.4 Unbound Reference
+
+If `lookup` reaches `∅` without finding the name, the kernel
+raises `UnboundVariable(name)`. This error propagates per §8.
+
+---
+
+## 3. The `resolve` Function
+
+### 3.1 Purpose
+
+`resolve(node, E)` produces a fully resolved Val from an Expr by
+recursively resolving Ref, Eval, and Quote nodes within arrays
+and objects. It is used exclusively when preparing external effect
+descriptors (§4.3).
+
+### 3.2 The Opaque Value Rule
+
+> `resolve()` MUST NOT recurse into any value returned by
+> `lookup()` or `eval()`. Such values are **terminal** —
+> returned without inspection, traversal, or re-evaluation,
+> regardless of their structure.
+
+This holds even if the returned value contains a `tisyn` field
+or structurally resembles an IR node.
+
+### 3.3 Algorithm
+
+```
+resolve(node, E):
+  if node.tisyn = "ref":
+    return lookup(node.name, E)          // TERMINAL
+
+  if node.tisyn = "eval":
+    return eval(node, E)                 // TERMINAL
+
+  if node.tisyn = "fn":
+    return node                          // TERMINAL
+
+  if node.tisyn = "quote":
+    return resolve(node.expr, E)         // unwrap, recurse
+
+  if node is array:
+    return [resolve(item, E) for item in node]   // TRAVERSABLE
+
+  if node is object:
+    result = {}
+    for (key, child) in node:
+      result[key] = resolve(child, E)
+    return result                        // TRAVERSABLE
+
+  return node                            // primitive, TERMINAL
+```
+
+### 3.4 Categories
+
+| Category | Behavior |
+|----------|----------|
+| **Terminal** | Return as-is. No further traversal. Results of `lookup`, `eval`; Fn nodes; primitives. |
+| **Unwrap** | Strip Quote, resolve contents. |
+| **Traversable** | Recurse into children. Plain arrays; plain objects without matching `tisyn`. |
+
+### 3.5 Postcondition
+
+After `resolve(data, E)`, the result contains no Ref, Eval, or
+Quote nodes. Only Val.
+
+### 3.6 Where `resolve` Is Applied
+
+`resolve` is called in exactly one place: Step 1 of the standard
+external effect boundary (§4.3). It is NOT called for structural
+operations (they use `unquote`), and NOT called for compound
+external operations (they use `unquote` to preserve child
+expressions).
+
+---
+
+## 4. Eval Node Execution
+
+### 4.1 The `unquote` Operation
+
+```
+unquote(node, E):
+  if node.tisyn = "quote":
+    return node.expr
+  else:
+    return eval(node, E)
+```
+
+Returns raw Expr fields from a Quote without evaluation. Used by
+structural operations to destructure their data. The result is an
+Expr, not necessarily a Val.
+
+### 4.2 Structural Execution
+
+When `classify(ID) = STRUCTURAL`:
+
+```
+eval_structural(ID, D, E):
+  fields = unquote(D, E)     // destructure quoted data
+  // ... operation-specific logic using fields
+  // eval() individual sub-expressions as needed
+  return Val
+```
+
+Structural operations evaluate locally, synchronously, with no
+journal events. See §5 for each operation.
+
+### 4.3 External Execution — Standard
+
+When `classify(ID) = EXTERNAL` and `ID ∉ COMPOUND_EXTERNAL`:
+
+```
+eval_external(ID, D, E):
+  resolved = resolve(D, E)              // Step 1: resolve all data
+  descriptor = {
+    id: ID,
+    data: resolved
+  }
+  result = SUSPEND(descriptor)           // Step 2: yield to execution layer
+  return result                          // Step 3: resume with result
+```
+
+**Step 1 — Resolve.** Call `resolve(D, E)` to produce a fully
+resolved Val. No Ref, Eval, or Quote nodes remain.
+
+**Step 2 — Suspend.** Hand the descriptor to the execution layer.
+The kernel pauses. The task enters SUSPENDED state.
+
+**Step 3 — Resume.** The execution layer provides a Val or Error.
+The kernel resumes and returns the result.
+
+### 4.4 External Execution — Compound
+
+When `ID ∈ COMPOUND_EXTERNAL = { "all", "race" }` or `ID = "spawn"`:
+
+```
+eval_external(ID, D, E):
+  inner = unquote(D, E)                 // strip Quote, preserve children
+  descriptor = { id: ID, data: inner }
+  result = SUSPEND(descriptor)
+  return result
+```
+
+**Critical difference:** `unquote` is used instead of `resolve`.
+The child expressions inside `inner.exprs` remain unevaluated.
+The execution layer evaluates each child in a separate task.
+
+### 4.5 Effect Descriptor Shape
+
+For standard external:
+
+```
+{ id: "agent-id.methodName", data: Val }
+```
+
+For compound external:
+
+```
+{ id: "all", data: { exprs: [Expr, Expr, ...] } }
+{ id: "race", data: { exprs: [Expr, Expr, ...] } }
+{ id: "spawn", data: Expr }
+```
+
+### 4.6 Effect ID Parsing
+
+The execution layer parses dotted IDs:
+
+```
+parseEffectId("fraud-detector.fraudCheck")
+  → { type: "fraud-detector", name: "fraudCheck" }
+
+parseEffectId("sleep")
+  → { type: "sleep", name: "sleep" }
+```
+
+Split on first dot. Undotted IDs: type and name are the same.
+
+---
+
+## 5. Built-in Structural Operations
+
+Each operation: input shape, evaluation procedure, return value.
+
+### 5.1 `let`
+
+**Shape:** `data: Q({ name: string, value: Expr, body: Expr })`
+
+```
+eval_structural("let", D, E):
+  { name, value, body } = unquote(D, E)
+  V = eval(value, E)
+  E' = extend(E, name, V)
+  return eval(body, E')
+```
+
+The binding is visible only within `body`. Not visible in `value`.
+No self-reference. Immutable.
+
+### 5.2 `seq`
+
+**Shape:** `data: Q({ exprs: [Expr, ...] })`
+
+```
+eval_structural("seq", D, E):
+  { exprs } = unquote(D, E)
+  result = null
+  for expr in exprs:
+    result = eval(expr, E)
+  return result
+```
+
+All elements evaluate in the same environment E. Bindings from
+`let` inside one element are NOT visible in subsequent elements.
+
+### 5.3 `if`
+
+**Shape:** `data: Q({ condition: Expr, then: Expr, else?: Expr })`
+
+```
+eval_structural("if", D, E):
+  { condition, then, else } = unquote(D, E)
+  C = eval(condition, E)
+  if truthy(C): return eval(then, E)
+  if "else" present: return eval(else, E)
+  return null
+```
+
+Truthiness: `false`, `null`, `0`, `""` are falsy. All else truthy.
+
+### 5.4 `while`
+
+**Shape:** `data: Q({ condition: Expr, exprs: [Expr, ...] })`
+
+```
+eval_structural("while", D, E):
+  { condition, exprs } = unquote(D, E)
+  result = null
+  loop:
+    C = eval(condition, E)
+    if not truthy(C): return result
+    for expr in exprs:
+      result = eval(expr, E)
+    goto loop
+```
+
+Condition and body are re-evaluated each iteration from the
+unquoted Expr nodes. Environment E does not change between
+iterations — bindings inside the body are scoped to each
+iteration and discarded.
+
+There is no break mechanism. Loops terminate when the condition
+is falsy, or via error/cancellation.
+
+### 5.5 `call`
+
+**Shape:** `data: Q({ fn: Expr, args: [Expr, ...] })`
+
+```
+eval_structural("call", D, E):
+  { fn, args } = unquote(D, E)
+  F = eval(fn, E)
+  if F.tisyn ≠ "fn": raise NotCallable(F)
+  Vs = [eval(a, E) for a in args]
+  if |F.params| ≠ |Vs|: raise ArityMismatch
+  E' = extend(E, F.params, Vs)
+  return eval(F.body, E')
+```
+
+Arguments evaluated left-to-right. Body evaluates in caller's
+environment extended with parameter bindings (call-site
+resolution). The body MAY contain external Evals — the kernel
+handles suspension/resumption normally.
+
+### 5.6 `get`
+
+**Shape:** `data: Q({ obj: Expr, key: string })`
+
+```
+eval_structural("get", D, E):
+  { obj, key } = unquote(D, E)
+  O = eval(obj, E)
+  if O is object and key ∈ O: return O[key]
+  return null
+```
+
+`key` is a string literal, not evaluated.
+
+### 5.7 Arithmetic (`add`, `sub`, `mul`, `div`, `mod`)
+
+**Shape:** `data: Q({ a: Expr, b: Expr })`
+
+```
+eval_structural(op, D, E):
+  { a, b } = unquote(D, E)
+  A = eval(a, E)
+  B = eval(b, E)
+  if typeof A ≠ number: raise TypeError(op, "left", A)
+  if typeof B ≠ number: raise TypeError(op, "right", B)
+  if op ∈ {"div","mod"} and B = 0: raise DivisionByZero
+  return apply(op, A, B)
+```
+
+Numeric-only. TypeError on non-number. DivisionByZero on `÷ 0`.
+
+### 5.8 Comparison (`gt`, `gte`, `lt`, `lte`)
+
+Same shape and type constraint as arithmetic. Returns boolean.
+
+### 5.9 Equality (`eq`, `neq`)
+
+**Shape:** `data: Q({ a: Expr, b: Expr })`
+
+Accept any Val types. Comparison via canonical encoding:
+
+```
+eq(A, B) = canonical(A) === canonical(B)
+```
+
+Returns boolean.
+
+### 5.10 Short-Circuit (`and`, `or`)
+
+**Shape:** `data: Q({ a: Expr, b: Expr })`
+
+```
+eval_structural("and", D, E):
+  { a, b } = unquote(D, E)
+  A = eval(a, E)
+  if not truthy(A): return A
+  return eval(b, E)
+
+eval_structural("or", D, E):
+  { a, b } = unquote(D, E)
+  A = eval(a, E)
+  if truthy(A): return A
+  return eval(b, E)
+```
+
+Return **operand values**, not booleans. `And(0, X)` → `0`.
+`Or(42, X)` → `42`.
+
+### 5.11 Unary (`not`, `neg`)
+
+**Shape:** `data: Q({ a: Expr })`
+
+`not`: accepts any Val, returns boolean.
+`neg`: numeric-only, TypeError on non-number.
+
+### 5.12 `construct`
+
+**Shape:** `data: Q({ key₁: Expr, key₂: Expr, ... })`
+
+```
+eval_structural("construct", D, E):
+  fields = unquote(D, E)
+  keys = Object.keys(fields).sort()     // lexicographic
+  result = {}
+  for key in keys:
+    result[key] = eval(fields[key], E)
+  return result
+```
+
+Fields evaluated in **lexicographic key order**. This ensures
+deterministic effect ordering across languages.
+
+### 5.13 `array`
+
+**Shape:** `data: Q({ items: [Expr, ...] })`
+
+Evaluate each item left-to-right. Return the array.
+
+### 5.14 `concat`
+
+**Shape:** `data: Q({ parts: [Expr, ...] })`
+
+Evaluate each part, coerce to string, concatenate, return.
+
+### 5.15 `throw`
+
+**Shape:** `data: Q({ message: Expr })`
+
+```
+eval_structural("throw", D, E):
+  { message } = unquote(D, E)
+  M = eval(message, E)
+  raise ExplicitThrow(M)
+```
+
+---
+
+## 6. Quote Semantics
+
+### 6.1 Quote as Evaluation Boundary
+
+A Quote node prevents evaluation of its contents. When the
+kernel encounters a Quote during evaluation:
+
+```
+eval(Quote(X), E) = X
+```
+
+The inner expression X is returned as-is — an Expr, not a Val.
+
+### 6.2 How Quoted Data Is Later Evaluated
+
+Structural operations receive their data wrapped in a single
+Quote. The operation calls `unquote(data, E)` to strip the
+Quote layer, obtaining the raw fields (which are Expr nodes).
+The operation then selectively evaluates individual fields:
+
+```
+eval_structural("if", D, E):
+  { condition, then, else } = unquote(D, E)     // strip Quote
+  C = eval(condition, E)                          // evaluate condition
+  if truthy(C): return eval(then, E)              // evaluate chosen branch
+```
+
+The condition and branches are Expr nodes that the `if` operation
+evaluates on demand. The unchosen branch is never evaluated.
+
+### 6.3 Quote and Concurrency
+
+Concurrency nodes (`all`, `race`) use Quote to preserve child
+expressions:
+
+```json
+{ "tisyn": "eval", "id": "all",
+  "data": { "tisyn": "quote", "expr": {
+    "exprs": [child₁, child₂, ...] }}}
+```
+
+`unquote` strips the outer Quote. The execution layer receives
+`{ exprs: [child₁, child₂] }` where each child is an unevaluated
+Expr. The execution layer spawns each as a separate task.
+
+### 6.4 The Single-Quote Invariant
+
+Structural operation data uses exactly one Quote layer. The
+sub-expressions inside that Quote MUST NOT themselves be Quotes
+at positions the operation evaluates (see §10.4). This ensures
+`eval` on any sub-expression always produces a Val.
+
+### 6.5 Quote in External Effect Data
+
+External effect data is NOT wrapped in Quote (standard effects
+use `resolve`, not `unquote`). Exception: compound external
+operations (`all`, `race`, `spawn`) use Quote because they need
+`unquote` to preserve child expressions.
+
+---
+
+## 7. Concurrency Model
+
+### 7.1 No Concurrency in the IR
+
+The IR is sequential. Concurrency is introduced by the execution
+layer when it encounters `all`, `race`, or `spawn` effect
+descriptors.
+
+### 7.2 `all` Execution
+
+When the execution layer receives `{ id: "all", data: { exprs } }`:
+
+```
+execute_all(exprs, parentEnv, parentTask):
+  children = []
+  for i in 0..exprs.length-1:
+    childId = parentTask.taskId + "." + parentTask.childCounter++
+    child = createTask(childId, exprs[i], parentEnv)
+    children.append(child)
+
+  startAll(children)        // begin concurrent evaluation
+  results = awaitAll(children)
+  return results            // Val[] in exprs order
+```
+
+**Rules:**
+
+1. Each child evaluates in a **snapshot** of the parent's
+   environment at spawn time. The snapshot is a reference to the
+   same immutable frame chain — no copying needed because
+   environments are immutable.
+2. Children run concurrently. The execution layer determines
+   actual parallelism.
+3. Results returned in `exprs` order, not completion order.
+4. If any child fails: remaining cancelled, error propagates.
+5. If parent cancelled: all children cancelled.
+6. Empty `exprs`: return `[]` immediately.
+
+### 7.3 `race` Execution
+
+```
+execute_race(exprs, parentEnv, parentTask):
+  children = []
+  for i in 0..exprs.length-1:
+    childId = parentTask.taskId + "." + parentTask.childCounter++
+    child = createTask(childId, exprs[i], parentEnv)
+    children.append(child)
+
+  startAll(children)
+  winner = awaitFirst(children)    // first to COMPLETE
+  cancelRest(children, winner)
+  return winner.result             // single Val, not array
+```
+
+**Rules:**
+
+1. First child to complete successfully wins.
+2. All other children cancelled.
+3. A child that fails does NOT win — race continues with rest.
+4. If ALL children fail, the last error propagates.
+5. Return value is the winner's result (not wrapped in array).
+
+### 7.4 Environment Snapshot
+
+Children receive the parent's environment at spawn time. Since
+environments are immutable linked lists, this is a pointer copy.
+Children cannot modify the parent's environment. The parent
+cannot modify the children's environment. No synchronization
+is needed.
+
+### 7.5 Determinism Under Concurrency
+
+Children produce effects independently. Their journals interleave
+nondeterministically (network timing). But replay is deterministic
+because:
+
+- Each child has its own coroutine ID.
+- The ReplayIndex is per-coroutine.
+- Each child's cursor advances independently.
+- The parent waits for all/first — the journal records which
+  children completed and in what order.
+
+### 7.6 Child Task Identity
+
+```
+taskId = parentTask.taskId + "." + parentTask.childCounter
+```
+
+Counter starts at 0, increments per spawn. Task IDs match
+`^root(\.\d+)*$`. Generated deterministically from spawn order.
+
+---
+
+## 8. Error Handling
+
+### 8.1 Error Types
+
+| Error | Cause |
+|-------|-------|
+| `UnboundVariable` | Ref resolution failed |
+| `NotCallable` | Call on non-Fn value |
+| `ArityMismatch` | Wrong argument count |
+| `TypeError` | Invalid operand type |
+| `DivisionByZero` | div/mod by zero |
+| `ExplicitThrow` | `throw` node evaluated |
+| `EffectError` | Agent returned error |
+| `DivergenceError` | Replay mismatch |
+| `MalformedIR` | Invalid IR structure |
+
+### 8.2 Propagation
+
+When a sub-expression raises an error, the enclosing operation
+stops and propagates. No further sub-expressions are evaluated.
+
+**Per operation:**
+
+- `let`: error in value → propagate (body not evaluated).
+  Error in body → propagate.
+- `seq`: first error stops the sequence.
+- `if`: error in condition → propagate (no branch). Error in
+  branch → propagate.
+- `while`: error in condition or body → propagate, loop ends.
+- `call`: error in fn → propagate. Error in arg → propagate
+  (left-to-right, remaining skipped). Error in body → propagate.
+- Binary ops: error in left → propagate (right not evaluated).
+- Short-circuit: error in `a` → propagate. If `a` short-circuits,
+  `b` is not evaluated (no error possible from `b`).
+
+### 8.3 Errors at the Task Boundary
+
+When an error propagates to the top of a task's expression tree:
+
+1. Kernel raises to the execution layer.
+2. Close(err) written.
+3. Task → FAILED.
+4. Parent notified (all: siblings cancelled; race: this child
+   lost, race continues).
+
+### 8.4 Effect Errors
+
+When an agent returns `{ ok: false, error }`:
+
+1. Yield(err) written, acknowledged.
+2. Error delivered to kernel via the resume path.
+3. Kernel raises the error — propagation per §8.2.
+
+On replay, the same error is stored in the journal and
+re-delivered identically.
+
+### 8.5 Cancellation Is Not an Error
+
+Cancellation propagates downward (parent → children), not
+upward. It is delivered via a separate signal, not through the
+error path. A parent's catch does NOT catch cancellation.
+
+```
+cancel(task):
+  if task is terminal: return
+  task.cancelling = true              // point of no return
+  for child in task.children.reverse():
+    cancel(child)
+  destroy task's evaluation scope
+  write Close(cancelled)
+  task → CANCELLED
+```
+
+Once `cancelling` is true, any agent result for the task's
+pending effect is discarded. No Yield written. Irrevocable.
+
+---
+
+## 9. Journaling Model
+
+### 9.1 What Is Recorded
+
+Two event types. Nothing else.
+
+**Yield** — records one external effect's description and result:
+
+```json
+{
+  "type": "yield",
+  "coroutineId": "root.0",
+  "description": { "type": "fraud-detector", "name": "fraudCheck" },
+  "result": { "status": "ok", "value": true }
+}
+```
+
+**Close** — records a task's terminal state:
+
+```json
+{
+  "type": "close",
+  "coroutineId": "root.0",
+  "result": { "status": "ok", "value": { "receiptId": "r-456" } }
+}
+```
+
+### 9.2 Event Result Shape
+
+```
+EventResult =
+  | { status: "ok",   value?: Val }
+  | { status: "err",  error: { message: string, name?: string } }
+  | { status: "cancelled" }
+```
+
+### 9.3 When Events Are Written
+
+**Yield:** Written when the execution layer receives an agent
+result (or replays a stored result) and BEFORE the kernel resumes.
+This is the persist-before-resume invariant.
+
+```
+1. Agent responds with result.
+2. Execution layer constructs Yield event.
+3. Execution layer appends to journal.
+4. Execution layer awaits durable acknowledgment.
+5. ONLY THEN: kernel resumes with the result.
+```
+
+If the host crashes between steps 3 and 5: the Yield is in the
+journal, the kernel was never resumed. On restart, replay feeds
+the stored result.
+
+If the host crashes between steps 1 and 3: the Yield is NOT in
+the journal. On restart, the effect is re-dispatched.
+
+**Close:** Written when a task reaches a terminal state
+(COMPLETED, FAILED, CANCELLED). Written after all children's
+Closes.
+
+### 9.4 Journal Structure
+
+The journal is an append-only sequence of events:
+
+```
+Journal = [Event₀, Event₁, Event₂, ...]
+```
+
+Events are totally ordered by append position. The journal is
+backed by a Durable Stream with epoch fencing (single writer).
+
+### 9.5 Ordering Guarantees
+
+**O1.** Events within the stream are totally ordered.
+
+**O2.** A child's Close precedes the parent's Yield that
+consumes it (causal ordering).
+
+**O3.** Yields for a given coroutine appear in the order the
+kernel yielded them.
+
+**O4.** A coroutine's Close appears after all its Yields.
+
+**O5.** A parent's Close appears after all children's Closes.
+
+### 9.6 Correlation IDs
+
+Each effect dispatch uses a correlation ID:
+
+```
+correlationId = taskId + ":" + yieldIndex
+```
+
+Where `yieldIndex` is the 0-based count of Yield events already
+written for this task. Deterministic. Unique within an execution.
+
+Cleanup effects (in finally blocks) continue the same yield index
+sequence. The index does NOT reset.
+
+### 9.7 What Is NOT Recorded
+
+- Structural operation evaluations (if, let, add, etc.)
+- Environment bindings
+- Internal control flow decisions
+- Progress notifications (ephemeral, separate channel)
+
+---
+
+## 10. Replay Semantics
+
+### 10.1 The Replay Index
+
+On startup, the kernel reads the journal and builds:
+
+```
+ReplayIndex:
+  yields:  Map<CoroutineId, Array<{ description, result }>>
+  cursors: Map<CoroutineId, number>
+  closes:  Map<CoroutineId, CloseEvent>
+```
+
+```
+buildIndex(events):
+  for event in events:
+    if event.type = "yield":
+      yields[event.coroutineId].append(event)
+    if event.type = "close":
+      closes[event.coroutineId] = event
+  for each coroutineId: cursors[id] = 0
+```
+
+### 10.2 The Matching Algorithm
+
+When the kernel suspends with descriptor `D` for `coroutineId`:
+
+```
+match(coroutineId, D):
+  entry = peekYield(coroutineId)
+
+  CASE 1: entry exists
+    expectedType = entry.description.type
+    expectedName = entry.description.name
+    actualType = parseEffectId(D.id).type
+    actualName = parseEffectId(D.id).name
+    if actualType ≠ expectedType: → DIVERGENCE
+    if actualName ≠ expectedName: → DIVERGENCE
+    consumeYield(coroutineId)    // cursor++
+    return entry.result          // REPLAY path
+
+  CASE 2: entry absent, close exists for coroutineId
+    → DIVERGENCE (continue-past-close)
+
+  CASE 3: entry absent, no close
+    → LIVE path (dispatch to agent)
+```
+
+### 10.3 Description Matching
+
+Only two fields are compared: `type` and `name`. All other fields
+are ignored. This allows arguments to change between versions
+without breaking replay.
+
+### 10.4 Divergence
+
+A divergence is fatal. The kernel MUST halt and surface:
+
+```
+DivergenceError {
+  coroutineId: string,
+  position: number,
+  expected: { type, name },
+  actual: { type, name }
+}
+```
+
+No further effects are replayed or dispatched.
+
+### 10.5 Replay vs Live
+
+During replay, the kernel executes identically to a live run. The
+only difference: at Step 2 of eval_external (§4.3), instead of
+dispatching to an agent and waiting, the execution layer feeds the
+stored result synchronously.
+
+Replay is synchronous. Every stored effect resolves in the same
+tick. A workflow with 1000 Yield events replays in one tick.
+
+### 10.6 Transition from Replay to Live
+
+After consuming all stored Yields for a coroutine, the next
+effect reaches CASE 3 (no entry, no close). This is the
+transition to live execution. The effect is dispatched to an
+agent. The task suspends. Execution continues normally.
+
+### 10.7 Crash Recovery Sequence
+
+```
+1. New kernel starts.
+2. Reads journal from Durable Stream.
+3. Builds ReplayIndex.
+4. Creates fresh evaluation from the IR tree.
+5. Kernel evaluates, hitting effects in order.
+6. Each effect matches a stored Yield → replayed synchronously.
+7. After all stored Yields consumed → live path.
+8. Kernel suspends, awaits agent response.
+9. Execution continues from the crash point.
+```
+
+The kernel is in the same state as before the crash because:
+same tree + same stored results → same branches → same bindings
+→ same environment → same next effect.
+
+---
+
+## 11. Determinism Guarantees
+
+### 11.1 The Determinism Theorem
+
+For a given IR tree T, initial environment E₀, effect result
+sequence R, and classification function C:
+
+The kernel produces a unique sequence of effect descriptors, a
+unique final value, and a unique task tree.
+
+### 11.2 What Must Be Deterministic
+
+| Component | Guarantee |
+|-----------|-----------|
+| Structural operations | Pure functions of inputs |
+| Effect descriptor construction | Deterministic from tree + env |
+| Effect ordering within a task | Single-threaded, sequential |
+| Task spawn ordering | Synchronous counter per parent |
+| Branching decisions | Same results → same conditions |
+| `construct` field order | Lexicographic key sorting |
+| `call` argument order | Left-to-right |
+| `seq` element order | Left-to-right |
+
+### 11.3 What Is Explicitly Non-Deterministic
+
+| Component | How handled |
+|-----------|-------------|
+| Effect result values | Journal stores them |
+| Wall-clock timing | Time is an effect |
+| Concurrent child completion order | Per-coroutine cursors |
+
+### 11.4 Structural Determinism
+
+The IR provides determinism structurally. Non-determinism sources
+present in JavaScript are absent from the IR:
+
+- No `Math.random()` (no random primitive)
+- No `Date.now()` (no time primitive)
+- No `Map`/`Set` iteration (no Map/Set type)
+- No `for...in` (no property enumeration)
+- No `Symbol` (no non-string keys)
+- No async scheduling (kernel is synchronous between effects)
+
+### 11.5 Canonical Encoding
+
+For byte-equal comparison of IR trees, journal events, and
+values:
+
+```
+canonical(value):
+  if primitive: JSON.stringify(value)
+  if array: "[" + join([canonical(item)], ",") + "]"
+  if object:
+    keys = sort(Object.keys(value))
+    return "{" + join(['"'+k+'":'+canonical(v) for (k,v)], ",") + "}"
+```
+
+Lexicographic key sorting at every level. No whitespace. Numbers
+in shortest round-trip form. All implementations MUST use IEEE 754
+binary64 for numeric computation.
+
+---
+
+## 12. Validation
+
+### 12.1 Node Classification
+
+Determined by `tisyn` field alone:
+
+- `tisyn` absent or unrecognized → Literal
+- `tisyn` matches discriminant → check required fields
+- Matching discriminant + missing fields → **Malformed** (error)
+
+Malformed nodes are NEVER treated as Literals.
+
+### 12.2 Single-Quote Validation
+
+For every structural Eval in the IR:
+
+1. `data` MUST be a Quote node.
+2. Let `P = positions(id, data.expr)`.
+3. No node in P may be a Quote.
+
+The `positions` function returns the set of Expr nodes that the
+operation will `eval()`:
+
+| Operation | Positions |
+|-----------|-----------|
+| `let` | `value`, `body` |
+| `seq` | each element of `exprs` |
+| `if` | `condition`, `then`, `else` (if present) |
+| `while` | `condition`, each element of `exprs` |
+| `call` | `fn`, each element of `args` |
+| `get` | `obj` |
+| binary ops | `a`, `b` |
+| unary ops | `a` |
+| `construct` | each value |
+| `array` | each element of `items` |
+| `concat` | each element of `parts` |
+| `throw` | `message` |
+
+### 12.3 When Validation Runs
+
+MUST validate when: parsing IR from JSON, receiving IR over the
+wire, loading from storage. MAY validate during evaluation.
+
+---
+
+## 13. Execution Lifecycle
+
+### 13.1 Initialization
+
+```
+1. Kernel receives: IR tree, initial arguments, journal stream.
+2. Build ReplayIndex from journal.
+3. Create root task with ID "root".
+4. Construct initial environment from arguments:
+   E₀ = extend(∅, paramNames, argValues)
+5. Begin evaluation: eval(IR.body, E₀)
+```
+
+### 13.2 Task States
+
+```
+CREATED → RUNNING ⇄ SUSPENDED → COMPLETED | FAILED | CANCELLED
+```
+
+| Transition | Trigger | Journal event |
+|-----------|---------|---------------|
+| CREATED → RUNNING | Task started | (none) |
+| RUNNING → SUSPENDED | External Eval | (none) |
+| SUSPENDED → RUNNING | Result received | Yield (before resume) |
+| RUNNING → COMPLETED | Body returns Val | Close(ok) |
+| RUNNING → FAILED | Unhandled error | Close(err) |
+| SUSPENDED → FAILED | Effect error | Yield(err), Close(err) |
+| * → CANCELLED | Cancel signal | Close(cancelled) |
+
+### 13.3 The Execution Loop
+
+Conceptually, per task:
+
+```
+loop:
+  result = eval(currentExpr, currentEnv)
+
+  if result is Val:
+    write Close(ok, result)
+    task → COMPLETED
+    return
+
+  if result is Error:
+    write Close(err, error)
+    task → FAILED
+    return
+
+  if result is Suspend(descriptor):
+    task → SUSPENDED
+    outcome = executionLayer.dispatch(descriptor)
+    // dispatch handles: replay check, agent dispatch,
+    //                   journal write, ack wait
+    if outcome is Val:
+      resume evaluation with outcome
+      goto loop
+    if outcome is Error:
+      deliver error to kernel
+      goto loop
+    if outcome is Cancelled:
+      write Close(cancelled)
+      task → CANCELLED
+      return
+```
+
+### 13.4 Completion
+
+Execution is complete when the root task reaches a terminal state
+(COMPLETED, FAILED, or CANCELLED). The final Close event for the
+root task is the last event in the journal.
+
+### 13.5 Invariants
+
+**P1 — Persist-before-resume.** Every Yield event MUST be durably
+acknowledged before the kernel resumes.
+
+**P2 — Close-after-children.** A parent's Close appears after all
+children's Closes in the journal.
+
+**P3 — Single writer.** Epoch fencing ensures at most one kernel
+writes to a stream at any time.
+
+**P4 — Classification stability.** The classification function
+does not change during execution or between replays.
+
+**P5 — Immutable IR.** The IR tree does not change during
+execution. It is read-only data.
+
+**P6 — Immutable environment.** Environment frames are
+append-only (new frames prepended, never modified).
+
+---
+
+## Appendix A: Kernel API Summary
+
+```
+// Core evaluation
+eval(expr: Expr, env: Env): Val | Error | Suspend
+
+// Data preparation
+unquote(node: Expr, env: Env): Expr | Val
+resolve(node: Expr, env: Env): Val
+
+// Environment
+lookup(name: string, env: Env): Val | Error
+extend(env: Env, name: string, val: Val): Env
+extend(env: Env, names: string[], vals: Val[]): Env
+
+// Classification
+classify(id: string): STRUCTURAL | EXTERNAL
+
+// Replay
+buildIndex(events: Event[]): ReplayIndex
+match(coroutineId: string, descriptor: EffectDescriptor): ReplayResult
+
+// Task management
+createTask(id: string, expr: Expr, env: Env): Task
+cancel(task: Task): void
+```
+
+---
+
+## Appendix B: Execution Trace Example
+
+IR:
+
+```
+Fn(["orderId"],
+  Let("order", Eval("order-service.fetchOrder", [Ref("orderId")]),
+    Let("receipt", Eval("payment-service.chargeCard",
+          [Get(Ref("order"), "payment")]),
+      Ref("receipt"))))
+```
+
+Invocation: `Call(workflow, "order-123")`.
+
+```
+Step  Kernel action                       Env              Journal
+────  ─────────────                       ───              ───────
+ 1    eval Fn → Fn (value)                ∅
+ 2    eval Call(Fn, "order-123")          ∅
+ 3    extend: orderId → "order-123"       {orderId}
+ 4    eval Let(order, fetchOrder, ...)    {orderId}
+ 5    eval fetchOrder Eval                {orderId}
+ 6    resolve data: [Ref(orderId)] → ["order-123"]
+ 7    SUSPEND {id:"order-service.fetchOrder", data:["order-123"]}
+ 8    match("root", desc) → LIVE
+ 9    dispatch to agent                                    Execute→Agent
+10    agent returns {id:"123",total:150,payment:{card:"visa"}}
+11    Yield written                                        [0] yield root
+12    kernel resumes with order value     {orderId}
+13    extend: order → {id,total,payment}  {orderId,order}
+14    eval Let(receipt, chargeCard, ...)   {orderId,order}
+15    eval chargeCard Eval                {orderId,order}
+16    resolve data: [Get(Ref(order),"payment")]
+      → eval Get → {card:"visa"}
+      → [{card:"visa"}]
+17    SUSPEND {id:"payment-service.chargeCard", data:[{card:"visa"}]}
+18    match("root", desc) → LIVE
+19    dispatch to agent                                    Execute→Agent
+20    agent returns {receiptId:"r-789"}
+21    Yield written                                        [1] yield root
+22    kernel resumes with receipt value    {orderId,order}
+23    extend: receipt → {receiptId:"r-789"} {orderId,order,receipt}
+24    eval Ref("receipt") → {receiptId:"r-789"}
+25    Close written                                        [2] close root ok
+```
+
+**Replay of same trace after crash at step 17:**
+
+```
+Step  Kernel action                       ReplayIndex
+────  ─────────────                       ───────────
+ 1-6  (same as above)                     cursor=0
+ 7    SUSPEND fetchOrder
+ 8    match("root") → entry[0] MATCH      cursor→1
+ 9    feed stored result synchronously     (no dispatch)
+10-16 (same as above)
+17    SUSPEND chargeCard
+18    match("root") → CASE 3 (no entry)   → LIVE
+19    dispatch to agent                    (normal execution)
+```
+
+Replay consumed one stored Yield synchronously. The second
+effect transitioned to live. Journal after completion:
+
+```
+[0] yield root order-service.fetchOrder ok {id,total,payment}
+[1] yield root payment-service.chargeCard ok {receiptId:"r-789"}
+[2] close root ok {receiptId:"r-789"}
+```

--- a/specs/tisyn-specification-1.0.md
+++ b/specs/tisyn-specification-1.0.md
@@ -1,0 +1,1729 @@
+# Tisyn System Specification
+
+**Version:** 1.0.0
+**Status:** Normative
+
+---
+
+## 1. Overview
+
+Tisyn is a minimal, serializable expression language designed for
+durable distributed execution. Programs are JSON documents. They
+are evaluated by a host interpreter that dispatches external
+operations to remote agents, records results in an append-only
+journal, and reconstructs execution state after crashes by
+replaying the journal into a fresh interpreter.
+
+The system has three layers:
+
+**Tisyn Core IR.** A JSON-serializable expression language with
+five node types. Contains no closures, no prototypes, no Symbols,
+no runtime references, and no language-specific constructs. It is
+the canonical interface between all layers.
+
+**Authoring Layer.** A TypeScript-specific API of types and
+constructor functions that produce IR nodes. Provides phantom type
+parameters for IDE inference. Does not exist in the IR.
+
+**Execution Layer.** The runtime that interprets IR trees, manages
+task lifecycles, and records durable events. The IR defines what
+the execution layer consumes; the execution layer defines what it
+does with it.
+
+### 1.1 Layer Boundaries
+
+1. The IR is the interface between all layers.
+2. No authoring-layer type appears in the IR.
+3. No execution-layer concept (tasks, journals, agents) appears
+   in the IR.
+4. Serialization is defined on the IR, not on authoring types.
+
+---
+
+## 2. Core Concepts
+
+### 2.1 Expr (Expression)
+
+An expression is a Tisyn IR node — a JSON document that describes
+a computation. Expressions are evaluated to produce values.
+
+```
+Expr = Literal | Eval | Quote | Ref | Fn
+```
+
+An expression is NOT a value until it has been evaluated. A `Ref`
+is an instruction to look up a value. An `Eval` is an instruction
+to perform a computation. A `Quote` is a container holding an
+unevaluated expression.
+
+### 2.2 Val (Value)
+
+A value is the result of evaluating an expression. Values inhabit
+environments, cross the execution boundary, and appear in journal
+events.
+
+```
+Val = JsonPrimitive | JsonArray | JsonObject | FnVal
+
+JsonPrimitive = string | number | boolean | null
+JsonArray     = Val[]
+JsonObject    = { [key: string]: Val }
+FnVal         = { "tisyn": "fn", "params": string[], "body": Expr }
+```
+
+A `FnVal` is both a Val and an Expr. It is the only type that
+inhabits both sets. When encountered during evaluation, a `Fn`
+node evaluates to itself.
+
+The `JsonObject` production has no exclusion clause. Any JSON
+object is a valid `JsonObject`, including objects whose `tisyn`
+field is `"eval"`, `"quote"`, or `"ref"`.
+
+### 2.3 Context-Based Classification
+
+Whether a JSON object is an Expr or a Val is determined by the
+context in which it appears, not by its structure.
+
+The same JSON object `{ "tisyn": "ref", "name": "x" }` is:
+
+- An **Expr** (Ref node) when encountered by the evaluator or
+  `resolve()` during IR tree traversal
+- A **Val** (opaque data) when returned by `lookup()`, returned
+  by `eval()`, received from an agent, or loaded from the journal
+
+Implementations MUST NOT inspect `tisyn` fields to determine
+whether a value is "really" an IR node. The origin determines
+classification.
+
+| Origin | Classification |
+|--------|---------------|
+| Node in IR tree being walked | Expr |
+| Result of `lookup(name, E)` | Val |
+| Result of `eval(expr, E)` (except Rule QUOTE) | Val |
+| Agent response `result.value` | Val |
+| Journal `result.value` | Val |
+
+There is no `is_val` predicate. Implementations do not need a
+function that inspects a value's structure to determine if it is
+a Val. The code paths guarantee it: `lookup` returns Val (by
+environment invariant), `eval` returns Val (by evaluation rules),
+agent responses are Val (by protocol), `resolve` returns Val for
+terminal positions (by the opaque value rule).
+
+### 2.4 Serialization Guarantee
+
+For every Val `v`:
+
+```
+JSON.parse(JSON.stringify(v)) ≡ v
+```
+
+For every Expr `e`:
+
+```
+JSON.parse(JSON.stringify(e)) ≡ e
+```
+
+All IR nodes and all values are JSON round-trip safe.
+
+### 2.5 Prohibited Values
+
+The following MUST NOT appear anywhere in an IR tree or value:
+
+`undefined`, `Infinity`, `-Infinity`, `NaN`, `BigInt`, `Symbol`,
+`Date`, `RegExp`, `Map`, `Set`, `WeakMap`, `WeakSet`,
+`ArrayBuffer`, `TypedArray`, functions (JS), class instances,
+circular references.
+
+---
+
+## 3. Node Definitions
+
+### 3.1 Eval
+
+```json
+{ "tisyn": "eval", "id": "<string>", "data": "<Expr>" }
+```
+
+A computation. `id` names the operation (non-empty string).
+`data` carries the input (any Expr).
+
+### 3.2 Quote
+
+```json
+{ "tisyn": "quote", "expr": "<Expr>" }
+```
+
+A delayed node. Inert until explicitly unquoted.
+
+### 3.3 Ref
+
+```json
+{ "tisyn": "ref", "name": "<string>" }
+```
+
+A reference to a value in the environment (non-empty string).
+
+### 3.4 Fn
+
+```json
+{ "tisyn": "fn", "params": ["<string>", ...], "body": "<Expr>" }
+```
+
+A function value. `params` is an ordered list of non-empty strings
+with no duplicates. `body` is any Expr. No captured environment.
+
+A `Fn` node is a value — it does not execute when encountered.
+It becomes executable only via `call`.
+
+### 3.5 Literal
+
+Any JSON value that either lacks a `tisyn` field or has a `tisyn`
+field not equal to `"eval"`, `"quote"`, `"ref"`, or `"fn"`.
+
+### 3.6 Grammar
+
+```
+Expr     = Literal | Eval | Quote | Ref | Fn
+Literal  = <JSON value not matching Eval | Quote | Ref | Fn>
+Eval     = { "tisyn": "eval", "id": string, "data": Expr }
+Quote    = { "tisyn": "quote", "expr": Expr }
+Ref      = { "tisyn": "ref", "name": string }
+Fn       = { "tisyn": "fn", "params": string[], "body": Expr }
+```
+
+The grammar is closed. No extensions without new discriminant
+values.
+
+### 3.7 Discriminant Table
+
+| `tisyn` value | Node type | Required fields |
+|---------------|-----------|-----------------|
+| `"eval"` | Eval | `id` (string), `data` (any) |
+| `"quote"` | Quote | `expr` (any) |
+| `"ref"` | Ref | `name` (string) |
+| `"fn"` | Fn | `params` (string[]), `body` (any) |
+| *(absent or other)* | Literal | *(the value itself)* |
+
+---
+
+## 4. Environment
+
+### 4.1 Definition
+
+An environment is an ordered chain of frames:
+
+```
+Env   = (Frame, Env) | ∅
+Frame = { name → Val }     (finite map, string keys, Val values)
+```
+
+### 4.2 Lookup
+
+```
+lookup(name, ∅)             = ERROR UnboundVariable(name)
+lookup(name, (frame, rest)) = frame[name]           if name ∈ frame
+                            = lookup(name, rest)     otherwise
+```
+
+### 4.3 Extension
+
+```
+extend(E, name, val)                  = ({ name → val }, E)
+extend(E, [n₁...nₖ], [v₁...vₖ])     = ({ n₁→v₁, ..., nₖ→vₖ }, E)
+extend(E, [n₁...nₖ], [v₁...vⱼ])     = ERROR ArityMismatch   when k ≠ j
+```
+
+### 4.4 Environment Contains Only Values
+
+No Expr that is not also a Val may appear in an environment
+binding. The evaluator MUST fully evaluate an expression before
+placing its result in the environment.
+
+### 4.5 Environments Do NOT Cross Transport Boundaries
+
+Environments are interpreter-internal state. They are NOT
+serialized, NOT journaled, NOT sent over the wire, and NOT
+shared between host and agent. On crash recovery, the
+environment is reconstructed by replaying the journal.
+
+### 4.6 Shadowing and Immutability
+
+A binding in an inner frame shadows one with the same name in
+an outer frame. There is no mutation operation. Bindings are set
+at frame creation and never change.
+
+---
+
+## 5. Evaluation Model
+
+### 5.1 The `eval` Function
+
+```
+eval : Expr × Env → Val | Error
+```
+
+Evaluation is deterministic: the same expression in the same
+environment always produces the same result.
+
+### 5.2 The `unquote` Operation
+
+```
+unquote(node, E):
+  if node.tisyn = "quote":
+    return node.expr
+  else:
+    return eval(node, E)
+```
+
+`unquote` returns the raw contents of a Quote node without
+evaluating them. The result is an Expr, NOT necessarily a Val.
+`unquote` is used exclusively by structural operations to
+destructure their quoted data.
+
+### 5.3 Evaluation Rules
+
+**Rule LITERAL:**
+
+```
+eval(literal, E) = literal
+```
+
+**Rule REF:**
+
+```
+eval({ tisyn: "ref", name: N }, E) = lookup(N, E)
+```
+
+**Rule QUOTE:**
+
+```
+eval({ tisyn: "quote", expr: X }, E) = X
+```
+
+Returns the contained expression without evaluating it. This is
+the only rule that may return a non-Val. It is used exclusively
+by `unquote` and `resolve`.
+
+**Rule FN:**
+
+```
+eval({ tisyn: "fn", params: P, body: B }, E) =
+  { tisyn: "fn", params: P, body: B }
+```
+
+A Fn node evaluates to itself. No environment is captured.
+
+**Rule EVAL:**
+
+```
+eval({ tisyn: "eval", id: ID, data: D }, E):
+  if classify(ID) = STRUCTURAL → eval_structural(ID, D, E)
+  if classify(ID) = EXTERNAL   → eval_external(ID, D, E)
+```
+
+### 5.4 Truthy and Falsy
+
+```
+truthy(v) = v ∉ { false, null, 0, "" }
+```
+
+All other JSON values (including `[]` and `{}`) are truthy.
+`undefined` does not exist in the IR.
+
+### 5.5 Function Scoping
+
+When a function is called, its body evaluates in the **caller's
+environment** extended with parameter bindings. There is no
+captured environment. This is call-site resolution.
+
+```
+eval(Call { fn, args }, E):
+  F = eval(fn, E)
+  Vs = [eval(a, E) for a in args]
+  E_call = extend(E, F.params, Vs)
+  return eval(F.body, E_call)
+```
+
+Free Refs in the body resolve at the call site. The compiler
+MUST ensure every Fn it produces either has no free variables
+or has all free variables guaranteed in scope at every call site.
+## 6. Structural Operations
+
+Structural operations are `Eval` nodes whose `id` is in the
+structural set. The evaluator handles them locally. They produce
+no journal events and cause no task suspension.
+
+Each operation's `data` is a Quote node containing the operation's
+fields. The evaluator calls `unquote(data, E)` to obtain the raw
+fields, then selectively `eval`s sub-expressions.
+
+### 6.1 let
+
+```json
+{ "tisyn": "eval", "id": "let",
+  "data": { "tisyn": "quote", "expr": {
+    "name": "<string>", "value": "<Expr>", "body": "<Expr>" }}}
+```
+
+```
+eval_structural("let", D, E):
+  { name, value, body } = unquote(D, E)
+  V = eval(value, E)
+  E' = extend(E, name, V)
+  return eval(body, E')
+```
+
+The binding is visible only within `body`. It is not visible in
+`value`. There is no self-reference. Bindings are immutable.
+
+### 6.2 seq
+
+```json
+{ "tisyn": "eval", "id": "seq",
+  "data": { "tisyn": "quote", "expr": {
+    "exprs": ["<Expr>", ...] }}}
+```
+
+```
+eval_structural("seq", D, E):
+  { exprs } = unquote(D, E)
+  result = null
+  for expr in exprs:
+    result = eval(expr, E)
+  return result
+```
+
+Seq does NOT create a new scope. All elements evaluate in the
+same environment. Bindings from `let` inside one element are NOT
+visible in subsequent elements.
+
+### 6.3 if
+
+```json
+{ "tisyn": "eval", "id": "if",
+  "data": { "tisyn": "quote", "expr": {
+    "condition": "<Expr>", "then": "<Expr>",
+    "else": "<Expr | absent>" }}}
+```
+
+```
+eval_structural("if", D, E):
+  { condition, then, else } = unquote(D, E)
+  C = eval(condition, E)
+  if truthy(C): return eval(then, E)
+  if "else" present: return eval(else, E)
+  return null
+```
+
+### 6.4 while
+
+```json
+{ "tisyn": "eval", "id": "while",
+  "data": { "tisyn": "quote", "expr": {
+    "condition": "<Expr>", "exprs": ["<Expr>", ...] }}}
+```
+
+```
+eval_structural("while", D, E):
+  { condition, exprs } = unquote(D, E)
+  result = null
+  loop:
+    C = eval(condition, E)
+    if not truthy(C): return result
+    for expr in exprs:
+      result = eval(expr, E)
+    goto loop
+```
+
+The condition and body expressions are re-evaluated each
+iteration from the unquoted Expr nodes.
+
+### 6.5 call
+
+```json
+{ "tisyn": "eval", "id": "call",
+  "data": { "tisyn": "quote", "expr": {
+    "fn": "<Expr>", "args": ["<Expr>", ...] }}}
+```
+
+```
+eval_structural("call", D, E):
+  { fn, args } = unquote(D, E)
+  F = eval(fn, E)
+  assert F.tisyn = "fn", else ERROR NotCallable(F)
+  Vs = [eval(a, E) for a in args]
+  E' = extend(E, F.params, Vs)
+  return eval(F.body, E')
+```
+
+Arguments are evaluated left-to-right. The body evaluates in the
+caller's environment extended with parameter bindings.
+
+### 6.6 get
+
+```json
+{ "tisyn": "eval", "id": "get",
+  "data": { "tisyn": "quote", "expr": {
+    "obj": "<Expr>", "key": "<string>" }}}
+```
+
+```
+eval_structural("get", D, E):
+  { obj, key } = unquote(D, E)
+  O = eval(obj, E)
+  if O is object and key ∈ O: return O[key]
+  return null
+```
+
+`key` is a string literal, not an expression. It is not evaluated.
+
+### 6.7 Binary Operators
+
+Shape: `data: Q({ a: Expr, b: Expr })`.
+
+**Arithmetic** (`add`, `sub`, `mul`, `div`, `mod`):
+
+```
+eval_structural(op, D, E):
+  { a, b } = unquote(D, E)
+  A = eval(a, E)
+  B = eval(b, E)
+  if typeof A ≠ number: raise TypeError(op + ": left operand")
+  if typeof B ≠ number: raise TypeError(op + ": right operand")
+  if op ∈ {"div","mod"} and B = 0: raise DivisionByZero
+  return apply_binop(op, A, B)
+```
+
+Arithmetic and comparison operators are **numeric-only**. Non-
+numeric operands raise TypeError. String concatenation belongs
+only to `concat`.
+
+**Comparison** (`gt`, `gte`, `lt`, `lte`):
+
+Same as arithmetic: numeric operands only, TypeError otherwise.
+Returns boolean.
+
+**Equality** (`eq`, `neq`):
+
+Accept ANY Val types. Comparison uses canonical encoding:
+
+```
+eq(A, B) = canonical(A) === canonical(B)
+```
+
+Returns boolean.
+
+**Short-circuit** (`and`, `or`):
+
+Accept ANY Val types. Return **operand values**, not booleans:
+
+```
+eval_structural("and", D, E):
+  { a, b } = unquote(D, E)
+  A = eval(a, E)
+  if not truthy(A): return A          // return A, not false
+  return eval(b, E)                   // return B, not true
+
+eval_structural("or", D, E):
+  { a, b } = unquote(D, E)
+  A = eval(a, E)
+  if truthy(A): return A              // return A, not true
+  return eval(b, E)                   // return B, not false
+```
+
+Examples:
+
+```
+And(0, "hello")    → 0        (0 is falsy, returned as-is)
+And("ok", "hello") → "hello"  ("ok" truthy, B returned)
+Or(42, "hello")    → 42       (42 truthy, returned as-is)
+Or(false, null)    → null     (false falsy, B returned)
+```
+
+### 6.8 Unary Operators
+
+Shape: `data: Q({ a: Expr })`.
+
+`not`: Accepts any Val. Always returns boolean.
+
+```
+Not(42)   → false
+Not(0)    → true
+Not(null) → true
+```
+
+`neg`: Numeric only. TypeError on non-number.
+
+### 6.9 Operator Summary
+
+| Operator | Accepts | Returns | Error on |
+|----------|---------|---------|----------|
+| `add`, `sub`, `mul`, `div`, `mod` | number, number | number | Non-number; div/mod by zero |
+| `neg` | number | number | Non-number |
+| `gt`, `gte`, `lt`, `lte` | number, number | boolean | Non-number |
+| `eq`, `neq` | any, any | boolean | (never) |
+| `and`, `or` | any, any | any (operand) | (never) |
+| `not` | any | boolean | (never) |
+| `concat` | any[] | string | (never — coerces to string) |
+
+### 6.10 construct
+
+```json
+{ "tisyn": "eval", "id": "construct",
+  "data": { "tisyn": "quote", "expr": {
+    "<key>": "<Expr>", ... }}}
+```
+
+```
+eval_structural("construct", D, E):
+  fields = unquote(D, E)
+  keys = Object.keys(fields).sort()    // lexicographic order
+  result = {}
+  for key in keys:
+    result[key] = eval(fields[key], E)
+  return result
+```
+
+`construct` MUST evaluate fields in **lexicographic key order**
+(Unicode code point order, ascending). This ensures deterministic
+effect ordering across languages with different object iteration
+behavior.
+
+### 6.11 array
+
+```json
+{ "tisyn": "eval", "id": "array",
+  "data": { "tisyn": "quote", "expr": {
+    "items": ["<Expr>", ...] }}}
+```
+
+Evaluate each item left-to-right. Return the array.
+
+### 6.12 concat
+
+Shape: `data: Q({ parts: [Expr, ...] })`.
+
+Evaluate each part, coerce to string, concatenate, return.
+
+### 6.13 throw
+
+Shape: `data: Q({ message: Expr })`.
+
+```
+eval_structural("throw", D, E):
+  { message } = unquote(D, E)
+  M = eval(message, E)
+  raise Error(M)
+```
+
+---
+
+## 7. External Operations and the Execution Boundary
+
+### 7.1 Classification
+
+Every `Eval.id` is classified by the interpreter:
+
+```
+classify : string → STRUCTURAL | EXTERNAL
+```
+
+The structural set:
+
+```
+STRUCTURAL_IDS = {
+  "let", "seq", "if", "while", "call", "get",
+  "gt", "gte", "lt", "lte", "eq", "neq",
+  "add", "sub", "mul", "div", "mod",
+  "and", "or", "not", "neg",
+  "construct", "array", "concat", "throw"
+}
+
+classify(id) = STRUCTURAL  if id ∈ STRUCTURAL_IDS
+classify(id) = EXTERNAL    otherwise
+```
+
+An interpreter MAY override classification, but overrides MUST be
+declared at initialization and MUST NOT change during execution.
+Classification MUST be identical between the original execution
+and any replay.
+
+### 7.2 Classification Properties
+
+| Property | STRUCTURAL | EXTERNAL |
+|----------|-----------|----------|
+| Evaluated by | Host evaluator | Agent (via execution layer) |
+| Journaled? | No | Yes (Yield event) |
+| Causes suspension? | No | Yes |
+
+### 7.3 The Dot Convention
+
+By convention, external `id` values use dotted notation:
+
+```
+"fraud-detector.fraudCheck"
+ └─── agent id ──┘└── method ──┘
+```
+
+The execution layer splits on the first dot. This is a convention,
+not an IR rule.
+
+### 7.4 Crossing the Boundary
+
+When the evaluator encounters a standard external Eval:
+
+```
+eval_external(ID, D, E):
+  resolved = resolve(D, E)              // Step 1: resolve
+  descriptor = { id: ID, data: resolved }
+  result = YIELD descriptor             // Step 2: suspend
+  return result                         // Step 3: resume
+```
+
+**Step 1 — Resolve.** Call `resolve(D, E)` to produce a fully
+resolved Val. See §9 for the `resolve` algorithm.
+
+**Step 2 — Yield.** Hand the descriptor to the execution layer.
+Task state → SUSPENDED.
+
+**Step 3 — Resume.** Execution layer provides a Val (or Error).
+Task state → RUNNING. Evaluator returns the result.
+
+### 7.5 What Crosses the Boundary
+
+| Direction | Payload | Type |
+|-----------|---------|------|
+| Evaluator → Execution | Effect descriptor | `{ id: string, data: Val }` |
+| Execution → Evaluator | Success result | Val |
+| Execution → Evaluator | Error result | Error |
+| Execution → Evaluator | Cancellation | Signal |
+
+The execution layer NEVER receives unevaluated IR nodes for
+standard external operations. Exception: concurrency nodes (§8).
+
+---
+
+## 8. Concurrency Semantics
+
+### 8.1 The IR Has No Concurrency
+
+The IR is a sequential expression language. There are no fork,
+join, spawn, or parallel primitives. Concurrency is introduced
+by the execution layer's interpretation of specific external
+`Eval.id` values.
+
+### 8.2 Compound External Operations
+
+The compound external operation set is:
+
+```
+COMPOUND_EXTERNAL_IDS = { "all", "race" }
+```
+
+These operations carry arrays of unevaluated child Expr nodes
+that the execution layer evaluates in separate tasks.
+
+For compound external operations, `eval_external` uses `unquote`
+instead of `resolve`, preserving child expressions:
+
+```
+eval_external(ID, D, E):
+  if ID ∈ COMPOUND_EXTERNAL_IDS:
+    inner = unquote(D, E)
+    descriptor = { id: ID, data: inner }
+    result = YIELD descriptor
+    return result
+
+  if ID = "spawn":
+    inner = unquote(D, E)
+    descriptor = { id: ID, data: inner }
+    result = YIELD descriptor
+    return result
+
+  // Standard external
+  resolved = resolve(D, E)
+  descriptor = { id: ID, data: resolved }
+  result = YIELD descriptor
+  return result
+```
+
+`resolve()` MUST NOT evaluate or traverse into child expression
+arrays of concurrency operations.
+
+### 8.3 all
+
+```json
+{ "tisyn": "eval", "id": "all",
+  "data": { "tisyn": "quote", "expr": {
+    "exprs": ["<Expr>", ...] }}}
+```
+
+**Execution-layer semantics:**
+
+1. For each expr in `exprs`, create a child task with the
+   parent's environment.
+2. Children run concurrently.
+3. Parent task is SUSPENDED until all complete.
+4. Results returned in `exprs` order (not completion order).
+5. If any child fails: remaining children cancelled, error
+   propagates to parent.
+6. If parent cancelled: all children cancelled.
+
+Empty `exprs` → return `[]` immediately.
+
+### 8.4 race
+
+Same shape as `all`. Execution-layer semantics:
+
+1. First child to complete successfully wins.
+2. All other children cancelled.
+3. If a child fails, it does NOT win — race continues with
+   remaining children.
+4. If ALL children fail, the last error propagates.
+5. Return value is the winner's result (not an array).
+
+One child → equivalent to evaluating the child directly.
+
+### 8.5 Cancellation Propagation
+
+Cancellation propagates downward in reverse creation order:
+
+```
+cancel(task):
+  if task is terminal: return
+  task.cancelling = true                 // point of no return
+  for child in task.children.reverse():
+    cancel(child)
+  task.evaluator.return()
+  write Close(cancelled)
+  task → CANCELLED
+```
+
+**Point-of-no-return.** Once `task.cancelling` is `true`, any
+agent result received for that task's pending effect is discarded.
+No Yield event is written. Cancellation is irrevocable.
+
+**Structured concurrency invariants** (enforced by execution
+layer):
+
+1. Every child task has exactly one parent.
+2. No child outlives its parent.
+3. Cancelling a parent cancels all descendants.
+4. A scope exits only after all children terminate.
+
+### 8.6 Task Identity
+
+Task IDs MUST match `^root(\.\d+)*$`.
+
+```
+root task:            "root"
+child N of parent P:  P + "." + N
+```
+
+N is a non-negative integer, incrementing per parent from 0.
+Task IDs are generated exclusively by this scheme — not user-
+chosen, not configurable, not random.
+
+**Correlation IDs:** `"{taskId}:{yieldIndex}"`. Since taskIds
+never contain colons, the separator is unambiguous.
+
+---
+
+## 9. The `resolve` Function
+
+### 9.1 Purpose
+
+`resolve(data, E)` produces a fully resolved Val from an Expr,
+recursively entering arrays and objects to resolve any nested
+Expr nodes. It is used exclusively at the external effect
+boundary (§7.4 Step 1) for standard (non-compound) operations.
+
+### 9.2 The Opaque Value Rule
+
+> `resolve()` MUST NOT recurse into any value returned by
+> `lookup()` or `eval()`. Such values are **terminal** — they
+> are returned without inspection, traversal, or re-evaluation,
+> regardless of their structure. Implementations MUST NOT
+> re-interpret or re-evaluate such values.
+
+This holds even if the returned value contains a `tisyn` field,
+structurally matches an IR node, or contains nested objects
+resembling IR expressions.
+
+### 9.3 Algorithm
+
+```
+resolve(node, E):
+
+  // ── TERMINAL: values from lookup/eval are opaque ──
+
+  if node.tisyn = "ref":
+    return lookup(node.name, E)          // TERMINAL
+
+  if node.tisyn = "eval":
+    return eval(node, E)                 // TERMINAL
+
+  if node.tisyn = "fn":
+    return node                          // TERMINAL
+
+  // ── UNWRAP: Quote removes one layer ──
+
+  if node.tisyn = "quote":
+    return resolve(node.expr, E)
+
+  // ── TRAVERSABLE: plain arrays and objects ──
+
+  if node is array:
+    return [resolve(item, E) for item in node]
+
+  if node is object:
+    result = {}
+    for (key, child) in node:
+      result[key] = resolve(child, E)
+    return result
+
+  // ── TERMINAL: primitives ──
+
+  return node
+```
+
+### 9.4 Categories
+
+| Category | Behavior | Examples |
+|----------|----------|---------|
+| **Terminal** | Return as-is. No traversal. | Results of `lookup`, `eval`; Fn nodes; primitives |
+| **Unwrap** | Remove Quote layer, resolve contents. | Quote nodes |
+| **Traversable** | Recurse into children. | Plain arrays; objects without matching `tisyn` |
+
+Only plain arrays and objects without a matching `tisyn`
+discriminant are traversable.
+
+### 9.5 Postcondition
+
+After `resolve(data, E)`, the result contains no `Ref`, `Eval`,
+or `Quote` nodes. Only Val (primitives, arrays, objects, Fn).
+
+### 9.6 Enforcement Criterion
+
+An implementation satisfies the opaque value rule if and only if:
+replacing every value in every environment binding with a sentinel
+does not change the output of `resolve()` beyond the expected
+sentinel substitutions at terminal positions.
+
+---
+
+## 10. Validation Rules
+
+### 10.1 Node Classification
+
+Classification is determined by the `tisyn` field alone:
+
+```
+classify_node(value):
+  if value is not an object: → Literal
+  if value has no "tisyn" field: → Literal
+  if value.tisyn = "eval":  → Eval (check required fields)
+  if value.tisyn = "quote": → Quote (check required fields)
+  if value.tisyn = "ref":   → Ref (check required fields)
+  if value.tisyn = "fn":    → Fn (check required fields)
+  otherwise:                → Literal
+```
+
+### 10.2 Malformed Node Rule
+
+If a node has a `tisyn` field matching a discriminant but is
+missing any required field or has a required field of the wrong
+type, the node is **malformed**. Malformed nodes are errors.
+They are NEVER treated as Literals.
+
+### 10.3 Fn Param Validation
+
+`params` must be an array of non-empty strings with no duplicates.
+
+### 10.4 Single-Quote Validation Rule
+
+For every structural Eval node `{ tisyn: "eval", id: ID, data: D }`
+where `classify(ID) = STRUCTURAL`:
+
+1. `D` MUST be a Quote node. If not → malformed.
+2. Let `fields = D.expr`.
+3. Let `P = positions(ID, fields)`.
+4. For every node `N` in `P`: if `N.tisyn = "quote"` →
+   **malformed**.
+
+### 10.5 The `positions` Function
+
+`positions(id, fields)` returns the set of nodes that the
+structural operation will `eval()` on:
+
+| Operation | `fields` shape | Evaluation positions |
+|-----------|---------------|---------------------|
+| `let` | `{ name, value, body }` | `value`, `body` |
+| `seq` | `{ exprs: [...] }` | each element of `exprs` |
+| `if` | `{ condition, then, else? }` | `condition`, `then`, `else` (if present) |
+| `while` | `{ condition, exprs: [...] }` | `condition`, each element of `exprs` |
+| `call` | `{ fn, args: [...] }` | `fn`, each element of `args` |
+| `get` | `{ obj, key }` | `obj` only |
+| binary ops | `{ a, b }` | `a`, `b` |
+| unary ops | `{ a }` | `a` |
+| `construct` | `{ k₁: v₁, ... }` | each value |
+| `array` | `{ items: [...] }` | each element of `items` |
+| `concat` | `{ parts: [...] }` | each element of `parts` |
+| `throw` | `{ message }` | `message` |
+
+This table is exhaustive. The check is one level deep — it
+examines only nodes at evaluation positions, not their children.
+
+**Non-positions** (not checked): `let.name`, `get.key`, the
+`fields` object itself, absent `if.else`.
+
+### 10.6 When Validation Occurs
+
+Implementations MUST validate when: parsing IR from JSON,
+receiving IR over the wire, loading IR from storage. Implementations
+MAY additionally validate during evaluation.
+## 11. Runtime Model
+
+### 11.1 Components
+
+```
+Runtime
+├── Evaluator         — walks IR tree, applies evaluation rules
+├── Task Tree         — parent/child task relationships
+├── Durable Stream    — append-only journal of Yield/Close events
+├── Replay Index      — per-coroutine cursor over stored events
+├── Agent Router      — maps effect type to agent connection
+└── Transport Pool    — manages connections to agents
+```
+
+### 11.2 Task Lifecycle
+
+A task has exactly one state at any instant:
+
+```
+CREATED → RUNNING ⇄ SUSPENDED → COMPLETED
+                                → FAILED
+         (any non-terminal)     → CANCELLED
+```
+
+Terminal states: COMPLETED, FAILED, CANCELLED.
+
+| From | To | Trigger | Journal |
+|------|----|---------|---------|
+| CREATED | RUNNING | Start | (none) |
+| RUNNING | SUSPENDED | External Eval | (none) |
+| SUSPENDED | RUNNING | Result received | Yield (before resume) |
+| RUNNING | COMPLETED | Body returns | Close(ok) |
+| RUNNING | FAILED | Unhandled error | Close(err) |
+| SUSPENDED | FAILED | Effect error | Yield(err), Close(err) |
+| * | CANCELLED | Cancel signal | Close(cancelled) |
+
+**Critical:** SUSPENDED → RUNNING writes the Yield event and
+awaits durable acknowledgment BEFORE calling `generator.next()`.
+This is the persist-before-resume invariant.
+
+### 11.3 Continuation Model
+
+Continuations are NOT serialized. There is no reified continuation
+object. The JavaScript generator is suspended at a `yield`
+statement — an opaque V8 heap object.
+
+**Crash recovery:** Replay the journal into a fresh generator.
+Same tree + same stored results → same branches → same state.
+
+**Replay is synchronous.** Every stored effect resolves
+synchronously inside `DurableEffect.enter()`. A workflow with
+1000 Yield events replays in one tick.
+
+### 11.4 Replay Index
+
+```
+ReplayIndex:
+  yields:  Map<CoroutineId, Array<{ description, result }>>
+  cursors: Map<CoroutineId, number>
+  closes:  Map<CoroutineId, CloseEvent>
+```
+
+**Matching algorithm** when the evaluator yields descriptor `D`
+for `coroutineId`:
+
+```
+match(coroutineId, D):
+  entry = peekYield(coroutineId)
+
+  CASE 1: entry exists
+    if D.type ≠ entry.description.type → DIVERGENCE
+    if D.name ≠ entry.description.name → DIVERGENCE
+    consumeYield(coroutineId)
+    return entry.result                    // REPLAY
+
+  CASE 2: entry absent, close exists     → DIVERGENCE
+
+  CASE 3: entry absent, no close         → LIVE (dispatch)
+```
+
+Description matching compares only `type` and `name`.
+Divergence is fatal — execution halts.
+
+### 11.5 Durable Events
+
+Two event types:
+
+**Yield:**
+
+```json
+{
+  "type": "yield",
+  "coroutineId": "root.0",
+  "description": { "type": "fraud-detector", "name": "fraudCheck" },
+  "result": { "status": "ok", "value": true }
+}
+```
+
+**Close:**
+
+```json
+{
+  "type": "close",
+  "coroutineId": "root.0",
+  "result": { "status": "ok", "value": { "receiptId": "r-456" } }
+}
+```
+
+**Event result types:**
+
+```
+EventResult =
+  | { status: "ok", value?: Val }
+  | { status: "err", error: { message: string, name?: string } }
+  | { status: "cancelled" }
+```
+
+**Ordering guarantees:**
+
+1. Events within a stream are totally ordered.
+2. A child's Close precedes the parent's Yield consuming it.
+3. Yields for a coroutine appear in yield order.
+4. Close appears after all Yields for that coroutine.
+5. Parent's Close appears after all children's Closes.
+
+### 11.6 Durability Guarantees
+
+**G1.** Acknowledged events persist across crashes.
+**G2.** Unacknowledged events may not persist.
+**G3.** Persist-before-resume: Yield MUST be ack'd before
+generator resumes.
+**G4.** Close-after-children: parent's Close after all children's.
+**G5.** Causal ordering in the stream.
+**G6.** Single writer: epoch fencing prevents split-brain.
+
+Durability does NOT guarantee exactly-once effect execution.
+Effects may execute zero times (replay) or more than once
+(crash + re-dispatch). Agents must handle at-least-once delivery.
+
+### 11.7 Resource and Cleanup Semantics
+
+Cleanup effects (in `finally` blocks during scope destruction)
+continue the same yield index sequence as normal effects. The
+yield index is NOT reset. Cleanup effects use the same
+correlation ID scheme.
+
+```
+Task root.0:
+  [0] yield agent.acquire ok            (id: "root.0:0")
+  [1] yield agent.riskyOp err "boom"    (id: "root.0:1")
+  [2] yield agent.release ok            (cleanup, id: "root.0:2")
+  [3] close root.0 err "boom"
+```
+
+The ReplayIndex does not distinguish cleanup effects from normal
+effects.
+
+Cleanup effects during cancellation are best-effort. If they
+complete before the parent's teardown, they are journaled.
+
+---
+
+## 12. Wire Protocol
+
+### 12.1 Transport Independence
+
+Messages are JSON objects conforming to JSON-RPC 2.0. The
+protocol does not prescribe a transport. Supported bindings:
+WebSocket, stdio (NDJSON), SSE + POST, in-process.
+
+### 12.2 Message Catalog
+
+Six message types. No others.
+
+| Message | Direction | JSON-RPC Type | Response? |
+|---------|-----------|--------------|-----------|
+| Initialize | Agent → Host | Request | Yes |
+| Execute | Host → Agent | Request | Yes |
+| Result | Agent → Host | Response | *(is response)* |
+| Progress | Agent → Host | Notification | No |
+| Cancel | Host → Agent | Notification | No |
+| Shutdown | Host → Agent | Notification | No |
+
+### 12.3 Initialize
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": {
+    "protocolVersion": "1.0",
+    "agentId": "fraud-detector",
+    "capabilities": {
+      "methods": ["fraudCheck", "riskScore"],
+      "progress": true,
+      "concurrency": 10
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{ "jsonrpc": "2.0", "id": 1,
+  "result": { "protocolVersion": "1.0", "sessionId": "sess-123" } }
+```
+
+Initialize MUST be the first message. No Execute before it
+completes. Incompatible version → error `-32002`, close.
+
+### 12.4 Execute
+
+```json
+{
+  "jsonrpc": "2.0", "id": "root.0:2", "method": "execute",
+  "params": {
+    "executionId": "ex-abc-123",
+    "taskId": "root.0",
+    "operation": "fraudCheck",
+    "args": [{ "id": "order-123", "total": 150 }],
+    "progressToken": "root.0:2",
+    "deadline": "2026-03-19T12:05:00Z"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Correlation: `"{taskId}:{yieldIndex}"` |
+| `executionId` | string | Yes | Workflow execution instance |
+| `taskId` | string | Yes | Coroutine ID |
+| `operation` | string | Yes | Method name |
+| `args` | Val[] | Yes | Resolved arguments |
+| `progressToken` | string | No | For progress notifications |
+| `deadline` | string | No | ISO 8601 absolute deadline |
+
+### 12.5 Result
+
+**Success:**
+
+```json
+{ "jsonrpc": "2.0", "id": "root.0:2",
+  "result": { "ok": true, "value": true } }
+```
+
+**Application error:**
+
+```json
+{ "jsonrpc": "2.0", "id": "root.0:2",
+  "result": { "ok": false, "error": { "message": "unavailable", "name": "ServiceError" } } }
+```
+
+**Protocol error:**
+
+```json
+{ "jsonrpc": "2.0", "id": "root.0:2",
+  "error": { "code": -32601, "message": "Method not found" } }
+```
+
+Application errors (`result.ok: false`) are journaled as
+Yield(err). Protocol errors (JSON-RPC `error`) are NOT
+journaled.
+
+### 12.6 Progress
+
+```json
+{ "jsonrpc": "2.0", "method": "progress",
+  "params": { "token": "root.0:2", "value": { "phase": "analyzing", "percent": 45 } } }
+```
+
+NOT journaled. NOT replayed. Best-effort. Ordered per-token.
+Discarded for unknown or expired tokens.
+
+### 12.7 Cancel
+
+```json
+{ "jsonrpc": "2.0", "method": "cancel",
+  "params": { "id": "root.0:2", "reason": "parent_cancelled" } }
+```
+
+Best-effort. No response expected. The host does not wait for
+acknowledgment.
+
+### 12.8 Shutdown
+
+```json
+{ "jsonrpc": "2.0", "method": "shutdown", "params": {} }
+```
+
+Agent should complete or cancel in-flight operations, then close.
+
+### 12.9 Connection Lifecycle
+
+```
+Agent connects → Initialize → Ready → Execute/Cancel/Progress → Shutdown → Close
+```
+
+Multiple Execute requests may be in-flight simultaneously up to
+the agent's declared `concurrency` limit. Results may arrive in
+any order.
+
+### 12.10 Reconnection
+
+A transport reconnection is a **fresh session**. There is no
+protocol-level session resumption.
+
+1. Connection drops.
+2. Host marks pending effects as UNRESOLVED.
+3. Agent reconnects, sends Initialize.
+4. Host re-dispatches UNRESOLVED effects (same correlation IDs).
+
+Re-dispatch may cause duplicate execution. Agents must handle
+at-least-once delivery.
+
+---
+
+## 13. Determinism Guarantees
+
+### 13.1 The Determinism Theorem
+
+For a given expression tree `T`, initial environment `E₀`,
+effect result sequence `R`, and classification function `C`:
+
+Evaluation produces a unique sequence of effect descriptors, a
+unique final value, and a unique task tree.
+
+### 13.2 What Must Be Deterministic
+
+| Requirement | Guaranteed by |
+|-------------|---------------|
+| Structural operations | All rules are pure functions |
+| Effect ordering | Single-threaded within a task |
+| Branching decisions | Same results → same conditions |
+| Task spawn ordering | Synchronous reducer, priority queue |
+| Construct field order | Lexicographic key sorting |
+
+### 13.3 What Is Non-Deterministic
+
+| Component | How handled |
+|-----------|-------------|
+| Effect result values | Journal stores results |
+| Wall-clock timing | Time is an effect |
+| Concurrent child completion order | Per-coroutine cursors |
+
+### 13.4 Structural Determinism
+
+The IR provides determinism structurally — no `Math.random()`,
+no `Date.now()`, no `Map` iteration, no `for...in`, no `Symbol`,
+no async scheduling. All non-determinism is confined to external
+effects, captured by the journal.
+
+### 13.5 Canonical JSON Encoding
+
+The canonical encoding of a JSON value uses lexicographic key
+sorting at every nesting level:
+
+```
+canonical(value):
+  if primitive: JSON.stringify(value)
+  if array: "[" + join([canonical(item)], ",") + "]"
+  if object:
+    keys = Object.keys(value).sort()
+    pairs = ['"' + key + '":' + canonical(value[key]) for key in keys]
+    return "{" + join(pairs, ",") + "}"
+```
+
+Properties: no whitespace, keys sorted lexicographically,
+numbers in shortest round-trip form, strings per RFC 8259 §7.
+
+Used for byte-equal comparison, hashing, interoperability
+testing. Wire messages and journal storage MAY use non-canonical
+encoding.
+
+All implementations MUST use IEEE 754 binary64 for numeric
+computation and JSON number parsing.
+
+---
+
+## 14. Error Semantics
+
+### 14.1 Errors Are Exceptions, Not Values
+
+The IR has no `Result<T, E>` wrapper. Evaluation either returns
+a Val or raises an Error. The `{ ok, value, error }` shape exists
+only on the wire and in journal events. The execution layer
+translates between representations.
+
+### 14.2 Error Types
+
+| Type | Cause |
+|------|-------|
+| UnboundVariable | Ref resolution failed |
+| NotCallable | Call on non-Fn value |
+| ArityMismatch | Wrong argument count |
+| TypeError | Invalid operand type |
+| DivisionByZero | div/mod by zero |
+| ExplicitThrow | throw node evaluated |
+| EffectError | Agent returned error |
+| DivergenceError | Replay mismatch |
+| MalformedIR | Invalid IR structure |
+
+### 14.3 Propagation Rules
+
+When a sub-expression errors, the enclosing operation stops and
+propagates. No further sub-expressions are evaluated.
+
+**let:** Error in `value` → propagate (body not evaluated).
+Error in `body` → propagate.
+
+**seq:** First error stops the sequence.
+
+**if:** Error in `condition` → propagate (no branch evaluated).
+Error in selected branch → propagate.
+
+**while:** Error in condition or body → propagate, loop ends.
+
+**call:** Error in fn → propagate. Error in any arg → propagate
+(remaining args skipped, left-to-right). Error in body → propagate.
+
+**Binary ops (non-short-circuit):** Error in left → propagate
+(right not evaluated). Left evaluated first.
+
+**Short-circuit:** `and`: if `a` errors → propagate. If `a`
+falsy → return A (no error, b not evaluated). Otherwise evaluate
+`b` normally.
+
+### 14.4 Propagation at the Execution Boundary
+
+When an error reaches the top of a task's expression tree:
+
+1. Execution layer catches it.
+2. Close(err) written.
+3. Task → FAILED.
+4. Parent notified per structured concurrency rules.
+
+### 14.5 Effect Errors
+
+Agent returns `{ ok: false, error }`:
+
+1. Yield(err) written, ack'd.
+2. `generator.throw(error)` called.
+3. If caught at generator level → task continues.
+4. If uncaught → propagates to task boundary.
+
+On replay, same error re-raised from journal.
+
+### 14.6 Cancellation Is Not an Error
+
+Cancellation propagates downward, not upward. It is a distinct
+signal: `generator.return()`, not `generator.throw()`. A parent's
+`catch` does NOT catch cancellation.
+
+### 14.7 No Try/Catch in the IR
+
+The IR has no error-handling construct. Error handling is at the
+generator level using JavaScript `try/catch`. A future `try`
+structural operation is deferred until journal interaction
+semantics are resolved.
+
+---
+
+## 15. Agent Abstraction
+
+### 15.1 Definition
+
+`Agent()` is an authoring-layer factory. It produces IR `Eval`
+nodes at call sites and provides generator implementations to
+the agent runtime.
+
+```typescript
+const FraudDetector = Agent("fraud-detector", {
+  *fraudCheck(order: Order): Operation<boolean> { ... },
+});
+```
+
+### 15.2 Dual Nature
+
+**Host:** `FraudDetector().fraudCheck(order)` produces an IR Eval
+node wrapped in a Workflow generator via `durableCall`.
+
+**Agent:** Runtime looks up `operations["fraudCheck"]`, runs the
+generator, returns the result.
+
+### 15.3 Method Identity
+
+Methods are identified by `(agentId, methodName)`. In the IR:
+`Eval.id = agentId + "." + methodName`. On the wire: agent
+identity from Initialize, method name in Execute's `operation`.
+
+Agent IDs: `[a-z][a-z0-9-]*`. Method names: `[a-zA-Z][a-zA-Z0-9]*`.
+Neither may contain dots.
+
+### 15.4 Method Resolution
+
+**On the host:** Parse `Eval.id` → agentId + methodName. Look up
+agent connection. Verify method in declared capabilities. Send
+Execute.
+
+**On the agent:** Look up `operation` in registry. Run generator.
+Return result.
+
+### 15.5 Invariants
+
+1. Arguments: JSON-serializable.
+2. Return values: JSON-serializable.
+3. One Yield per method call (durability boundary).
+4. Agent crash → full re-dispatch (retry boundary).
+5. One definition, two roles.
+
+---
+
+## 16. Compiler Guarantees
+
+### 16.1 Three Levels
+
+**Level 1 — Structural validity.** Output conforms to the grammar
+and passes all validation rules. Always guaranteed.
+
+**Level 2 — Scope consistency.** Every Ref is bound by an
+enclosing Let or Fn. Always guaranteed.
+
+**Level 3 — Journal equivalence.** For all result sequences R:
+
+```
+journal(interpret(compile(G), R)) = journal(run(G, R))
+```
+
+Guaranteed for source within the authoring subset.
+
+### 16.2 Journal Equality
+
+Two journals are equal iff they have the same events in the same
+order, where event equality compares: `type`, `coroutineId`,
+`description.type`, `description.name`, `result.status`,
+`result.value` (deep), `result.error.message`.
+
+### 16.3 Allowed vs Disallowed Differences
+
+**Allowed:** Variable names, control flow restructuring, expression
+decomposition.
+
+**Disallowed:** Effect ordering, effect descriptions, branching
+behavior, task structure, final result.
+
+### 16.4 Compilation Determinism
+
+Same source → byte-identical output. No random IDs, no timestamps.
+
+### 16.5 Free Variable Constraint
+
+For every Fn produced, either the body has no free variables
+(via substitution) or all free variables are guaranteed in scope
+at every call site. The compiler MUST emit a diagnostic otherwise.
+
+---
+
+## 17. Observability
+
+### 17.1 Two Surfaces
+
+**Durable:** The journal. Every Yield and Close event. Read via
+catch-up-then-tail.
+
+**Ephemeral:** Progress notifications. Forwarded from agents.
+Not journaled. May be lost.
+
+### 17.2 What Observers See
+
+| Event | When | Contains |
+|-------|------|----------|
+| Yield | Effect completed | Agent, method, result |
+| Close(ok) | Task completed | Final value |
+| Close(err) | Task failed | Error |
+| Close(cancelled) | Task cancelled | — |
+| Progress | During effect | Agent-defined payload |
+
+Observers do NOT see structural operations, environment bindings,
+internal control flow, or replay/live distinction.
+
+---
+
+## 18. Protocol Versioning
+
+Three independent version axes:
+
+| Thing | What changes | Versioned by |
+|-------|-------------|-------------|
+| IR grammar | New node types | IR version |
+| Structural operations | New ids in set | Interpreter version |
+| Wire protocol | Message changes | Protocol version |
+
+Classification changes are breaking. In-flight executions must
+complete on the old interpreter version before upgrading.
+
+---
+
+## Appendix A: Authoring Layer Types
+
+```typescript
+type Expr<T> = T | Eval<T> | Quote<T> | Ref<T> | TisynFn<T>;
+
+interface Eval<T, TInput = unknown> {
+  tisyn: "eval"; id: string; data: TInput; T?: T;
+}
+interface Quote<T> { tisyn: "quote"; expr: Expr<T>; }
+interface Ref<T> { tisyn: "ref"; name: string; T?: T; }
+interface TisynFn<T> { tisyn: "fn"; params: string[]; body: Expr<T>; }
+
+type AgentOperations = Record<string, (...args: any[]) => Operation<any>>;
+interface AgentDefinition<T extends AgentOperations> {
+  id: string; operations: T; create(): AgentClient<T>;
+}
+type AgentClient<T extends AgentOperations> = {
+  [K in keyof T]: T[K] extends (...a: infer A) => Operation<infer R>
+    ? (...a: A) => Workflow<R> : never;
+};
+```
+
+Phantom fields (`T?`) are stripped by `JSON.stringify`.
+
+---
+
+## Appendix B: Wire Protocol Types
+
+```typescript
+interface ExecuteRequest {
+  jsonrpc: "2.0"; id: string; method: "execute";
+  params: {
+    executionId: string; taskId: string;
+    operation: string; args: Json[];
+    progressToken?: string; deadline?: string;
+  };
+}
+
+interface ExecuteResponse {
+  jsonrpc: "2.0"; id: string;
+  result: { ok: boolean; value?: Json;
+            error?: { message: string; name?: string } };
+}
+
+interface CancelNotification {
+  jsonrpc: "2.0"; method: "cancel";
+  params: { id: string; reason?: string };
+}
+
+interface ProgressNotification {
+  jsonrpc: "2.0"; method: "progress";
+  params: { token: string; value: Json };
+}
+```
+
+---
+
+## Appendix C: Journal Event Types
+
+```typescript
+type DurableEvent = YieldEvent | CloseEvent;
+
+interface YieldEvent {
+  type: "yield"; coroutineId: string;
+  description: { type: string; name: string };
+  result: EventResult;
+}
+
+interface CloseEvent {
+  type: "close"; coroutineId: string;
+  result: EventResult;
+}
+
+type EventResult =
+  | { status: "ok"; value?: Json }
+  | { status: "err"; error: { message: string; name?: string } }
+  | { status: "cancelled" };
+```
+
+---
+
+## Appendix D: End-to-End Example
+
+### D.1 Workflow
+
+```typescript
+function* orderWorkflow(orderId: string): Workflow<Receipt> {
+  const order = yield* OrderService().fetchOrder(orderId);
+  if (order.total > 100) {
+    const passed = yield* FraudDetector().fraudCheck(order);
+    if (!passed) throw new Error("Fraud detected");
+  }
+  return yield* PaymentService().chargeCard(order.payment);
+}
+```
+
+### D.2 Execution Trace
+
+```
+Step  Action                              State    Journal
+────  ──────                              ─────    ───────
+ 1    eval Let(order, fetchOrder(...))     RUNNING
+ 2    resolve args: [Ref(orderId)] → ["order-123"]
+ 3    yield fetchOrder descriptor          SUSPENDED
+ 4    Agent A returns {id,total:150,payment}         Execute→A
+ 5    Yield written                                  [0] yield fetchOrder ok
+ 6    generator.next(order)                RUNNING
+ 7    eval Gt(Get(order,"total"), 100) → true
+ 8    eval Let(passed, fraudCheck(...))
+ 9    resolve args: [Ref(order)] → [{id,total,payment}]
+10    yield fraudCheck descriptor           SUSPENDED
+11    Agent B returns true                            Execute→B
+12    Yield written                                  [1] yield fraudCheck ok
+13    generator.next(true)                 RUNNING
+14    eval Not(true) → false → skip throw
+15    resolve args: [Get(order,"payment")] → [{card:"visa"}]
+16    yield chargeCard descriptor           SUSPENDED
+
+     ████ HOST CRASHES ████
+
+17    New host reads journal ([0],[1])
+18    Build ReplayIndex: root cursor=0
+19    Fresh generator, eval tree
+20    reach fetchOrder → index[0] MATCH → feed stored result   REPLAY
+21    reach fraudCheck → index[1] MATCH → feed stored result   REPLAY
+22    reach chargeCard → no entry → LIVE
+23    yield chargeCard descriptor           SUSPENDED  Execute→C
+24    Agent C returns {receiptId:"r-789"}
+25    Yield written                                  [2] yield chargeCard ok
+26    generator.next({receiptId})           RUNNING
+27    workflow returns                      COMPLETED [3] close root ok
+```
+
+### D.3 Final Journal
+
+```
+[0] yield root order-service.fetchOrder  ok {id:"123",total:150,payment:{card:"visa"}}
+[1] yield root fraud-detector.fraudCheck ok true
+[2] yield root payment-service.chargeCard ok {receiptId:"r-789"}
+[3] close root ok {receiptId:"r-789"}
+```
+
+### D.4 Interoperability Test
+
+Two implementations are compatible if, given the same IR tree,
+the same agent results, and the same classification, they produce
+the same journal (byte-equal after canonical encoding) and the
+same final result.


### PR DESCRIPTION
Moved to here https://github.com/cowboyd/tisyn/pull/1

## Motivation

Modern distributed systems scatter workflow logic across retry loops, message queues, saga compensations, and state machines. Each approach solves part of the crash-recovery problem but forces developers to write infrastructure alongside business logic. The core insight behind Tisyn is that if you can replay a computation from a log of its external interactions, you don't need to serialize its internal state — you need two properties: **determinism** and **effect isolation**.

Tisyn addresses this by compiling developer-written TypeScript generator functions into an immutable JSON intermediate representation (IR), evaluating that IR in a kernel that yields effect descriptors to remote agents, and recording every effect result in an append-only journal. On crash, a fresh kernel replays the journal to reconstruct execution state without re-executing side effects. The developer never sees the IR, the journal, or the replay mechanism.

This PR adds the complete specification suite that defines how every layer of this system works — from IR grammar to wire protocol to conformance testing.

## Approach

The specifications are organized in `specs/` and cover six concerns:

| Document | What it defines |
|----------|----------------|
| **tisyn-specification-1.0.md** | The system specification: five IR node types, evaluation rules, environment model, structural and external operations, concurrency semantics (`all`/`race`), the `resolve` function and its opaque value rule, validation, runtime lifecycle, JSON-RPC 2.0 wire protocol, determinism guarantees, error semantics, and the agent abstraction |
| **tisyn-architecture.md** | Architecture and design rationale: the compilation-to-evaluation pipeline, end-to-end execution flow, why workflows are data (not code), journaling with persist-before-resume (write-ahead logging for effects), deterministic replay, structured concurrency, the agent model, error/cancellation propagation, transport independence, and comparison to Temporal/Restate/Azure Durable Functions |
| **tisyn-kernel-specification.md** | Kernel specification: the `eval` function's three-outcome signature (`Val | Error | Suspend`), environment as immutable linked-list frames, `resolve` vs `unquote` data preparation, all 18 structural operations, Quote semantics and the single-Quote invariant, concurrency model with per-coroutine journals, replay algorithm with positional cursor matching, and the determinism theorem |
| **tisyn-compiler-specification-1.1.0.md** | Compiler specification: the restricted TypeScript authoring subset, three `yield*` desugaring cases (agent effects, concurrency, built-ins), block-to-Let transformation, while-with-return compiled as recursive Fn + Call via call-site resolution, expression compilation rules, and the unsupported construct catalog |
| **tisyn-agent-specification-1.1.0.md** | Agent implementation specification: the execution contract (exactly one Result per Execute), correlation ID stability for deduplication, three idempotency strategies, best-effort cancellation, concurrency limits, application vs protocol error distinction, serialization constraints, reconnection as fresh session, and progress reporting |
| **tisyn-conformance-suite.md** | Conformance test suite: four conformance levels (IR, Compiler, Kernel, Agent), fixture schemas for seven test types, the replay algorithm with exhaustive divergence conditions, deterministic scheduling order for concurrent tests, canonical JSON encoding rules, journal comparison modes, and complete Core fixtures with expected outputs |

The three hard boundaries between layers — Compiler to Kernel (JSON IR), Kernel to Execution Layer (effect descriptors), Execution Layer to Agent (JSON-RPC 2.0) — are defined precisely enough that independent implementations can interoperate: same IR + same effect results = byte-identical journals.