### PR TITLE
docs: expand package readmes

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -26,24 +26,24 @@ Declarations are pure metadata plus typed call helpers. They do not execute anyt
 
 The current public surface from `src/index.ts` is:
 
-- `agent`
-- `operation`
-- `implementAgent`
-- `Dispatch`
-- `dispatch`
-- `invoke`
+- `agent`: Declare a named agent boundary and its available operations.
+- `operation`: Declare the typed input/output contract for one operation on an agent.
+- `implementAgent`: Bind generator handlers to a declaration so the runtime can dispatch to it.
+- `Dispatch`: Represent the Effection middleware contract that routes invocations to handlers.
+- `dispatch`: Install dispatch middleware into the current Effection scope.
+- `invoke`: Execute a declared operation against the currently installed dispatch stack.
 
 Important exported types:
 
-- `OperationSpec`
-- `DeclaredAgent`
-- `AgentDeclaration`
-- `AgentImplementation`
-- `ImplementationHandlers`
-- `Invocation`
-- `ArgsOf`
-- `ResultOf`
-- `Workflow`
+- `OperationSpec`: Describe the typed input and result shape of a declared operation.
+- `DeclaredAgent`: Represent the callable declaration object returned by `agent()`.
+- `AgentDeclaration`: Name the structural type for a declared agent contract.
+- `AgentImplementation`: Represent a declaration paired with concrete handlers and install logic.
+- `ImplementationHandlers`: Type the handler map expected by `implementAgent()`.
+- `Invocation`: Represent one concrete operation call ready for dispatch.
+- `ArgsOf`: Extract the input shape from an operation declaration.
+- `ResultOf`: Extract the result type from an operation declaration.
+- `Workflow`: Represent the authored workflow return type used in ambient contract declarations.
 
 ## Define a Declaration
 

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -24,13 +24,13 @@ If `@tisyn/ir` defines the language of Tisyn, `@tisyn/compiler` is what lets app
 
 The public API from `src/index.ts` is:
 
-- `compile`
-- `compileOne`
-- `generateWorkflowModule`
-- `DiscoveredContract`
-- `ContractMethod`
-- `CompileError`
-- `ErrorCodes`
+- `compile`: Compile authored source into discovered contracts plus compiled workflow IR values.
+- `compileOne`: Compile a single exported workflow from authored source and return just that result.
+- `generateWorkflowModule`: Generate a complete TypeScript module containing declarations and compiled workflows.
+- `DiscoveredContract`: Describe one ambient agent contract discovered from authored source.
+- `ContractMethod`: Describe one discovered method on a contract, including names and types.
+- `CompileError`: Represent a compiler failure with structured location and error-code data.
+- `ErrorCodes`: Export the stable compiler error-code catalog for tooling and tests.
 
 There are also exported IR-builder helpers such as `Q`, `Ref`, `Fn`, `Let`, `Call`, `ExternalEval`, `AllEval`, and `RaceEval`. These are primarily compiler-facing utilities and lower-level tooling helpers rather than the main entrypoint most consumers should start with.
 

--- a/packages/conformance/README.md
+++ b/packages/conformance/README.md
@@ -30,9 +30,9 @@ Fixtures can cover:
 
 The public surface from `src/index.ts` is:
 
-- `runFixture`
-- `Fixture`
-- `FixtureResult`
+- `runFixture`: Execute one conformance fixture and return its structured outcome.
+- `Fixture`: Describe the inputs, expectations, and setup for a conformance scenario.
+- `FixtureResult`: Report whether a fixture passed or failed and why.
 
 ## Example
 

--- a/packages/durable-streams/README.md
+++ b/packages/durable-streams/README.md
@@ -24,10 +24,10 @@ The important behavioral contract is that `append()` only completes after the ev
 
 The public surface from `src/index.ts` is:
 
-- `DurableStream`
-- `InMemoryStream`
-- `ReplayIndex`
-- `YieldEntry`
+- `DurableStream`: Define the append/read contract for durable event storage backends.
+- `InMemoryStream`: Provide a simple in-memory `DurableStream` implementation for tests and fixtures.
+- `ReplayIndex`: Index prior yield events so replay can answer lookup questions efficiently.
+- `YieldEntry`: Represent one indexed replay entry derived from a prior yield event.
 
 ## Example
 

--- a/packages/ir/README.md
+++ b/packages/ir/README.md
@@ -29,12 +29,12 @@ The surface is intentionally broad, but it groups into a few jobs.
 
 ### Types and values
 
-- `Json`
-- `Val`
-- `TisynExpr`
-- `Expr`
-- `TisynFn`
-- `IrInput`
+- `Json`: Represent plain JSON-compatible values that can be serialized across boundaries.
+- `Val`: Represent the runtime value domain accepted by environments and protocols.
+- `TisynExpr`: Represent the full union of legal Tisyn expression nodes and literals.
+- `Expr`: Represent a typed expression input used by constructor helpers.
+- `TisynFn`: Represent a function-shaped IR value with parameter names and a body expression.
+- `IrInput`: Represent the validated input shapes accepted by IR-consuming APIs.
 
 ### Constructors
 

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -25,38 +25,38 @@ Use `@tisyn/kernel` when you need the evaluator itself, not the full durable run
 
 The public surface from `src/index.ts` is:
 
-- `evaluate`
-- `classify`
-- `isStructural`
-- `isCompoundExternal`
-- `resolve`
-- `unquote`
+- `evaluate`: Step through IR evaluation until a value, yield, or close result is produced.
+- `classify`: Classify an eval id as structural or external.
+- `isStructural`: Check whether an eval id is handled directly by kernel semantics.
+- `isCompoundExternal`: Check whether an eval id is a compound external form such as `all` or `race`.
+- `resolve`: Look up a named reference in an environment.
+- `unquote`: Convert quoted values back into executable expressions where kernel rules allow it.
 - environment helpers:
-  - `Env`
-  - `EMPTY_ENV`
-  - `lookup`
-  - `extend`
-  - `extendMulti`
-  - `envFromRecord`
+  - `Env`: Represent the lexical environment abstraction used during evaluation.
+  - `EMPTY_ENV`: Provide the canonical empty environment value.
+  - `lookup`: Read a bound value from an environment by name.
+  - `extend`: Create a child environment with one additional binding.
+  - `extendMulti`: Create a child environment with multiple bindings at once.
+  - `envFromRecord`: Build an environment from a plain record of values.
 - validation error re-export:
-  - `MalformedIR`
+  - `MalformedIR`: Represent the invalid-IR error raised when malformed input crosses a trust boundary.
 - runtime errors:
-  - `UnboundVariable`
-  - `NotCallable`
-  - `ArityMismatch`
-  - `TypeError`
-  - `DivisionByZero`
-  - `ExplicitThrow`
+  - `UnboundVariable`: Report an attempt to evaluate a reference with no matching binding.
+  - `NotCallable`: Report an attempt to call a value that is not function-shaped.
+  - `ArityMismatch`: Report a call whose argument count does not match the function shape.
+  - `TypeError`: Report a structural operation receiving values of the wrong kind.
+  - `DivisionByZero`: Report division or modulo by zero in structural arithmetic.
+  - `ExplicitThrow`: Report a `Throw(...)` node raising an application-level error.
 - event types:
-  - `EffectDescription`
-  - `EventResult`
-  - `YieldEvent`
-  - `CloseEvent`
-  - `DurableEvent`
-  - `EffectDescriptor`
+  - `EffectDescription`: Describe a yielded effect before dispatch or persistence.
+  - `EventResult`: Represent the evaluator outcome shape consumed by the runtime.
+  - `YieldEvent`: Represent a persisted effect yield and its eventual result.
+  - `CloseEvent`: Represent a persisted terminal execution result.
+  - `DurableEvent`: Union together all event types that can appear in the durable stream.
+  - `EffectDescriptor`: Name the canonical structural shape of an effect descriptor.
 - helpers:
-  - `canonical`
-  - `parseEffectId`
+  - `canonical`: Produce a stable canonical representation for event payloads and comparisons.
+  - `parseEffectId`: Split an effect id into its agent and operation parts.
 
 ## Example
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -24,39 +24,39 @@ Use this package when you are building transport adapters, framing layers, or pr
 
 ### Types
 
-- `HostMessage`
-- `AgentMessage`
-- `InitializeRequest`
-- `InitializeResponse`
-- `ExecuteRequest`
-- `ExecuteResponse`
-- `ProgressNotification`
-- `CancelNotification`
-- `ShutdownNotification`
-- `ResultPayload`
-- `ApplicationError`
+- `HostMessage`: Union together all messages the host may send to a remote agent.
+- `AgentMessage`: Union together all messages a remote agent may send back to the host.
+- `InitializeRequest`: Represent the host-to-agent handshake request that opens a protocol session.
+- `InitializeResponse`: Represent the agent’s response to initialization.
+- `ExecuteRequest`: Represent a request to invoke one remote operation.
+- `ExecuteResponse`: Represent the success or failure response for an execute request.
+- `ProgressNotification`: Represent a one-way progress update during remote execution.
+- `CancelNotification`: Represent a one-way request to cancel an in-flight execution.
+- `ShutdownNotification`: Represent a one-way notification that the protocol session is ending.
+- `ResultPayload`: Represent the JSON-compatible result envelope carried by execution responses.
+- `ApplicationError`: Represent an application-level execution failure returned over the protocol.
 
 ### Constants
 
-- `ProtocolErrorCode`
+- `ProtocolErrorCode`: Export the stable numeric error codes used for protocol-layer failures.
 
 ### Constructors
 
-- `initializeRequest`
-- `initializeResponse`
-- `initializeProtocolError`
-- `executeRequest`
-- `executeSuccess`
-- `executeApplicationError`
-- `executeProtocolError`
-- `progressNotification`
-- `cancelNotification`
-- `shutdownNotification`
+- `initializeRequest`: Build a well-shaped initialize request message.
+- `initializeResponse`: Build a successful initialize response message.
+- `initializeProtocolError`: Build an initialize failure response at the protocol layer.
+- `executeRequest`: Build a request to execute one operation remotely.
+- `executeSuccess`: Build a successful execute response message.
+- `executeApplicationError`: Build an execute response that carries an application error.
+- `executeProtocolError`: Build an execute response that carries a protocol error.
+- `progressNotification`: Build a progress notification message.
+- `cancelNotification`: Build a cancellation notification message.
+- `shutdownNotification`: Build a shutdown notification message.
 
 ### Parsers
 
-- `parseHostMessage`
-- `parseAgentMessage`
+- `parseHostMessage`: Validate and narrow parsed JSON into one of the allowed host message shapes.
+- `parseAgentMessage`: Validate and narrow parsed JSON into one of the allowed agent message shapes.
 
 ## Example
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -25,11 +25,11 @@ If you want to run Tisyn programs rather than just inspect or validate them, thi
 
 The public surface from `src/index.ts` is:
 
-- `execute`
-- `ExecuteOptions`
-- `ExecuteResult`
-- `executeRemote`
-- `ExecuteRemoteOptions`
+- `execute`: Run IR durably against a stream, replay prior events, and dispatch live effects.
+- `ExecuteOptions`: Describe the inputs accepted by `execute()`, including IR, environment, and stream configuration.
+- `ExecuteResult`: Describe the structured outcome returned by `execute()`.
+- `executeRemote`: Execute received IR in a remote-execution context with supplied environment values.
+- `ExecuteRemoteOptions`: Describe the inputs accepted by `executeRemote()`.
 
 ## Execute IR Durably
 

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -23,37 +23,37 @@ Use it when a Tisyn effect should execute somewhere other than the current proce
 
 ### Host-side installation and sessions
 
-- `installRemoteAgent`
-- `createSession`
-- `ProtocolSession`
-- `CreateSessionOptions`
+- `installRemoteAgent`: Install an agent declaration so its invocations are forwarded over a transport session.
+- `createSession`: Create and manage a host-side protocol session over a concrete transport.
+- `ProtocolSession`: Represent the live session object that manages protocol lifecycle and request routing.
+- `CreateSessionOptions`: Describe the configuration accepted by `createSession()`.
 
 ### Transport interfaces
 
-- `Transport`
-- `AgentTransport`
-- `AgentTransportFactory`
+- `Transport`: Define the host-side transport contract used to open a protocol session.
+- `AgentTransport`: Define the agent-side transport contract used by protocol servers.
+- `AgentTransportFactory`: Define a factory that creates agent-side transports on demand.
 
 ### Concrete transports
 
-- `inprocessTransport`
-- `stdioTransport`
-- `websocketTransport`
-- `workerTransport`
-- `ssePostTransport`
+- `inprocessTransport`: Create an in-process reference transport with no real IO boundary.
+- `stdioTransport`: Create a transport that talks to a child process over stdin/stdout.
+- `websocketTransport`: Create a transport that speaks the protocol over WebSocket.
+- `workerTransport`: Create a transport that speaks the protocol through a worker boundary.
+- `ssePostTransport`: Create an HTTP transport that combines POST requests with SSE responses.
 
 ### Agent-side adapters
 
-- `createStdioAgentTransport`
-- `createSsePostAgentTransport`
-- `createProtocolServer`
-- `AgentServerTransport`
-- `ProtocolServer`
+- `createStdioAgentTransport`: Adapt stdin/stdout streams into an agent-side transport.
+- `createSsePostAgentTransport`: Adapt POST and SSE channels into an agent-side transport.
+- `createProtocolServer`: Build the agent-side protocol loop that serves requests over a transport.
+- `AgentServerTransport`: Define the server-side transport contract consumed by `createProtocolServer()`.
+- `ProtocolServer`: Represent the running server-side protocol adapter.
 
 ### Verification helpers
 
-- `transportComplianceSuite`
-- `TransportFactoryBuilder`
+- `transportComplianceSuite`: Run the shared conformance checks against a transport implementation.
+- `TransportFactoryBuilder`: Type the helper shape used to construct transports for compliance tests.
 
 ## Example
 

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -24,20 +24,20 @@ Use it whenever IR comes from another process, persistent storage, user input, o
 
 The public surface from `src/index.ts` is:
 
-- `validateGrammar`
-- `validateIr`
-- `assertValidIr`
-- `MalformedIR`
-- `tisynExprSchema`
-- `evalSchema`
-- `quoteSchema`
-- `refSchema`
-- `fnSchema`
+- `validateGrammar`: Check that an IR tree follows the allowed grammar rules without throwing.
+- `validateIr`: Perform full validation and return the structured result.
+- `assertValidIr`: Validate IR and throw `MalformedIR` if it is invalid.
+- `MalformedIR`: Represent a validation failure that crossed a trust boundary.
+- `tisynExprSchema`: Export the top-level schema for a full Tisyn expression.
+- `evalSchema`: Export the schema for eval nodes.
+- `quoteSchema`: Export the schema for quote nodes.
+- `refSchema`: Export the schema for ref nodes.
+- `fnSchema`: Export the schema for function-shaped IR nodes.
 
 Useful exported types:
 
-- `ValidationError`
-- `ValidationResult`
+- `ValidationError`: Describe one concrete validation problem found in the IR.
+- `ValidationResult`: Represent the success or failure result returned by validation functions.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- expand the package READMEs across the workspace
- add more complete package-level guidance, examples, and API framing
- keep the change set docs-only on top of the examples/multi-agent-chat branch

## Testing
- not run (documentation-only changes)