### PR TITLE
Free the invoke name: remove public helper, widen dispatch

### DIFF
--- a/.changeset/remove-public-invoke.md
+++ b/.changeset/remove-public-invoke.md
@@ -1,0 +1,14 @@
+---
+"@tisyn/agent": minor
+---
+
+Removed the `invoke(invocation)` helper and the `Invocation` public type
+export. Call sites that previously wrote `yield* invoke(agent.op(args))`
+should now pass the call descriptor straight to `dispatch`, which accepts
+either a `(effectId, data)` pair or a `{ effectId, data }` object:
+
+    const result = yield* dispatch(agent.op(args));
+
+The descriptor shape returned by `agent().op(args)` is unchanged; only the
+public `Invocation` type name and the `invoke` function are removed. The
+`invoke` name is freed for a future nested-invocation helper.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const { result } = yield* execute({ ir });
 ### Define an agent and install a remote transport
 
 ```ts
-import { agent, operation, invoke } from "@tisyn/agent";
+import { agent, operation, dispatch } from "@tisyn/agent";
 import { installRemoteAgent, websocketTransport } from "@tisyn/transport";
 
 const math = agent("math", {
@@ -113,7 +113,7 @@ const math = agent("math", {
 });
 
 yield* installRemoteAgent(math, websocketTransport({ url: "ws://localhost:8080" }));
-const result = yield* invoke(math.double({ value: 21 }));
+const result = yield* dispatch(math.double({ value: 21 }));
 ```
 
 For the detailed agent model and API examples, see [`@tisyn/agent`](./packages/agent/README.md).

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -20,9 +20,8 @@ This package sits between authored workflow logic and concrete side effects.
 - `operation<Spec>()` declares one typed operation on that boundary.
 - `Agents.use()` binds handlers directly to a declaration in the current scope, installing routing and resolve middleware.
 - `Effects.around()` installs Effection middleware layers that intercept or route effect invocations.
-- `dispatch()` performs an effect call through the current `Effects` middleware boundary.
+- `dispatch()` performs an effect call through the current `Effects` middleware boundary. It accepts either an explicit `(effectId, data)` pair or a call descriptor object produced by `agent().op(args)`.
 - `resolve()` queries the Effects middleware chain to check if an agent is bound in the current scope.
-- `invoke()` executes a declared operation against the current dispatch stack.
 - `useAgent()` retrieves a typed facade for an agent bound in the current scope via `Agents.use()` or `useTransport()`. The facade exposes direct methods for each operation plus `.around()` for per-operation middleware.
 
 Agent declarations are typed metadata plus call helpers. They describe invocations, but do not execute anything by themselves.
@@ -36,9 +35,8 @@ The public surface exported from `src/index.ts` includes:
 - `Agents` — setup namespace; `Agents.use(declaration, handlers)` binds handlers directly in the current scope
 - `implementAgent` — create an `AgentImplementation` object for use by protocol servers and transports (internal/advanced)
 - `Effects` — the Effection middleware context for invocation routing; use `Effects.around()` to install intercept layers
-- `dispatch` — perform an effect call through the current `Effects` middleware boundary
+- `dispatch` — perform an effect call through the current `Effects` middleware boundary. Accepts either `(effectId, data)` or a `{ effectId, data }` descriptor returned by `agent().op(args)`
 - `resolve` — query the Effects middleware chain to check if an agent is bound
-- `invoke` — execute a declared operation against the current dispatch stack
 - `useAgent` — retrieve a typed facade for an agent previously bound via `Agents.use()` or `useTransport()`; returns an object with one method per operation plus `.around()`
 - `installCrossBoundaryMiddleware` — install an IR function node as the cross-boundary middleware carrier for further remote delegation
 - `getCrossBoundaryMiddleware` — read the current cross-boundary middleware carrier from scope (returns `null` if not set)
@@ -51,7 +49,6 @@ Important exported types:
 - `AgentDeclaration` — structural type for a declared agent contract
 - `AgentImplementation` — declaration paired with handlers and install logic
 - `ImplementationHandlers` — type the handler map expected by `Agents.use()` and `implementAgent()`
-- `Invocation` — represent one concrete operation call ready for dispatch
 - `ArgsOf` — extract the input shape from an operation declaration
 - `ResultOf` — extract the result type from an operation declaration
 - `Workflow` — represent the authored workflow return type used in ambient declarations
@@ -69,7 +66,7 @@ const orders = agent("orders", {
 });
 ```
 
-Calling a declared operation produces an invocation description. It is a typed effect request, not a direct function call.
+Calling a declared operation produces a call descriptor. It is a typed effect request, not a direct function call.
 
 ```ts
 const request = orders.fetch({ input: { orderId: "ord-1" } });
@@ -121,12 +118,12 @@ facade.around MW → facade core handler → dispatch() → Effects.around MW �
 
 Multiple `useAgent()` calls with the same declaration in the same scope share middleware visibility — middleware installed via one reference is visible to all. Child-scope facade middleware inherits down but does not affect the parent scope.
 
-## Invoke an Operation
+## Dispatch an Operation
 
 ```ts
-import { invoke } from "@tisyn/agent";
+import { dispatch } from "@tisyn/agent";
 
-const order = yield* invoke(
+const order = yield* dispatch(
   orders.fetch({ input: { orderId: "ord-1" } }),
 );
 ```
@@ -139,7 +136,7 @@ This is useful when:
 ```ts
 yield* Agents.use(checkout, {
   *complete({ input }) {
-    const order = yield* invoke(
+    const order = yield* dispatch(
       orders.fetch({ input: { orderId: input.orderId } }),
     );
 
@@ -153,10 +150,10 @@ yield* Agents.use(checkout, {
 An agent declaration gives Tisyn a typed, named capability boundary.
 
 - **Declarations** define what operations exist and what they accept or return.
-- **Invocations** describe one requested operation call.
+- **Call descriptors** — produced by calling a declared operation (e.g. `orders.fetch(args)`) — describe one requested operation as a plain `{ effectId, data }` object.
 - **Implementations** attach concrete handlers to those declarations.
 - **Facades** (from `useAgent()`) expose per-operation dispatch methods and `.around()` for per-operation middleware.
-- **Effects middleware** decides how invocations are routed.
+- **Effects middleware** decides how dispatched calls are routed.
 - **Cross-boundary constraints** are installed as ordinary `Effects.around()` middleware in the execution scope — there is no separate enforcement mechanism.
 
 That routing can stay local, or it can be forwarded through another layer such as a worker or network transport. `@tisyn/agent` stays focused on the contract and dispatch shape rather than the transport itself.

--- a/packages/agent/src/dispatch.test.ts
+++ b/packages/agent/src/dispatch.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
-import { agent, operation, implementAgent, invoke } from "./index.js";
+import { agent, operation, implementAgent, dispatch } from "./index.js";
 
-describe("invoke", () => {
-  it("dispatches through installed middleware", function* () {
+describe("dispatch", () => {
+  it("routes a call descriptor through installed middleware", function* () {
     const math = agent("math", {
       double: operation<{ value: number }, number>(),
     });
@@ -16,11 +16,11 @@ describe("invoke", () => {
 
     yield* impl.install();
 
-    const result = yield* invoke(math.double({ value: 21 }));
+    const result = yield* dispatch(math.double({ value: 21 }));
     expect(result).toBe(42);
   });
 
-  it("propagates errors from dispatch", function* () {
+  it("propagates errors from the handler", function* () {
     const failing = agent("failing", {
       boom: operation<void, never>(),
     });
@@ -34,7 +34,7 @@ describe("invoke", () => {
     yield* impl.install();
 
     try {
-      yield* invoke(failing.boom());
+      yield* dispatch(failing.boom());
       expect.unreachable("should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(Error);

--- a/packages/agent/src/dispatch.ts
+++ b/packages/agent/src/dispatch.ts
@@ -57,9 +57,10 @@ export const Effects = Object.assign(EffectsApi, {
  * object with the same shape returned by agent().op(args).
  */
 export function dispatch<T = Val>(effectId: string, data: Val): Operation<T>;
-export function dispatch<T = Val>(
-  request: { readonly effectId: string; readonly data: unknown },
-): Operation<T>;
+export function dispatch<T = Val>(request: {
+  readonly effectId: string;
+  readonly data: unknown;
+}): Operation<T>;
 export function dispatch<T = Val>(
   effectIdOrRequest: string | { readonly effectId: string; readonly data: unknown },
   maybeData?: Val,

--- a/packages/agent/src/dispatch.ts
+++ b/packages/agent/src/dispatch.ts
@@ -53,11 +53,25 @@ export const Effects = Object.assign(EffectsApi, {
 /**
  * Dispatch an effect through the Effects middleware chain.
  *
- * Cross-boundary constraints are installed as ordinary Effects.around()
- * middleware in the execution scope — no separate enforcement context.
+ * Accepts either an explicit (effectId, data) pair or a call descriptor
+ * object with the same shape returned by agent().op(args).
  */
-export const dispatch: (effectId: string, data: Val) => Operation<Val> =
-  EffectsApi.operations.dispatch;
+export function dispatch<T = Val>(effectId: string, data: Val): Operation<T>;
+export function dispatch<T = Val>(
+  request: { readonly effectId: string; readonly data: unknown },
+): Operation<T>;
+export function dispatch<T = Val>(
+  effectIdOrRequest: string | { readonly effectId: string; readonly data: unknown },
+  maybeData?: Val,
+): Operation<T> {
+  if (typeof effectIdOrRequest === "string") {
+    return EffectsApi.operations.dispatch(effectIdOrRequest, maybeData as Val) as Operation<T>;
+  }
+  return EffectsApi.operations.dispatch(
+    effectIdOrRequest.effectId,
+    effectIdOrRequest.data as Val,
+  ) as Operation<T>;
+}
 
 /**
  * Query the Effects middleware chain to check if an agent is bound.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -13,7 +13,6 @@ export { Agents } from "./agents.js";
 export type { AgentHandle } from "./use-agent.js";
 export type { AgentFacade } from "./facade.js";
 export { evaluateMiddlewareFn } from "./middleware-eval.js";
-export { invoke } from "./invoke.js";
 export { resource, provide } from "./workflow.js";
 export type {
   OperationSpec,
@@ -22,7 +21,6 @@ export type {
   DeclaredAgent,
   AgentImplementation,
   ImplementationHandlers,
-  Invocation,
   ArgsOf,
   ResultOf,
   Workflow,

--- a/packages/agent/src/invoke.ts
+++ b/packages/agent/src/invoke.ts
@@ -1,9 +1,0 @@
-import type { Operation } from "effection";
-import type { Val } from "@tisyn/ir";
-import type { Invocation } from "./types.js";
-import { dispatch } from "./dispatch.js";
-
-/** Convert an Invocation to a dispatch call. */
-export function* invoke<T = Val>(invocation: Invocation): Operation<T> {
-  return (yield* dispatch(invocation.effectId, invocation.data as Val)) as T;
-}

--- a/packages/runtime/src/over-the-wire.test.ts
+++ b/packages/runtime/src/over-the-wire.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
-import { agent, operation, implementAgent, invoke } from "@tisyn/agent";
+import { agent, operation, implementAgent, dispatch } from "@tisyn/agent";
 import { executeRemote } from "./execute-remote.js";
 import type { Json } from "@tisyn/ir";
 
@@ -29,7 +29,7 @@ describe("Over the wire", () => {
       // Install shopify agent that uses GraphQL internally
       const shopifyImpl = implementAgent(shopify, {
         *createOrder(input) {
-          return yield* invoke(
+          return yield* dispatch(
             graphql.execute({
               document:
                 "mutation CreateOrder($input: CreateOrderInput!) { createOrder(input: $input) { orderId status } }",
@@ -45,7 +45,7 @@ describe("Over the wire", () => {
         customerId: "123",
         lineItems: [{ sku: "ABC", quantity: 2 }],
       });
-      const result = yield* invoke(invocation);
+      const result = yield* dispatch(invocation);
 
       expect(result).toEqual({
         orderId: "order-1",

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -103,7 +103,7 @@ On the remote side, adapters such as `createProtocolServer()` and `createStdioAg
 ## Example
 
 ```ts
-import { agent, operation, invoke } from "@tisyn/agent";
+import { agent, operation, dispatch } from "@tisyn/agent";
 import { installRemoteAgent } from "@tisyn/transport";
 import { websocketTransport } from "@tisyn/transport/websocket";
 
@@ -116,7 +116,7 @@ yield* installRemoteAgent(
   websocketTransport({ url: "ws://localhost:8080" }),
 );
 
-const result = yield* invoke(math.double({ input: { value: 21 } }));
+const result = yield* dispatch(math.double({ input: { value: 21 } }));
 ```
 
 ## Choosing a Transport

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -230,7 +230,7 @@ yield* scoped(function* () {
 
 `@tisyn/transport/browser` exports:
 
-- `Browser` — a `DeclaredAgent` for use with `installRemoteAgent(Browser, factory)` and `invoke(Browser.navigate(...))` / `invoke(Browser.execute(...))`
+- `Browser` — a `DeclaredAgent` for use with `installRemoteAgent(Browser, factory)` and `dispatch(Browser.navigate(...))` / `dispatch(Browser.execute(...))`
 - `browserTransport` — transport factory
 - `LocalCapability` — composition primitive type
 - `localCapability` — capability constructor

--- a/packages/transport/src/cross-boundary-middleware.test.ts
+++ b/packages/transport/src/cross-boundary-middleware.test.ts
@@ -22,7 +22,6 @@ import { Fn, Q, Throw, If, Eq, Ref, Eval } from "@tisyn/ir";
 import {
   agent,
   operation,
-  invoke,
   implementAgent,
   installCrossBoundaryMiddleware,
   Effects,
@@ -65,7 +64,7 @@ describe("cross-boundary middleware", () => {
       yield* installCrossBoundaryMiddleware(alwaysDeny);
 
       try {
-        yield* invoke(calc.add({ a: 1, b: 2 }));
+        yield* dispatch(calc.add({ a: 1, b: 2 }));
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -89,7 +88,7 @@ describe("cross-boundary middleware", () => {
     yield* scoped(function* () {
       yield* installRemoteAgent(calc, factory);
       // No installCrossBoundaryMiddleware call
-      const result = yield* invoke(calc.add({ a: 3, b: 4 }));
+      const result = yield* dispatch(calc.add({ a: 3, b: 4 }));
       expect(result).toBe(7);
     });
   });
@@ -112,7 +111,7 @@ describe("cross-boundary middleware", () => {
       yield* installRemoteAgent(calc, factory);
       yield* installCrossBoundaryMiddleware(shortCircuit);
 
-      const result = yield* invoke(calc.add({ a: 1, b: 2 }));
+      const result = yield* dispatch(calc.add({ a: 1, b: 2 }));
       expect(result).toBe("short-circuit");
     });
   });
@@ -235,7 +234,7 @@ describe("cross-boundary middleware", () => {
       yield* installCrossBoundaryMiddleware(denyProbe);
 
       try {
-        yield* invoke(child.op({ a: 1, b: 2 }));
+        yield* dispatch(child.op({ a: 1, b: 2 }));
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -301,7 +300,7 @@ describe("cross-boundary middleware", () => {
       yield* installRemoteAgent(probe, factory);
       yield* installCrossBoundaryMiddleware(transform);
 
-      const log = (yield* invoke(probe.run())) as unknown as string[];
+      const log = (yield* dispatch(probe.run())) as unknown as string[];
       expect(log).toEqual(["child-max:transformed", "child-min:transformed", "core:transformed"]);
     });
   });
@@ -340,7 +339,7 @@ describe("cross-boundary middleware", () => {
       yield* installRemoteAgent(probe, factory);
       yield* installCrossBoundaryMiddleware(passthrough);
 
-      const result = (yield* invoke(probe.run({ x: 42 }))) as unknown as {
+      const result = (yield* dispatch(probe.run({ x: 42 }))) as unknown as {
         receivedEffectId: string;
         receivedData: { x: number };
       };

--- a/packages/transport/src/scope-isolation.test.ts
+++ b/packages/transport/src/scope-isolation.test.ts
@@ -18,7 +18,6 @@ import { Fn, Throw } from "@tisyn/ir";
 import {
   agent,
   operation,
-  invoke,
   Effects,
   installCrossBoundaryMiddleware,
   dispatch,
@@ -73,7 +72,7 @@ describe("inprocessTransport scope isolation", () => {
 
       yield* installRemoteAgent(calc, factory);
 
-      const result = yield* invoke(calc.add({ a: 1, b: 2 }));
+      const result = yield* dispatch(calc.add({ a: 1, b: 2 }));
       expect(result).toBe(3);
     });
   });
@@ -108,7 +107,7 @@ describe("inprocessTransport scope isolation", () => {
       yield* installCrossBoundaryMiddleware(alwaysDeny);
 
       try {
-        yield* invoke(calc.add({ a: 1, b: 2 }));
+        yield* dispatch(calc.add({ a: 1, b: 2 }));
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -152,7 +151,7 @@ describe("inprocessTransport scope isolation", () => {
       yield* installRemoteAgent(helper, helperFactory);
 
       try {
-        yield* invoke(helper.run({ a: 1, b: 2 }));
+        yield* dispatch(helper.run({ a: 1, b: 2 }));
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -199,7 +198,7 @@ describe("inprocessTransport scope isolation", () => {
 
       yield* installRemoteAgent(calc, factory);
 
-      const result = yield* invoke(calc.add({ a: 1, b: 2 }));
+      const result = yield* dispatch(calc.add({ a: 1, b: 2 }));
       expect(result).toBe(3);
     });
   });

--- a/packages/transport/src/transport-compliance.ts
+++ b/packages/transport/src/transport-compliance.ts
@@ -6,7 +6,7 @@ import type { Operation } from "effection";
 import type { Val } from "@tisyn/ir";
 import type { AgentDeclaration, OperationSpec, ImplementationHandlers } from "@tisyn/agent";
 import type { AgentTransportFactory, HostMessage } from "./transport.js";
-import { agent, operation, Effects, dispatch, invoke } from "@tisyn/agent";
+import { agent, operation, Effects, dispatch } from "@tisyn/agent";
 import { installRemoteAgent } from "./install-remote.js";
 import { parseEffectId } from "@tisyn/kernel";
 
@@ -56,7 +56,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
 
         yield* scoped(function* () {
           yield* installRemoteAgent(math, recordingFactory);
-          yield* invoke(math.double({ value: 21 }));
+          yield* dispatch(math.double({ value: 21 }));
         });
 
         const initIndex = messages.findIndex((m) => m.method === "initialize");
@@ -91,9 +91,9 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
 
         yield* scoped(function* () {
           yield* installRemoteAgent(math, recordingFactory);
-          yield* invoke(math.double({ value: 1 }));
-          yield* invoke(math.double({ value: 2 }));
-          yield* invoke(math.double({ value: 3 }));
+          yield* dispatch(math.double({ value: 1 }));
+          yield* dispatch(math.double({ value: 2 }));
+          yield* dispatch(math.double({ value: 3 }));
         });
 
         const initMessages = messages.filter((m) => m.method === "initialize");
@@ -113,9 +113,9 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
 
         yield* scoped(function* () {
           yield* installRemoteAgent(math, factory);
-          expect(yield* invoke(math.double({ value: 1 }))).toBe(2);
-          expect(yield* invoke(math.double({ value: 5 }))).toBe(10);
-          expect(yield* invoke(math.double({ value: 21 }))).toBe(42);
+          expect(yield* dispatch(math.double({ value: 1 }))).toBe(2);
+          expect(yield* dispatch(math.double({ value: 5 }))).toBe(10);
+          expect(yield* dispatch(math.double({ value: 21 }))).toBe(42);
         });
       });
 
@@ -145,7 +145,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
 
         yield* scoped(function* () {
           yield* installRemoteAgent(math, recordingFactory);
-          yield* invoke(math.double({ value: 1 }));
+          yield* dispatch(math.double({ value: 1 }));
         });
 
         const shutdownMessages = messages.filter((m) => m.method === "shutdown");
@@ -169,7 +169,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
 
         yield* scoped(function* () {
           yield* installRemoteAgent(math, factory);
-          const result = yield* invoke(math.double({ value: 21 }));
+          const result = yield* dispatch(math.double({ value: 21 }));
           expect(result).toBe(42);
         });
       });
@@ -188,7 +188,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
         yield* scoped(function* () {
           yield* installRemoteAgent(failing, factory);
           try {
-            yield* invoke(failing.boom());
+            yield* dispatch(failing.boom());
             expect.unreachable("should have thrown");
           } catch (error) {
             expect(error).toBeInstanceOf(Error);
@@ -211,7 +211,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
         yield* scoped(function* () {
           yield* installRemoteAgent(math, factory);
           try {
-            yield* invoke({ effectId: "math-unknown.nonexistent", data: {} });
+            yield* dispatch({ effectId: "math-unknown.nonexistent", data: {} });
             expect.unreachable("should have thrown");
           } catch (error) {
             expect(error).toBeInstanceOf(Error);
@@ -267,7 +267,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
         yield* scoped(function* () {
           yield* installRemoteAgent(failing, factory);
           try {
-            yield* invoke(failing.boom());
+            yield* dispatch(failing.boom());
             expect.unreachable("should have thrown");
           } catch (error) {
             expect(error).toBeInstanceOf(Error);
@@ -310,7 +310,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
         yield* scoped(function* () {
           yield* installRemoteAgent(slow, recordingFactory);
           const task = yield* spawn(function* () {
-            yield* invoke(slow.work());
+            yield* dispatch(slow.work());
           });
           // Wait until the execute request has been sent before halting
           yield* when(function* () {
@@ -356,7 +356,7 @@ export function transportComplianceSuite(name: string, createFactory: TransportF
           });
 
           // Remote agent should work
-          expect(yield* invoke(math.double({ value: 5 }))).toBe(10);
+          expect(yield* dispatch(math.double({ value: 5 }))).toBe(10);
 
           // Local agent should also work
           const localResult = yield* dispatch("local.op", null);

--- a/packages/transport/src/transports/browser.test.ts
+++ b/packages/transport/src/transports/browser.test.ts
@@ -342,7 +342,9 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        yield* dispatch(Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 1, b: 2 }) }));
+        yield* dispatch(
+          Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 1, b: 2 }) }),
+        );
       });
 
       // Playwright should never have been launched

--- a/packages/transport/src/transports/browser.test.ts
+++ b/packages/transport/src/transports/browser.test.ts
@@ -1,8 +1,7 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect, vi, beforeEach } from "vitest";
 import { scoped } from "effection";
-import { invoke } from "@tisyn/agent";
-import { agent, operation } from "@tisyn/agent";
+import { agent, operation, dispatch } from "@tisyn/agent";
 import { Fn } from "@tisyn/ir";
 import type { IrInput } from "@tisyn/ir";
 import { installRemoteAgent } from "../install-remote.js";
@@ -111,7 +110,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        const result = yield* invoke(
+        const result = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 3, b: 4 }) }),
         );
         expect(result).toBe(7);
@@ -130,12 +129,12 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
 
-        const sum = yield* invoke(
+        const sum = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 10, b: 20 }) }),
         );
         expect(sum).toBe(30);
 
-        const greeting = yield* invoke(
+        const greeting = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("greet", "hello", { name: "World" }) }),
         );
         expect(greeting).toBe("Hello, World!");
@@ -149,7 +148,7 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
         try {
-          yield* invoke(
+          yield* dispatch(
             Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 1, b: 2 }) }),
           );
           expect.unreachable("should have thrown");
@@ -170,14 +169,14 @@ describe("browser transport", () => {
         yield* installRemoteAgent(Browser, factory);
 
         // Calc works
-        const sum = yield* invoke(
+        const sum = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 1, b: 2 }) }),
         );
         expect(sum).toBe(3);
 
         // Greet fails — no host fallback
         try {
-          yield* invoke(
+          yield* dispatch(
             Browser.execute({ workflow: effectWorkflow("greet", "hello", { name: "X" }) }),
           );
           expect.unreachable("should have thrown");
@@ -199,7 +198,7 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
         // Execute to trigger transport setup
-        yield* invoke(Browser.execute({ workflow: literalWorkflow(42) }));
+        yield* dispatch(Browser.execute({ workflow: literalWorkflow(42) }));
       });
 
       expect(mockContext.addInitScript).toHaveBeenCalledWith({
@@ -218,7 +217,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        const result = yield* invoke(Browser.execute({ workflow: literalWorkflow("ignored") }));
+        const result = yield* dispatch(Browser.execute({ workflow: literalWorkflow("ignored") }));
         expect(result).toEqual(expectedResult);
       });
 
@@ -238,7 +237,7 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
         try {
-          yield* invoke(Browser.execute({ workflow: literalWorkflow(null) }));
+          yield* dispatch(Browser.execute({ workflow: literalWorkflow(null) }));
           expect.unreachable("should have thrown");
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
@@ -259,7 +258,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        const result = yield* invoke(
+        const result = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 100, b: 200 }) }),
         );
         expect(JSON.parse(JSON.stringify(result))).toEqual(result);
@@ -277,7 +276,7 @@ describe("browser transport", () => {
         yield* installRemoteAgent(Browser, factory);
         try {
           // Pass IR that references nonexistent agent — causes runtime error
-          yield* invoke(Browser.execute({ workflow: effectWorkflow("nonexistent", "op", {}) }));
+          yield* dispatch(Browser.execute({ workflow: effectWorkflow("nonexistent", "op", {}) }));
           expect.unreachable("should have thrown");
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
@@ -305,10 +304,10 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
 
-        const r1 = yield* invoke(
+        const r1 = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("counting", "inc", {}) }),
         );
-        const r2 = yield* invoke(
+        const r2 = yield* dispatch(
           Browser.execute({ workflow: effectWorkflow("counting", "inc", {}) }),
         );
 
@@ -330,7 +329,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        const result = yield* invoke(Browser.execute({ workflow: literalWorkflow(42) }));
+        const result = yield* dispatch(Browser.execute({ workflow: literalWorkflow(42) }));
         expect(result).toBe(42);
       });
     });
@@ -343,7 +342,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        yield* invoke(Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 1, b: 2 }) }));
+        yield* dispatch(Browser.execute({ workflow: effectWorkflow("calc", "add", { a: 1, b: 2 }) }));
       });
 
       // Playwright should never have been launched
@@ -359,7 +358,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        yield* invoke(Browser.execute({ workflow: literalWorkflow("hello") }));
+        yield* dispatch(Browser.execute({ workflow: literalWorkflow("hello") }));
       });
 
       expect(mockBrowser.close).toHaveBeenCalled();
@@ -376,7 +375,7 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        yield* invoke(Browser.navigate({ url: "https://example.com" }));
+        yield* dispatch(Browser.navigate({ url: "https://example.com" }));
       });
 
       expect(mockPage.goto).toHaveBeenCalledWith("https://example.com");
@@ -390,8 +389,8 @@ describe("browser transport", () => {
 
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
-        yield* invoke(Browser.navigate({ url: "https://example.com/app" }));
-        yield* invoke(Browser.execute({ workflow: literalWorkflow("test") }));
+        yield* dispatch(Browser.navigate({ url: "https://example.com/app" }));
+        yield* dispatch(Browser.execute({ workflow: literalWorkflow("test") }));
       });
 
       expect(mockPage.goto).toHaveBeenCalledWith("https://example.com/app");
@@ -409,7 +408,7 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
         try {
-          yield* invoke(Browser.navigate({ url: "https://unreachable.test" }));
+          yield* dispatch(Browser.navigate({ url: "https://unreachable.test" }));
           expect.unreachable("should have thrown");
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
@@ -431,7 +430,7 @@ describe("browser transport", () => {
       yield* scoped(function* () {
         yield* installRemoteAgent(Browser, factory);
         try {
-          yield* invoke(Browser.navigate({ url: "https://example.com" }));
+          yield* dispatch(Browser.navigate({ url: "https://example.com" }));
           expect.unreachable("should have thrown");
         } catch (error) {
           expect(error).toBeInstanceOf(Error);

--- a/packages/transport/src/transports/sse-post.test.ts
+++ b/packages/transport/src/transports/sse-post.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from "node:net";
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
 import { resource, useScope, withResolvers, scoped, spawn } from "effection";
-import { agent, operation, invoke, implementAgent } from "@tisyn/agent";
+import { agent, operation, dispatch, implementAgent } from "@tisyn/agent";
 import { installRemoteAgent } from "../install-remote.js";
 import { createProtocolServer } from "../protocol-server.js";
 import { transportComplianceSuite } from "../transport-compliance.js";
@@ -91,7 +91,7 @@ describe("sse-post transport specific", () => {
       for (let i = 1; i <= 5; i++) {
         tasks.push(
           yield* spawn(function* () {
-            return yield* invoke(math.double({ value: i }));
+            return yield* dispatch(math.double({ value: i }));
           }),
         );
       }
@@ -161,7 +161,7 @@ describe("sse-post transport specific", () => {
 
       try {
         yield* installRemoteAgent(slow, factory);
-        yield* invoke(slow.work());
+        yield* dispatch(slow.work());
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);

--- a/packages/transport/src/transports/stdio.test.ts
+++ b/packages/transport/src/transports/stdio.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
 import { spawn, scoped, sleep } from "effection";
-import { agent, operation, invoke } from "@tisyn/agent";
+import { agent, operation, dispatch } from "@tisyn/agent";
 import { installRemoteAgent } from "../install-remote.js";
 import { stdioTransport } from "./stdio.js";
 import { resolve } from "node:path";
@@ -25,7 +25,7 @@ describe("stdio transport", () => {
       });
 
       yield* installRemoteAgent(math, fixtureTransport("math-agent"));
-      const result = yield* invoke(math.double({ value: 21 }));
+      const result = yield* dispatch(math.double({ value: 21 }));
       expect(result).toBe(42);
     });
 
@@ -36,7 +36,7 @@ describe("stdio transport", () => {
 
       yield* installRemoteAgent(failing, fixtureTransport("failing-agent"));
       try {
-        yield* invoke(failing.boom());
+        yield* dispatch(failing.boom());
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -50,9 +50,9 @@ describe("stdio transport", () => {
       });
 
       yield* installRemoteAgent(math, fixtureTransport("math-agent"));
-      expect(yield* invoke(math.double({ value: 1 }))).toBe(2);
-      expect(yield* invoke(math.double({ value: 5 }))).toBe(10);
-      expect(yield* invoke(math.double({ value: 21 }))).toBe(42);
+      expect(yield* dispatch(math.double({ value: 1 }))).toBe(2);
+      expect(yield* dispatch(math.double({ value: 5 }))).toBe(10);
+      expect(yield* dispatch(math.double({ value: 21 }))).toBe(42);
     });
 
     it("cancel on interruption", function* () {
@@ -62,7 +62,7 @@ describe("stdio transport", () => {
 
       yield* installRemoteAgent(slow, fixtureTransport("slow-agent"));
       const task = yield* spawn(function* () {
-        yield* invoke(slow.work());
+        yield* dispatch(slow.work());
       });
       yield* sleep(100);
       yield* task.halt();
@@ -74,10 +74,10 @@ describe("stdio transport", () => {
         double: operation<{ value: number }, number>(),
       });
 
-      // Scope exits cleanly after invoke
+      // Scope exits cleanly after dispatch
       yield* scoped(function* () {
         yield* installRemoteAgent(math, fixtureTransport("math-agent"));
-        yield* invoke(math.double({ value: 1 }));
+        yield* dispatch(math.double({ value: 1 }));
       });
       // No timeout = process exited cleanly
     });
@@ -91,7 +91,7 @@ describe("stdio transport", () => {
 
       yield* installRemoteAgent(badAgent, fixtureTransport("bad-json-agent"));
       try {
-        yield* invoke(badAgent.op());
+        yield* dispatch(badAgent.op());
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -105,7 +105,7 @@ describe("stdio transport", () => {
 
       yield* installRemoteAgent(crashAgent, fixtureTransport("crash-agent"));
       try {
-        yield* invoke(crashAgent.op());
+        yield* dispatch(crashAgent.op());
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);
@@ -121,7 +121,7 @@ describe("stdio transport", () => {
       // Fire multiple requests rapidly to test framing
       const results = [];
       for (let i = 1; i <= 10; i++) {
-        results.push(yield* invoke(math.double({ value: i })));
+        results.push(yield* dispatch(math.double({ value: i })));
       }
       expect(results).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
     });

--- a/packages/transport/src/transports/websocket.test.ts
+++ b/packages/transport/src/transports/websocket.test.ts
@@ -6,7 +6,7 @@ import { resource, useScope, withResolvers, createQueue, scoped, spawn } from "e
 import { WebSocketServer } from "ws";
 import type { HostMessage } from "@tisyn/protocol";
 import { parseHostMessage } from "@tisyn/protocol";
-import { agent, operation, invoke, implementAgent } from "@tisyn/agent";
+import { agent, operation, dispatch, implementAgent } from "@tisyn/agent";
 import { installRemoteAgent } from "../install-remote.js";
 import { createProtocolServer } from "../protocol-server.js";
 import { transportComplianceSuite } from "../transport-compliance.js";
@@ -96,7 +96,7 @@ describe("websocket transport specific", () => {
       for (let i = 1; i <= 5; i++) {
         tasks.push(
           yield* spawn(function* () {
-            return yield* invoke(math.double({ value: i }));
+            return yield* dispatch(math.double({ value: i }));
           }),
         );
       }
@@ -149,7 +149,7 @@ describe("websocket transport specific", () => {
 
       try {
         yield* installRemoteAgent(slow, factory);
-        yield* invoke(slow.work());
+        yield* dispatch(slow.work());
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(Error);

--- a/packages/transport/src/transports/worker.test.ts
+++ b/packages/transport/src/transports/worker.test.ts
@@ -4,7 +4,7 @@ import { expect } from "vitest";
 import { resource, useScope, createQueue, createChannel, spawn } from "effection";
 import type { HostMessage } from "@tisyn/protocol";
 import { parseHostMessage, parseAgentMessage } from "@tisyn/protocol";
-import { agent, operation, invoke, implementAgent } from "@tisyn/agent";
+import { agent, operation, dispatch, implementAgent } from "@tisyn/agent";
 import { installRemoteAgent } from "../install-remote.js";
 import { createProtocolServer } from "../protocol-server.js";
 import { transportComplianceSuite } from "../transport-compliance.js";
@@ -94,7 +94,7 @@ describe("worker transport (real worker)", () => {
 
     yield* installRemoteAgent(math, factory);
 
-    const result = yield* invoke(math.double({ value: 21 }));
+    const result = yield* dispatch(math.double({ value: 21 }));
     expect(result).toBe(42);
   });
 
@@ -113,7 +113,7 @@ describe("worker transport (real worker)", () => {
     for (let i = 1; i <= 5; i++) {
       tasks.push(
         yield* spawn(function* () {
-          return yield* invoke(math.double({ value: i }));
+          return yield* dispatch(math.double({ value: i }));
         }),
       );
     }
@@ -138,7 +138,7 @@ describe("worker transport (real worker)", () => {
     yield* installRemoteAgent(failing, factory);
 
     try {
-      yield* invoke(failing.boom());
+      yield* dispatch(failing.boom());
       expect.unreachable("should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(Error);

--- a/specs/tisyn-browser-contract-test-plan.md
+++ b/specs/tisyn-browser-contract-test-plan.md
@@ -112,7 +112,7 @@ separately.
 
 - **In-process composition:** Uses `browserTransport({ capabilities })` with test agents (`Calc`, `Greet`) defined via `localCapability()`. No Playwright mock needed.
 - **Real-browser mode:** Mocks `playwright-core` at module level. `page.evaluate` returns predetermined result envelopes. `page.addScriptTag`, `page.waitForFunction`, and `page.goto` are verified.
-- **Navigate tests:** Use `Browser.navigate({ url })` via `invoke`. Real-browser tests verify `mockPage.goto` calls. In-process test verifies thrown error.
+- **Navigate tests:** Use `Browser.navigate({ url })` via `dispatch`. Real-browser tests verify `mockPage.goto` calls. In-process test verifies thrown error.
 
 ### 3.2 Compiler Acceptance Tests
 


### PR DESCRIPTION
## Summary

- Remove the public `invoke(invocation)` helper and `Invocation` type export from `@tisyn/agent`, freeing the `invoke` name for upcoming nested-invocation work.
- Widen `dispatch(...)` with an overload so it accepts either `(effectId, data)` or the `{ effectId, data }` descriptor returned by `agent().op(args)`. No new named descriptor type is exported — the overload uses an inline structural shape.
- Migrate ~70 test call sites across `@tisyn/agent`, `@tisyn/transport`, `@tisyn/runtime` from `yield* invoke(agent.op(args))` to `yield* dispatch(agent.op(args))`. The raw-object compliance case becomes `yield* dispatch({ effectId, data })`.
- The `Invocation` interface stays in `packages/agent/src/types.ts` as the internal return type of `OperationCall<S>`; only its re-export from `index.ts` is removed. No runtime semantics change.
- Update the three README examples (root, `@tisyn/agent`, `@tisyn/transport`) to show `dispatch(...)` instead of `invoke(...)`.

## Test plan

- [x] `pnpm --filter @tisyn/agent test` — 50/50 pass
- [x] `pnpm --filter @tisyn/transport test` — 107/107 pass (covers stdio, websocket, worker, sse-post, browser, inprocess via the shared compliance suite)
- [x] `pnpm --filter @tisyn/runtime test` — 228/228 pass
- [x] `pnpm build` — clean
- [x] `pnpm changeset status` — `@tisyn/agent` bumped minor