### PR TITLE
Upgrade to vitest 4 and adopt @effectionx/bdd

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@effectionx/inspector": "https://pkg.pr.new/thefrontside/inspector/@effectionx/inspector@8c7cc3f",
     "@types/node": "^25.5.0",
     "oxlint": "^1.56.0",
+    "tsx": "^4.21.0",
     "typescript": "~5.8.0"
   },
   "packageManager": "pnpm@9.15.9"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -23,6 +23,6 @@
     "typescript": "~5.8.0"
   },
   "devDependencies": {
-    "vitest": "^3"
+    "vitest": "^4"
   }
 }

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest run"
+    "test": "vitest run && node --import tsx --test src/crash-replay.test.ts"
   },
   "dependencies": {
     "@tisyn/agent": "workspace:*",
@@ -22,7 +22,8 @@
     "@tisyn/runtime": "workspace:*"
   },
   "devDependencies": {
+    "@effectionx/bdd": "^0.5.1",
     "effection": "4.1.0-alpha.7",
-    "vitest": "^3"
+    "vitest": "^4"
   }
 }

--- a/packages/conformance/src/crash-replay.test.ts
+++ b/packages/conformance/src/crash-replay.test.ts
@@ -10,14 +10,14 @@
  * 6. Verify: final journal matches expected
  */
 
-import { describe, it, expect } from "vitest";
-import { run } from "effection";
+import { describe, it } from "@effectionx/bdd/node";
+import { expect } from "vitest";
 import { execute } from "@tisyn/runtime";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { AgentRegistry } from "@tisyn/agent";
 
 describe("End-to-end crash/replay", () => {
-  it("should replay stored effects and continue with live dispatch", async () => {
+  it("should replay stored effects and continue with live dispatch", function* () {
     // IR: three sequential effects
     // const a = yield* x.step1([]);
     // const b = yield* x.step2([a]);
@@ -82,12 +82,10 @@ describe("End-to-end crash/replay", () => {
     });
 
     // First run will fail on 3rd effect
-    const firstResult = await run(function* () {
-      return yield* execute({
-        ir: ir as never,
-        stream: firstRunStream,
-        agents: firstRunAgents,
-      });
+    const firstResult = yield* execute({
+      ir: ir as never,
+      stream: firstRunStream,
+      agents: firstRunAgents,
     });
 
     // First run should have error result (crashed on step3)
@@ -116,12 +114,10 @@ describe("End-to-end crash/replay", () => {
       return 30; // step3 result
     });
 
-    const secondResult = await run(function* () {
-      return yield* execute({
-        ir: ir as never,
-        stream: replayStream,
-        agents: secondRunAgents,
-      });
+    const secondResult = yield* execute({
+      ir: ir as never,
+      stream: replayStream,
+      agents: secondRunAgents,
     });
 
     // Verify: only 1 live agent call (step3)

--- a/packages/conformance/vitest.config.ts
+++ b/packages/conformance/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["node_modules/**", "dist/**", "src/crash-replay.test.ts"],
+  },
+});

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "expect-type": "^1",
-    "vitest": "^3"
+    "vitest": "^4"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest run"
+    "test": "node --import tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@tisyn/agent": "workspace:*",
@@ -21,8 +21,9 @@
     "@tisyn/kernel": "workspace:*"
   },
   "devDependencies": {
+    "@effectionx/bdd": "^0.5.1",
     "effection": "4.1.0-alpha.7",
-    "vitest": "^3"
+    "vitest": "^4"
   },
   "peerDependencies": {
     "effection": "4.1.0-alpha.7"

--- a/packages/runtime/src/journal.test.ts
+++ b/packages/runtime/src/journal.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { run } from "effection";
+import { describe, it } from "@effectionx/bdd/node";
+import { expect } from "vitest";
 import { execute } from "./execute.js";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { AgentRegistry } from "@tisyn/agent";
 import type { YieldEvent } from "@tisyn/kernel";
 
 describe("Journal", () => {
-  it("yield event written before resume", async () => {
+  it("yield event written before resume", function* () {
     const stream = new InMemoryStream();
     const agents = new AgentRegistry();
 
@@ -35,12 +35,10 @@ describe("Journal", () => {
       data: [],
     };
 
-    const { result, journal } = await run(function* () {
-      return yield* execute({
-        ir: ir as never,
-        stream,
-        agents,
-      });
+    const { result, journal } = yield* execute({
+      ir: ir as never,
+      stream,
+      agents,
     });
 
     expect(result).toEqual({ status: "ok", value: 42 });

--- a/packages/runtime/src/replay.test.ts
+++ b/packages/runtime/src/replay.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { run } from "effection";
+import { describe, it } from "@effectionx/bdd/node";
+import { expect } from "vitest";
 import { execute } from "./execute.js";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { AgentRegistry } from "@tisyn/agent";
@@ -48,7 +48,7 @@ function closeEvent(value: unknown, coroutineId = "root"): CloseEvent {
 }
 
 describe("Replay", () => {
-  it("replay hit returns stored result", async () => {
+  it("replay hit returns stored result", function* () {
     const stored: DurableEvent[] = [yieldEvent("a", "op", 42)];
     const stream = new InMemoryStream(stored);
 
@@ -60,12 +60,10 @@ describe("Replay", () => {
       return 999;
     });
 
-    const { result, journal } = await run(function* () {
-      return yield* execute({
-        ir: singleEffectIR("a", "op") as never,
-        stream,
-        agents,
-      });
+    const { result, journal } = yield* execute({
+      ir: singleEffectIR("a", "op") as never,
+      stream,
+      agents,
     });
 
     expect(agentCalled).toBe(false);
@@ -77,7 +75,7 @@ describe("Replay", () => {
     });
   });
 
-  it("replay miss transitions to live", async () => {
+  it("replay miss transitions to live", function* () {
     // Store only the first effect
     const stored: DurableEvent[] = [yieldEvent("a", "step1", 10)];
     const stream = new InMemoryStream(stored);
@@ -90,12 +88,10 @@ describe("Replay", () => {
       return 20;
     });
 
-    const { result, journal } = await run(function* () {
-      return yield* execute({
-        ir: twoEffectIR("a", "step1", "a", "step2") as never,
-        stream,
-        agents,
-      });
+    const { result, journal } = yield* execute({
+      ir: twoEffectIR("a", "step1", "a", "step2") as never,
+      stream,
+      agents,
     });
 
     // Only the second effect should trigger live dispatch
@@ -109,18 +105,16 @@ describe("Replay", () => {
     expect(journal[2]!.type).toBe("close");
   });
 
-  it("replay divergence: wrong type", async () => {
+  it("replay divergence: wrong type", function* () {
     // Stored says type "a", but kernel will yield type "b"
     const stored: DurableEvent[] = [yieldEvent("a", "op", 10)];
     const stream = new InMemoryStream(stored);
     const agents = new AgentRegistry();
 
-    const { result } = await run(function* () {
-      return yield* execute({
-        ir: singleEffectIR("b", "op") as never,
-        stream,
-        agents,
-      });
+    const { result } = yield* execute({
+      ir: singleEffectIR("b", "op") as never,
+      stream,
+      agents,
     });
 
     expect(result.status).toBe("err");
@@ -131,18 +125,16 @@ describe("Replay", () => {
     }
   });
 
-  it("replay divergence: wrong name", async () => {
+  it("replay divergence: wrong name", function* () {
     // Stored says name "foo", but kernel will yield name "bar"
     const stored: DurableEvent[] = [yieldEvent("a", "foo", 10)];
     const stream = new InMemoryStream(stored);
     const agents = new AgentRegistry();
 
-    const { result } = await run(function* () {
-      return yield* execute({
-        ir: singleEffectIR("a", "bar") as never,
-        stream,
-        agents,
-      });
+    const { result } = yield* execute({
+      ir: singleEffectIR("a", "bar") as never,
+      stream,
+      agents,
     });
 
     expect(result.status).toBe("err");
@@ -153,18 +145,16 @@ describe("Replay", () => {
     }
   });
 
-  it("replay divergence: continue past close", async () => {
+  it("replay divergence: continue past close", function* () {
     // Journal has a close event — kernel shouldn't yield more effects
     const stored: DurableEvent[] = [closeEvent(42)];
     const stream = new InMemoryStream(stored);
     const agents = new AgentRegistry();
 
-    const { result } = await run(function* () {
-      return yield* execute({
-        ir: singleEffectIR("a", "op") as never,
-        stream,
-        agents,
-      });
+    const { result } = yield* execute({
+      ir: singleEffectIR("a", "op") as never,
+      stream,
+      agents,
     });
 
     expect(result.status).toBe("err");
@@ -174,7 +164,7 @@ describe("Replay", () => {
     }
   });
 
-  it("replay ignores data differences", async () => {
+  it("replay ignores data differences", function* () {
     // Stored yield has data that differs from current IR args,
     // but type/name match — should replay successfully
     const stored: DurableEvent[] = [yieldEvent("a", "op", 99)];
@@ -189,12 +179,10 @@ describe("Replay", () => {
     });
 
     // IR sends different data than what was stored — shouldn't matter
-    const { result } = await run(function* () {
-      return yield* execute({
-        ir: singleEffectIR("a", "op", ["different", "data"]) as never,
-        stream,
-        agents,
-      });
+    const { result } = yield* execute({
+      ir: singleEffectIR("a", "op", ["different", "data"]) as never,
+      stream,
+      agents,
     });
 
     expect(agentCalled).toBe(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       oxlint:
         specifier: ^1.56.0
         version: 1.56.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~5.8.0
         version: 5.8.3
@@ -47,8 +50,8 @@ importers:
         version: 5.8.3
     devDependencies:
       vitest:
-        specifier: ^3
-        version: 3.2.4(@types/node@25.5.0)
+        specifier: ^4
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
 
   packages/conformance:
     dependencies:
@@ -68,12 +71,15 @@ importers:
         specifier: workspace:*
         version: link:../runtime
     devDependencies:
+      '@effectionx/bdd':
+        specifier: ^0.5.1
+        version: 0.5.1(effection@4.1.0-alpha.7)
       effection:
         specifier: 4.1.0-alpha.7
         version: 4.1.0-alpha.7
       vitest:
-        specifier: ^3
-        version: 3.2.4(@types/node@25.5.0)
+        specifier: ^4
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
 
   packages/durable-streams:
     dependencies:
@@ -91,8 +97,8 @@ importers:
         specifier: ^1
         version: 1.3.0
       vitest:
-        specifier: ^3
-        version: 3.2.4(@types/node@25.5.0)
+        specifier: ^4
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
 
   packages/kernel:
     dependencies:
@@ -115,12 +121,15 @@ importers:
         specifier: workspace:*
         version: link:../kernel
     devDependencies:
+      '@effectionx/bdd':
+        specifier: ^0.5.1
+        version: 0.5.1(effection@4.1.0-alpha.7)
       effection:
         specifier: 4.1.0-alpha.7
         version: 4.1.0-alpha.7
       vitest:
-        specifier: ^3
-        version: 3.2.4(@types/node@25.5.0)
+        specifier: ^4
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
 
 packages:
 
@@ -132,6 +141,12 @@ packages:
 
   '@b9g/crank@0.7.8':
     resolution: {integrity: sha512-22osqQnltRa/ekYktqO5L0WQsY8MLXkcdqwfzIPW+3ZKNJCE0P4vuna4Y2WHCYVFtv9SO2xwjOxLa/gOcmjitw==}
+
+  '@effectionx/bdd@0.5.1':
+    resolution: {integrity: sha512-VY4CGDWRiCyfWrMf/9SE+nIGuH/U+XKg8vJF2vI5hPpCnf1jSIz3dP+38TYBz3+ekzz8fBHSM1hKgwPqsmXTrA==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      effection: ^3 || ^4
 
   '@effectionx/inspector@https://pkg.pr.new/thefrontside/inspector/@effectionx/inspector@8c7cc3f':
     resolution: {tarball: https://pkg.pr.new/thefrontside/inspector/@effectionx/inspector@8c7cc3f}
@@ -160,6 +175,12 @@ packages:
 
   '@effectionx/stream-helpers@0.8.1':
     resolution: {integrity: sha512-17rocf3av2VId8uqZJxBREhQRSaowA7+MKAbu27P3ZboIhpuIu8jqoQ1+YfKWdMy/ORrApeIljgoJl+1hJ3fvQ==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      effection: ^3 || ^4
+
+  '@effectionx/test-adapter@0.7.3':
+    resolution: {integrity: sha512-OgGzsIhBN8XYsFDAETbeGqwwrW2sNdQukxHRNNngjJE0G6LiKkwDrXs8ANGzarPihoE02YANVMbyWAruBuUnYg==}
     engines: {node: '>= 22'}
     peerDependencies:
       effection: ^3 || ^4
@@ -583,34 +604,34 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   arkregex@0.0.5:
     resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
@@ -622,21 +643,16 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   configliere@0.2.4:
     resolution: {integrity: sha512-xGvxseKlsySjwXzB9HXNHe0/eqA9nCUUEo1227tTnhiBjlUrlMTN7CgpO4ufK9+TW/823dhjfOLY83fYqOh/hA==}
     engines: {node: '>= 16'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -645,25 +661,12 @@ packages:
   ctrlc-windows@2.2.0:
     resolution: {integrity: sha512-t9y568r+T8FUuBaqKK60YGFJdj3b3ktdJW9WXIT3CuBdQhAOYdSZu75jFUN0Ay4Yz5HHicVQqAYCwcnqhOn23g==}
 
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   effection@4.1.0-alpha.7:
     resolution: {integrity: sha512-ir7qM7vQXOo7eiuNxaD6FgwUetdy3XMB3dwtzUxp9ytiZl6abZUrXwM3vMqKWdMW4cW1KZzJqSEuXofJFscwFw==}
     engines: {node: '>= 16'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -691,6 +694,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
   h3@2.0.1-rc.14:
     resolution: {integrity: sha512-163qbGmTr/9rqQRNuqMqtgXnOUAkE4KTdauiC9y0E5iG1I65kte9NyfWvZw5RTDMt6eY+DtyoNzrQ9wA2BfvGQ==}
     engines: {node: '>=20.11.1'}
@@ -707,22 +713,16 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   oxlint@1.56.0:
     resolution: {integrity: sha512-Q+5Mj5PVaH/R6/fhMMFzw4dT+KPB+kQW4kaL8FOIq7tfhlnEVp6+3lcWqFruuTNlUo9srZUW3qH7Id4pskeR6g==}
@@ -745,10 +745,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -762,6 +758,9 @@ packages:
 
   remeda@2.33.6:
     resolution: {integrity: sha512-tazDGH7s75kUPGBKLvhgBEHMgW+TdDFhjUAMdQj57IoWz6HsGa5D2RX5yDUz6IIqiRRvZiaEHzCzWdTeixc/Kg==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -797,36 +796,31 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   ts-case-convert@2.1.0:
     resolution: {integrity: sha512-Ye79el/pHYXfoew6kqhMwCoxp4NWjKNcm2kBzpmEMIU9dd9aBmHNNFtZ+WTm0rz1ngyDmfqDXDlyUnBXayiD0w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -835,11 +829,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -881,26 +870,33 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -928,6 +924,11 @@ snapshots:
   '@ark/util@0.56.0': {}
 
   '@b9g/crank@0.7.8': {}
+
+  '@effectionx/bdd@0.5.1(effection@4.1.0-alpha.7)':
+    dependencies:
+      '@effectionx/test-adapter': 0.7.3(effection@4.1.0-alpha.7)
+      effection: 4.1.0-alpha.7
 
   '@effectionx/inspector@https://pkg.pr.new/thefrontside/inspector/@effectionx/inspector@8c7cc3f(effection@4.1.0-alpha.7)':
     dependencies:
@@ -969,6 +970,10 @@ snapshots:
       effection: 4.1.0-alpha.7
       immutable: 5.1.5
       remeda: 2.33.6
+
+  '@effectionx/test-adapter@0.7.3(effection@4.1.0-alpha.7)':
+    dependencies:
+      effection: 4.1.0-alpha.7
 
   '@effectionx/timebox@0.4.2(effection@4.1.0-alpha.7)':
     dependencies:
@@ -1201,47 +1206,46 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.0':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.0':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.0':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.0
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.0': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   arkregex@0.0.5:
     dependencies:
@@ -1255,22 +1259,14 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  cac@6.7.14: {}
-
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
-
-  check-error@2.1.3: {}
+  chai@6.2.2: {}
 
   configliere@0.2.4:
     dependencies:
       '@standard-schema/spec': 1.1.0
       ts-case-convert: 2.1.0
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1280,15 +1276,9 @@ snapshots:
 
   ctrlc-windows@2.2.0: {}
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  deep-eql@5.0.2: {}
-
   effection@4.1.0-alpha.7: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -1332,6 +1322,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   h3@2.0.1-rc.14:
     dependencies:
       rou3: 0.7.12
@@ -1341,17 +1335,13 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-tokens@9.0.1: {}
-
-  loupe@3.2.1: {}
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  ms@2.1.3: {}
-
   nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
 
   oxlint@1.56.0:
     optionalDependencies:
@@ -1381,8 +1371,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.1: {}
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -1394,6 +1382,8 @@ snapshots:
       source-map-js: 1.2.1
 
   remeda@2.33.6: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.59.0:
     dependencies:
@@ -1444,55 +1434,33 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
+  std-env@4.0.0: {}
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   ts-case-convert@2.1.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
 
   typescript@5.8.3: {}
 
   undici-types@7.18.2: {}
 
-  vite-node@3.2.4(@types/node@25.5.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@7.3.1(@types/node@25.5.0):
+  vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1503,47 +1471,34 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@25.5.0):
+  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)
-      vite-node: 3.2.4(@types/node@25.5.0)
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrade vitest from v3 to v4 across all packages
- Replace manual `run()` wrapping with `@effectionx/bdd`'s native generator support in 3 test files that use effection
- Runtime tests now run via `node --test` with `@effectionx/bdd/node`
- Conformance keeps vitest for non-effection tests, adds `node --test` for crash-replay

## Test plan
- [ ] CI passes: lint, format, build, tests
- [ ] Runtime tests run via node:test with @effectionx/bdd
- [ ] Conformance tests run via vitest + node:test
- [ ] IR and compiler tests unchanged on vitest 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)