### PR TITLE
Harden @tisyn/protocol: constructors, parsers, schemas

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@sinclair/typebox": "^0.34.48",
     "@tisyn/ir": "workspace:*"
   },
   "devDependencies": {

--- a/packages/protocol/src/constructors.test.ts
+++ b/packages/protocol/src/constructors.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  initializeRequest,
+  initializeResponse,
+  initializeProtocolError,
+  executeRequest,
+  executeSuccess,
+  executeApplicationError,
+  executeProtocolError,
+  progressNotification,
+  cancelNotification,
+  shutdownNotification,
+} from "./constructors.js";
+import { ProtocolErrorCode } from "./types.js";
+
+describe("Protocol constructors", () => {
+  it("initializeRequest", () => {
+    const msg = initializeRequest(1, {
+      protocolVersion: "1.0",
+      agentId: "test",
+      capabilities: { methods: ["op1"] },
+    });
+    expect(msg).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "1.0",
+        agentId: "test",
+        capabilities: { methods: ["op1"] },
+      },
+    });
+  });
+
+  it("initializeResponse", () => {
+    const msg = initializeResponse(1, {
+      protocolVersion: "1.0",
+      sessionId: "sess-1",
+    });
+    expect(msg).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { protocolVersion: "1.0", sessionId: "sess-1" },
+    });
+  });
+
+  it("initializeProtocolError", () => {
+    const msg = initializeProtocolError(1, {
+      code: ProtocolErrorCode.IncompatibleVersion,
+      message: "bad version",
+    });
+    expect(msg.error.code).toBe(-32002);
+  });
+
+  it("executeRequest", () => {
+    const msg = executeRequest("req-1", {
+      executionId: "ex-1",
+      taskId: "root",
+      operation: "double",
+      args: [{ value: 21 }],
+    });
+    expect(msg.method).toBe("execute");
+    expect(msg.id).toBe("req-1");
+    expect(msg.params.operation).toBe("double");
+  });
+
+  it("executeSuccess", () => {
+    const msg = executeSuccess("req-1", 42);
+    expect(msg.result).toEqual({ ok: true, value: 42 });
+  });
+
+  it("executeApplicationError", () => {
+    const msg = executeApplicationError("req-1", {
+      message: "kaboom",
+      name: "TestError",
+    });
+    expect(msg.result).toEqual({
+      ok: false,
+      error: { message: "kaboom", name: "TestError" },
+    });
+  });
+
+  it("executeProtocolError", () => {
+    const msg = executeProtocolError("req-1", {
+      code: ProtocolErrorCode.MethodNotFound,
+      message: "not found",
+    });
+    expect(msg.error.code).toBe(-32601);
+  });
+
+  it("progressNotification", () => {
+    const msg = progressNotification("token-1", { percent: 50 });
+    expect(msg.method).toBe("progress");
+    expect(msg.params).toEqual({ token: "token-1", value: { percent: 50 } });
+  });
+
+  it("cancelNotification with reason", () => {
+    const msg = cancelNotification("req-1", "timeout");
+    expect(msg.params).toEqual({ id: "req-1", reason: "timeout" });
+  });
+
+  it("cancelNotification without reason", () => {
+    const msg = cancelNotification("req-1");
+    expect(msg.params).toEqual({ id: "req-1" });
+    expect(msg.params).not.toHaveProperty("reason");
+  });
+
+  it("shutdownNotification", () => {
+    const msg = shutdownNotification();
+    expect(msg).toEqual({ jsonrpc: "2.0", method: "shutdown", params: {} });
+  });
+});

--- a/packages/protocol/src/constructors.ts
+++ b/packages/protocol/src/constructors.ts
@@ -1,0 +1,82 @@
+import type { Val } from "@tisyn/ir";
+import type {
+  InitializeRequest,
+  InitializeResponse,
+  InitializeProtocolError,
+  ExecuteRequest,
+  ExecuteResponse,
+  ExecuteProtocolError,
+  ProgressNotification,
+  CancelNotification,
+  ShutdownNotification,
+  AgentCapabilities,
+  JsonRpcError,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Initialize
+// ---------------------------------------------------------------------------
+
+export function initializeRequest(
+  id: string | number,
+  params: { protocolVersion: string; agentId: string; capabilities: AgentCapabilities },
+): InitializeRequest {
+  return { jsonrpc: "2.0", id, method: "initialize", params };
+}
+
+export function initializeResponse(
+  id: string | number,
+  result: { protocolVersion: string; sessionId: string },
+): InitializeResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+export function initializeProtocolError(
+  id: string | number,
+  error: JsonRpcError,
+): InitializeProtocolError {
+  return { jsonrpc: "2.0", id, error };
+}
+
+// ---------------------------------------------------------------------------
+// Execute
+// ---------------------------------------------------------------------------
+
+export function executeRequest(id: string, params: ExecuteRequest["params"]): ExecuteRequest {
+  return { jsonrpc: "2.0", id, method: "execute", params };
+}
+
+export function executeSuccess(id: string, value: Val): ExecuteResponse {
+  return { jsonrpc: "2.0", id, result: { ok: true, value } };
+}
+
+export function executeApplicationError(
+  id: string,
+  error: { message: string; name?: string },
+): ExecuteResponse {
+  return { jsonrpc: "2.0", id, result: { ok: false, error } };
+}
+
+export function executeProtocolError(id: string, error: JsonRpcError): ExecuteProtocolError {
+  return { jsonrpc: "2.0", id, error };
+}
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+export function progressNotification(token: string, value: Val): ProgressNotification {
+  return { jsonrpc: "2.0", method: "progress", params: { token, value } };
+}
+
+export function cancelNotification(id: string, reason?: string): CancelNotification {
+  return {
+    jsonrpc: "2.0",
+    method: "cancel",
+    params: reason !== undefined ? { id, reason } : { id },
+  };
+}
+
+export function shutdownNotification(): ShutdownNotification {
+  return { jsonrpc: "2.0", method: "shutdown", params: {} };
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -19,6 +19,23 @@ export type {
   ProgressNotification,
   CancelNotification,
   ShutdownNotification,
+  HostMessage,
+  AgentMessage,
 } from "./types.js";
 
 export { ProtocolErrorCode } from "./types.js";
+
+export {
+  initializeRequest,
+  initializeResponse,
+  initializeProtocolError,
+  executeRequest,
+  executeSuccess,
+  executeApplicationError,
+  executeProtocolError,
+  progressNotification,
+  cancelNotification,
+  shutdownNotification,
+} from "./constructors.js";
+
+export { parseHostMessage, parseAgentMessage } from "./parse.js";

--- a/packages/protocol/src/parse.test.ts
+++ b/packages/protocol/src/parse.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { parseHostMessage, parseAgentMessage } from "./parse.js";
+import {
+  initializeRequest,
+  initializeResponse,
+  initializeProtocolError,
+  executeRequest,
+  executeSuccess,
+  executeApplicationError,
+  executeProtocolError,
+  progressNotification,
+  cancelNotification,
+  shutdownNotification,
+} from "./constructors.js";
+import { ProtocolErrorCode } from "./types.js";
+
+describe("parseHostMessage", () => {
+  it("accepts valid initialize request", () => {
+    const msg = initializeRequest(1, {
+      protocolVersion: "1.0",
+      agentId: "test",
+      capabilities: { methods: ["op1"] },
+    });
+    expect(parseHostMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid execute request", () => {
+    const msg = executeRequest("req-1", {
+      executionId: "ex-1",
+      taskId: "root",
+      operation: "double",
+      args: [{ value: 21 }],
+    });
+    expect(parseHostMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid cancel notification", () => {
+    const msg = cancelNotification("req-1", "timeout");
+    expect(parseHostMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid shutdown notification", () => {
+    const msg = shutdownNotification();
+    expect(parseHostMessage(msg)).toEqual(msg);
+  });
+
+  it("throws on invalid input", () => {
+    expect(() => parseHostMessage({ foo: "bar" })).toThrow("Invalid HostMessage");
+  });
+
+  it("throws on null", () => {
+    expect(() => parseHostMessage(null)).toThrow("Invalid HostMessage");
+  });
+
+  it("throws on missing jsonrpc field", () => {
+    expect(() => parseHostMessage({ method: "shutdown", params: {} })).toThrow(
+      "Invalid HostMessage",
+    );
+  });
+});
+
+describe("parseAgentMessage", () => {
+  it("accepts valid initialize response", () => {
+    const msg = initializeResponse(1, {
+      protocolVersion: "1.0",
+      sessionId: "sess-1",
+    });
+    expect(parseAgentMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid initialize protocol error", () => {
+    const msg = initializeProtocolError(1, {
+      code: ProtocolErrorCode.IncompatibleVersion,
+      message: "bad",
+    });
+    expect(parseAgentMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid execute success", () => {
+    const msg = executeSuccess("req-1", 42);
+    expect(parseAgentMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid execute application error", () => {
+    const msg = executeApplicationError("req-1", {
+      message: "kaboom",
+    });
+    expect(parseAgentMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid execute protocol error", () => {
+    const msg = executeProtocolError("req-1", {
+      code: ProtocolErrorCode.MethodNotFound,
+      message: "not found",
+    });
+    expect(parseAgentMessage(msg)).toEqual(msg);
+  });
+
+  it("accepts valid progress notification", () => {
+    const msg = progressNotification("token-1", { percent: 50 });
+    expect(parseAgentMessage(msg)).toEqual(msg);
+  });
+
+  it("throws on invalid input", () => {
+    expect(() => parseAgentMessage("not an object")).toThrow("Invalid AgentMessage");
+  });
+
+  it("roundtrips through JSON", () => {
+    const msg = executeSuccess("req-1", { nested: [1, "two", null] });
+    const roundtripped = JSON.parse(JSON.stringify(msg));
+    expect(parseAgentMessage(roundtripped)).toEqual(msg);
+  });
+});

--- a/packages/protocol/src/parse.ts
+++ b/packages/protocol/src/parse.ts
@@ -1,0 +1,29 @@
+import { Value } from "@sinclair/typebox/value";
+import { HostMessageSchema, AgentMessageSchema } from "./schemas.js";
+import type { HostMessage, AgentMessage } from "./types.js";
+
+/**
+ * Validate an already-parsed JS value as a HostMessage.
+ * Throws on invalid structure.
+ */
+export function parseHostMessage(input: unknown): HostMessage {
+  if (!Value.Check(HostMessageSchema, input)) {
+    const errors = [...Value.Errors(HostMessageSchema, input)];
+    const detail = errors.map((e) => `${e.path}: ${e.message}`).join("; ");
+    throw new Error(`Invalid HostMessage: ${detail}`);
+  }
+  return input as HostMessage;
+}
+
+/**
+ * Validate an already-parsed JS value as an AgentMessage.
+ * Throws on invalid structure.
+ */
+export function parseAgentMessage(input: unknown): AgentMessage {
+  if (!Value.Check(AgentMessageSchema, input)) {
+    const errors = [...Value.Errors(AgentMessageSchema, input)];
+    const detail = errors.map((e) => `${e.path}: ${e.message}`).join("; ");
+    throw new Error(`Invalid AgentMessage: ${detail}`);
+  }
+  return input as AgentMessage;
+}

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -1,0 +1,161 @@
+import { Type, type TSchema } from "@sinclair/typebox";
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 base
+// ---------------------------------------------------------------------------
+
+const JsonRpc = Type.Literal("2.0");
+const Id = Type.Union([Type.String(), Type.Number()]);
+const StringId = Type.String();
+
+const JsonRpcError = Type.Object({
+  code: Type.Number(),
+  message: Type.String(),
+});
+
+// ---------------------------------------------------------------------------
+// Val — recursive JSON value (mirrors @tisyn/ir Val)
+// ---------------------------------------------------------------------------
+
+const Val: TSchema = Type.Recursive((Self) =>
+  Type.Union([
+    Type.String(),
+    Type.Number(),
+    Type.Boolean(),
+    Type.Null(),
+    Type.Array(Self),
+    Type.Record(Type.String(), Self),
+  ]),
+);
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+const AgentCapabilities = Type.Object({
+  methods: Type.Array(Type.String()),
+  progress: Type.Optional(Type.Boolean()),
+  concurrency: Type.Optional(Type.Number()),
+});
+
+// ---------------------------------------------------------------------------
+// Initialize
+// ---------------------------------------------------------------------------
+
+export const InitializeRequestSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  id: Id,
+  method: Type.Literal("initialize"),
+  params: Type.Object({
+    protocolVersion: Type.String(),
+    agentId: Type.String(),
+    capabilities: AgentCapabilities,
+  }),
+});
+
+export const InitializeResponseSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  id: Id,
+  result: Type.Object({
+    protocolVersion: Type.String(),
+    sessionId: Type.String(),
+  }),
+});
+
+export const InitializeProtocolErrorSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  id: Id,
+  error: JsonRpcError,
+});
+
+// ---------------------------------------------------------------------------
+// Execute
+// ---------------------------------------------------------------------------
+
+export const ExecuteRequestSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  id: StringId,
+  method: Type.Literal("execute"),
+  params: Type.Object({
+    executionId: Type.String(),
+    taskId: Type.String(),
+    operation: Type.String(),
+    args: Type.Array(Val),
+    progressToken: Type.Optional(Type.String()),
+    deadline: Type.Optional(Type.String()),
+  }),
+});
+
+const ResultSuccess = Type.Object({
+  ok: Type.Literal(true),
+  value: Val,
+});
+
+const ResultApplicationError = Type.Object({
+  ok: Type.Literal(false),
+  error: Type.Object({
+    message: Type.String(),
+    name: Type.Optional(Type.String()),
+  }),
+});
+
+const ResultPayload = Type.Union([ResultSuccess, ResultApplicationError]);
+
+export const ExecuteResponseSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  id: StringId,
+  result: ResultPayload,
+});
+
+export const ExecuteProtocolErrorSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  id: StringId,
+  error: JsonRpcError,
+});
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+export const ProgressNotificationSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  method: Type.Literal("progress"),
+  params: Type.Object({
+    token: Type.String(),
+    value: Val,
+  }),
+});
+
+export const CancelNotificationSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  method: Type.Literal("cancel"),
+  params: Type.Object({
+    id: Type.String(),
+    reason: Type.Optional(Type.String()),
+  }),
+});
+
+export const ShutdownNotificationSchema = Type.Object({
+  jsonrpc: JsonRpc,
+  method: Type.Literal("shutdown"),
+  params: Type.Object({}),
+});
+
+// ---------------------------------------------------------------------------
+// Unions
+// ---------------------------------------------------------------------------
+
+export const HostMessageSchema = Type.Union([
+  InitializeRequestSchema,
+  ExecuteRequestSchema,
+  CancelNotificationSchema,
+  ShutdownNotificationSchema,
+]);
+
+export const AgentMessageSchema = Type.Union([
+  InitializeResponseSchema,
+  InitializeProtocolErrorSchema,
+  ExecuteResponseSchema,
+  ExecuteProtocolErrorSchema,
+  ProgressNotificationSchema,
+]);

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -163,3 +163,20 @@ export const ProtocolErrorCode = {
   InvalidRequest: -32600,
   InternalError: -32603,
 } as const;
+
+// ---------------------------------------------------------------------------
+// Message unions
+// ---------------------------------------------------------------------------
+
+export type HostMessage =
+  | InitializeRequest
+  | ExecuteRequest
+  | CancelNotification
+  | ShutdownNotification;
+
+export type AgentMessage =
+  | InitializeResponse
+  | InitializeProtocolError
+  | ExecuteResponse
+  | ExecuteProtocolError
+  | ProgressNotification;

--- a/packages/transport/src/install-remote.ts
+++ b/packages/transport/src/install-remote.ts
@@ -4,6 +4,7 @@ import type { OperationSpec, AgentDeclaration } from "@tisyn/agent";
 import type { AgentTransportFactory } from "./transport.js";
 import { parseEffectId } from "@tisyn/kernel";
 import { Dispatch } from "@tisyn/agent";
+import { executeRequest } from "@tisyn/protocol";
 import { createSession } from "./session.js";
 
 let executionCounter = 0;
@@ -40,17 +41,14 @@ export function* installRemoteAgent<Ops extends Record<string, OperationSpec>>(
       if (type === id) {
         const requestId = `${id}:${requestCounter++}`;
 
-        const stream = session.execute({
-          jsonrpc: "2.0",
-          id: requestId,
-          method: "execute",
-          params: {
+        const stream = session.execute(
+          executeRequest(requestId, {
             executionId,
             taskId: "root",
             operation: name,
             args: [data],
-          },
-        });
+          }),
+        );
 
         // Subscribe and drain — Phase 1 discards progress
         const sub = yield* stream;

--- a/packages/transport/src/session.ts
+++ b/packages/transport/src/session.ts
@@ -1,8 +1,14 @@
 import type { Operation, Stream } from "effection";
 import { resource, spawn, createSignal, withResolvers } from "effection";
-import type { AgentCapabilities, ExecuteRequest, ResultPayload } from "@tisyn/protocol";
+import type {
+  AgentCapabilities,
+  ExecuteRequest,
+  ResultPayload,
+  AgentMessage,
+} from "@tisyn/protocol";
+import { initializeRequest, cancelNotification, shutdownNotification } from "@tisyn/protocol";
 import type { Val } from "@tisyn/ir";
-import type { AgentTransport, AgentMessage } from "./transport.js";
+import type { AgentTransport } from "./transport.js";
 
 /**
  * A protocol session over a transport. Handles initialize handshake,
@@ -52,13 +58,13 @@ export function createSession(options: CreateSessionOptions): Operation<Protocol
       }
 
       const initMsg = initResult.value;
-      if (hasError(initMsg)) {
+      if ("error" in initMsg) {
         rejectInit(
           new Error(`Initialize failed: ${initMsg.error.message} (code ${initMsg.error.code})`),
         );
         return;
       }
-      if (!hasSessionId(initMsg)) {
+      if (!("result" in initMsg && "sessionId" in initMsg.result)) {
         rejectInit(new Error("Unexpected message during initialize"));
         return;
       }
@@ -70,14 +76,14 @@ export function createSession(options: CreateSessionOptions): Operation<Protocol
           const { value, done } = yield* sub.next();
           if (done) break;
 
-          if (hasResultPayload(value)) {
+          if ("result" in value && "ok" in value.result) {
             const req = pending.get(String(value.id));
             if (req) {
               pending.delete(String(value.id));
               req.onResult(value.result as ResultPayload);
             }
-          } else if (hasError(value) && "id" in value) {
-            const id = String((value as { id: string | number }).id);
+          } else if ("error" in value && "id" in value) {
+            const id = String(value.id);
             const req = pending.get(id);
             if (req) {
               pending.delete(id);
@@ -85,7 +91,7 @@ export function createSession(options: CreateSessionOptions): Operation<Protocol
                 new Error(`Protocol error: ${value.error.message} (code ${value.error.code})`),
               );
             }
-          } else if (isProgress(value)) {
+          } else if ("method" in value && value.method === "progress") {
             const req = pending.get(value.params.token);
             if (req) {
               req.onProgress(value.params.value);
@@ -110,16 +116,7 @@ export function createSession(options: CreateSessionOptions): Operation<Protocol
     });
 
     // Send initialize and wait for response
-    yield* transport.send({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {
-        protocolVersion: "1.0",
-        agentId,
-        capabilities,
-      },
-    });
+    yield* transport.send(initializeRequest(1, { protocolVersion: "1.0", agentId, capabilities }));
 
     yield* initOp;
 
@@ -170,11 +167,7 @@ export function createSession(options: CreateSessionOptions): Operation<Protocol
             if (pending.has(request.id)) {
               pending.delete(request.id);
               try {
-                yield* transport.send({
-                  jsonrpc: "2.0",
-                  method: "cancel",
-                  params: { id: request.id },
-                });
+                yield* transport.send(cancelNotification(request.id));
               } catch {
                 // Transport may already be closed
               }
@@ -188,46 +181,10 @@ export function createSession(options: CreateSessionOptions): Operation<Protocol
       yield* provide(session);
     } finally {
       try {
-        yield* transport.send({
-          jsonrpc: "2.0",
-          method: "shutdown",
-          params: {},
-        });
+        yield* transport.send(shutdownNotification());
       } catch {
         // Transport may already be closed (e.g. child process exited)
       }
     }
   });
-}
-
-// --- Message discriminators ---
-
-function hasError(
-  msg: AgentMessage,
-): msg is AgentMessage & { error: { code: number; message: string } } {
-  return "error" in msg;
-}
-
-function hasSessionId(msg: AgentMessage): boolean {
-  return (
-    "result" in msg &&
-    typeof (msg as { result: Record<string, unknown> }).result === "object" &&
-    "sessionId" in ((msg as { result: Record<string, unknown> }).result as Record<string, unknown>)
-  );
-}
-
-function hasResultPayload(
-  msg: AgentMessage,
-): msg is AgentMessage & { id: string | number; result: ResultPayload } {
-  return (
-    "result" in msg &&
-    typeof (msg as { result: Record<string, unknown> }).result === "object" &&
-    "ok" in ((msg as { result: Record<string, unknown> }).result as Record<string, unknown>)
-  );
-}
-
-function isProgress(
-  msg: AgentMessage,
-): msg is { jsonrpc: "2.0"; method: "progress"; params: { token: string; value: Val } } {
-  return "method" in msg && msg.method === "progress";
 }

--- a/packages/transport/src/stdio-agent.ts
+++ b/packages/transport/src/stdio-agent.ts
@@ -5,7 +5,15 @@ import { fromReadable } from "@effectionx/node/stream";
 import { lines } from "@effectionx/stream-helpers";
 import type { Val } from "@tisyn/ir";
 import type { OperationSpec, AgentDeclaration, ImplementationHandlers } from "@tisyn/agent";
-import type { HostMessage, AgentMessage } from "./transport.js";
+import type { AgentMessage } from "@tisyn/protocol";
+import {
+  parseHostMessage,
+  initializeResponse,
+  initializeProtocolError,
+  executeSuccess,
+  executeApplicationError,
+  ProtocolErrorCode,
+} from "@tisyn/protocol";
 
 /**
  * Run an agent over stdio using NDJSON framing. This is the agent-side
@@ -32,25 +40,23 @@ export function* runStdioAgent<Ops extends Record<string, OperationSpec>>(
     const { value: line, done } = yield* sub.next();
     if (done) break;
 
-    const msg = JSON.parse(line) as HostMessage;
+    const msg = parseHostMessage(JSON.parse(line));
 
     if (msg.method === "initialize") {
-      const params = msg.params as { agentId: string; protocolVersion: string };
-      if (params.agentId !== declaration.id) {
-        sendMessage({
-          jsonrpc: "2.0",
-          id: msg.id as string | number,
-          error: { code: -32002, message: `Unknown agent: ${params.agentId}` },
-        });
+      if (msg.params.agentId !== declaration.id) {
+        sendMessage(
+          initializeProtocolError(msg.id, {
+            code: ProtocolErrorCode.IncompatibleVersion,
+            message: `Unknown agent: ${msg.params.agentId}`,
+          }),
+        );
       } else {
-        sendMessage({
-          jsonrpc: "2.0",
-          id: msg.id as string | number,
-          result: {
+        sendMessage(
+          initializeResponse(msg.id, {
             protocolVersion: "1.0",
             sessionId: `session-${declaration.id}-${Date.now()}`,
-          },
-        });
+          }),
+        );
       }
     } else if (msg.method === "execute") {
       const { id, params } = msg;
@@ -58,32 +64,22 @@ export function* runStdioAgent<Ops extends Record<string, OperationSpec>>(
       const handler = (handlers as Record<string, (args: Val) => Operation<Val>>)[opName];
 
       if (!handler) {
-        sendMessage({
-          jsonrpc: "2.0",
-          id,
-          result: {
-            ok: false,
-            error: { message: `No handler for operation: ${opName}`, name: "MethodNotFound" },
-          },
-        });
+        sendMessage(
+          executeApplicationError(id, {
+            message: `No handler for operation: ${opName}`,
+            name: "MethodNotFound",
+          }),
+        );
       } else {
         const task = yield* spawn(function* () {
           try {
             const val = yield* handler(args[0] as Val);
             inflight.delete(id);
-            sendMessage({
-              jsonrpc: "2.0",
-              id,
-              result: { ok: true, value: val as Val },
-            });
+            sendMessage(executeSuccess(id, val as Val));
           } catch (error) {
             inflight.delete(id);
             const err = error instanceof Error ? error : new Error(String(error));
-            sendMessage({
-              jsonrpc: "2.0",
-              id,
-              result: { ok: false, error: { message: err.message, name: err.name } },
-            });
+            sendMessage(executeApplicationError(id, { message: err.message, name: err.name }));
           }
         });
 

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -1,15 +1,5 @@
 import type { Operation, Stream } from "effection";
-import type {
-  InitializeRequest,
-  InitializeResponse,
-  InitializeProtocolError,
-  ExecuteRequest,
-  ExecuteResponse,
-  ExecuteProtocolError,
-  ProgressNotification,
-  CancelNotification,
-  ShutdownNotification,
-} from "@tisyn/protocol";
+import type { HostMessage, AgentMessage } from "@tisyn/protocol";
 
 /**
  * Generic bidirectional transport: send outgoing messages, receive incoming
@@ -20,24 +10,7 @@ export interface Transport<TSend, TReceive> {
   receive: Stream<TReceive, void>;
 }
 
-/**
- * Messages the host sends to the agent.
- */
-export type HostMessage =
-  | InitializeRequest
-  | ExecuteRequest
-  | CancelNotification
-  | ShutdownNotification;
-
-/**
- * Messages the agent sends to the host.
- */
-export type AgentMessage =
-  | InitializeResponse
-  | InitializeProtocolError
-  | ExecuteResponse
-  | ExecuteProtocolError
-  | ProgressNotification;
+export type { HostMessage, AgentMessage };
 
 /**
  * A transport typed for the Tisyn protocol message catalog.

--- a/packages/transport/src/transports/inprocess.ts
+++ b/packages/transport/src/transports/inprocess.ts
@@ -2,6 +2,13 @@ import type { Operation, Task } from "effection";
 import { createChannel, spawn } from "effection";
 import type { Val } from "@tisyn/ir";
 import type { OperationSpec, AgentDeclaration, ImplementationHandlers } from "@tisyn/agent";
+import {
+  initializeResponse,
+  initializeProtocolError,
+  executeSuccess,
+  executeApplicationError,
+  ProtocolErrorCode,
+} from "@tisyn/protocol";
 import type {
   AgentTransport,
   AgentTransportFactory,
@@ -39,28 +46,20 @@ export function inprocessTransport<Ops extends Record<string, OperationSpec>>(
         if (done) break;
 
         if (msg.method === "initialize") {
-          const params = msg.params as {
-            agentId: string;
-            protocolVersion: string;
-          };
-          if (params.agentId !== declaration.id) {
-            yield* agentToHost.send({
-              jsonrpc: "2.0",
-              id: msg.id as string | number,
-              error: {
-                code: -32002,
-                message: `Unknown agent: ${params.agentId}`,
-              },
-            });
+          if (msg.params.agentId !== declaration.id) {
+            yield* agentToHost.send(
+              initializeProtocolError(msg.id, {
+                code: ProtocolErrorCode.IncompatibleVersion,
+                message: `Unknown agent: ${msg.params.agentId}`,
+              }),
+            );
           } else {
-            yield* agentToHost.send({
-              jsonrpc: "2.0",
-              id: msg.id as string | number,
-              result: {
+            yield* agentToHost.send(
+              initializeResponse(msg.id, {
                 protocolVersion: "1.0",
                 sessionId: `session-${declaration.id}-${Date.now()}`,
-              },
-            });
+              }),
+            );
           }
         } else if (msg.method === "execute") {
           const { id, params } = msg;
@@ -68,39 +67,25 @@ export function inprocessTransport<Ops extends Record<string, OperationSpec>>(
           const handler = (handlers as Record<string, (args: Val) => Operation<Val>>)[opName];
 
           if (!handler) {
-            yield* agentToHost.send({
-              jsonrpc: "2.0",
-              id,
-              result: {
-                ok: false,
-                error: {
-                  message: `No handler for operation: ${opName}`,
-                  name: "MethodNotFound",
-                },
-              },
-            });
+            yield* agentToHost.send(
+              executeApplicationError(id, {
+                message: `No handler for operation: ${opName}`,
+                name: "MethodNotFound",
+              }),
+            );
           } else {
             // Spawn combined handler+response task so errors don't crash the agent loop
             const task = yield* spawn(function* () {
               try {
                 const val = yield* handler(args[0] as Val);
                 inflight.delete(id);
-                yield* agentToHost.send({
-                  jsonrpc: "2.0",
-                  id,
-                  result: { ok: true, value: val as Val },
-                });
+                yield* agentToHost.send(executeSuccess(id, val as Val));
               } catch (error) {
                 inflight.delete(id);
                 const err = error instanceof Error ? error : new Error(String(error));
-                yield* agentToHost.send({
-                  jsonrpc: "2.0",
-                  id,
-                  result: {
-                    ok: false,
-                    error: { message: err.message, name: err.name },
-                  },
-                });
+                yield* agentToHost.send(
+                  executeApplicationError(id, { message: err.message, name: err.name }),
+                );
               }
             });
 

--- a/packages/transport/src/transports/stdio.ts
+++ b/packages/transport/src/transports/stdio.ts
@@ -3,7 +3,9 @@ import { resource } from "effection";
 import { exec } from "@effectionx/process";
 import { lines, filter, map } from "@effectionx/stream-helpers";
 import { pipe } from "remeda";
-import type { AgentTransportFactory, HostMessage, AgentMessage } from "../transport.js";
+import type { AgentMessage } from "@tisyn/protocol";
+import { parseAgentMessage } from "@tisyn/protocol";
+import type { AgentTransportFactory, HostMessage } from "../transport.js";
 
 export interface StdioTransportOptions {
   command: string;
@@ -33,7 +35,7 @@ export function stdioTransport(options: StdioTransportOptions): AgentTransportFa
         }),
         map(function* (line: string) {
           try {
-            return JSON.parse(line) as AgentMessage;
+            return parseAgentMessage(JSON.parse(line));
           } catch {
             throw new Error(`Malformed JSON from child process: ${line}`);
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
 
   packages/protocol:
     dependencies:
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
       '@tisyn/ir':
         specifier: workspace:*
         version: link:../ir
@@ -650,6 +653,9 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@sinclair/typebox@0.34.48':
+    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1253,6 +1259,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@sinclair/typebox@0.34.48': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     { "path": "packages/agent" },
     { "path": "packages/conformance" },
     { "path": "packages/compiler" },
-    { "path": "packages/protocol" }
+    { "path": "packages/protocol" },
+    { "path": "packages/transport" }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `@sinclair/typebox` schemas, message constructors, and runtime parsers to `@tisyn/protocol`
- Replace ad-hoc object literals and unsafe `as` casts across transport code with centralized helpers
- Add `HostMessage`/`AgentMessage` union types to protocol package (previously defined only in transport)

## Changes

**Protocol package (`@tisyn/protocol`):**
- `schemas.ts` — TypeBox schemas for all 9 message types + union schemas
- `constructors.ts` — 10 constructor functions (`initializeRequest`, `executeSuccess`, `shutdownNotification`, etc.)
- `parse.ts` — `parseHostMessage(unknown)` and `parseAgentMessage(unknown)` with TypeBox validation
- `types.ts` — added `HostMessage` and `AgentMessage` union types
- 26 new tests across `constructors.test.ts` and `parse.test.ts`

**Transport package (`@tisyn/transport`):**
- `transport.ts` — re-exports unions from protocol instead of defining locally
- `session.ts` — 3 message literals → constructors; removed 4 local discriminator functions
- `install-remote.ts` — ExecuteRequest literal → `executeRequest()` constructor
- `inprocess.ts` — 5 message literals → constructors; removed protocol-shape `as` casts
- `stdio-agent.ts` — 5 message literals → constructors; `parseHostMessage()` for inbound validation
- `stdio.ts` — `parseAgentMessage()` instead of `as AgentMessage` cast

## Test plan

- [x] `pnpm --filter @tisyn/protocol test` — 37 tests pass (11 existing + 26 new)
- [x] `pnpm --filter @tisyn/transport test` — 19 tests pass (unchanged)
- [x] `pnpm build` — clean
- [x] `npx oxfmt . --check` — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)