### PR TITLE
[codex] docs: add fn schema parsing example

### DIFF
--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -102,6 +102,31 @@ The main public surface is exported from `src/index.ts`.
 - `ValidationResult`  
   Represents the success or failure result returned by validation functions.
 
+## Parsing Unknown Input
+
+Use the exported TypeBox schemas when you need to validate already-parsed JavaScript values before treating them as IR.
+
+`tisynExprSchema` covers a full `IrInput`-style expression tree. `fnSchema` is narrower: it validates function-shaped IR nodes only.
+
+```ts
+import { Value } from "@sinclair/typebox/value";
+import { fnSchema } from "@tisyn/validate";
+import type { TisynFn } from "@tisyn/ir";
+
+function parseFnInput(input: unknown): TisynFn<unknown[], unknown> {
+  if (!Value.Check(fnSchema, input)) {
+    const detail = [...Value.Errors(fnSchema, input)]
+      .map((error) => `${error.path}: ${error.message}`)
+      .join("; ");
+    throw new Error(`Invalid fn node: ${detail}`);
+  }
+
+  return input as TisynFn<unknown[], unknown>;
+}
+```
+
+If you need to accept any full IR expression rather than only `fn` nodes, validate against `tisynExprSchema` instead.
+
 ## Validation Rules Worth Knowing
 
 Most callers can treat validation as a black box, but a few package-level rules are worth knowing when constructing IR directly:


### PR DESCRIPTION
This PR adds a documentation example for parsing already-parsed unknown input with `@tisyn/validate`'s `fnSchema`.

It shows:
- validating input with `Value.Check(fnSchema, input)`
- surfacing TypeBox validation errors in a readable message
- narrowing to a function-shaped IR node after validation

This fills a gap in the validate package docs for consumers who need to accept `fn` nodes from untyped input.