### PR TITLE
[codex] Add missing package READMEs

### DIFF
--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -1,0 +1,69 @@
+# `@tisyn/claude-code`
+
+`@tisyn/claude-code` adapts Claude Code to the portable `@tisyn/code-agent` contract.
+
+It lets Tisyn workflows talk to Claude Code through the same session-oriented operations used by other coding-agent backends, while hiding the details of ACP JSON-RPC or the Claude Agent SDK.
+
+## Where It Fits
+
+`@tisyn/claude-code` sits above the portable contract and below transport/session wiring.
+
+- `@tisyn/code-agent` defines the backend-neutral coding-agent contract.
+- `@tisyn/claude-code` translates that contract into Claude Code-specific protocols.
+- `@tisyn/transport` installs the binding into a Tisyn execution scope.
+- `@tisyn/protocol` provides the Tisyn-side execute/progress message shapes the binding emits.
+
+Use this package when you want a Claude-backed implementation of the `CodeAgent` contract.
+
+## What It Provides
+
+The public surface exported from `src/index.ts` includes:
+
+- `createBinding` — create a `LocalAgentBinding` backed by a Claude Code ACP process
+- `createSdkBinding` — create a `LocalAgentBinding` backed by the Claude Agent SDK
+- `createMockClaudeCodeTransport` — mock transport for tests
+- `AcpAdapterConfig` — configuration for the ACP stdio adapter
+- `SdkAdapterConfig` — configuration for the SDK-backed adapter
+- `SessionHandle`, `PromptResult`, `ForkData` — portable contract types re-exported from `@tisyn/code-agent`
+- `PlanResult` — Claude-specific prompt result extension that can include tool results
+
+## Adapter Shapes
+
+### ACP binding
+
+`createBinding()` connects Tisyn protocol messages to a Claude Code ACP stdio process.
+
+It is responsible for:
+
+- spawning or attaching to an ACP process
+- translating Tisyn execute requests into ACP JSON-RPC requests
+- translating ACP success/error/progress messages back into Tisyn protocol messages
+- synthesizing the Tisyn initialize response ACP does not speak natively
+
+### SDK binding
+
+`createSdkBinding()` uses `@anthropic-ai/claude-agent-sdk` directly instead of going through ACP stdio.
+
+It is responsible for:
+
+- creating persistent SDK sessions
+- streaming progress events back into the Tisyn protocol shape
+- mapping Tisyn operations such as `newSession`, `plan`, `fork`, and `openFork` onto SDK calls
+
+## Relationship to Other Packages
+
+- [`@tisyn/code-agent`](../code-agent/README.md) supplies the contract this package implements.
+- [`@tisyn/transport`](../transport/README.md) consumes the returned `LocalAgentBinding`.
+- [`@tisyn/protocol`](../protocol/README.md) provides the execute/progress message helpers used on the Tisyn side.
+- [`@tisyn/agent`](../agent/README.md) remains the declaration layer; this package is an implementation adapter, not a contract definition package.
+
+## Boundaries
+
+`@tisyn/claude-code` does not:
+
+- define the portable coding-agent contract
+- define general Tisyn transport/session semantics
+- compile workflows
+- own the higher-level review/spec workflows that happen to use Claude Code
+
+It exists specifically to make Claude Code conform to the shared `CodeAgent` surface.

--- a/packages/code-agent/README.md
+++ b/packages/code-agent/README.md
@@ -1,0 +1,59 @@
+# `@tisyn/code-agent`
+
+`@tisyn/code-agent` defines the portable agent contract for session-oriented coding agents.
+
+It gives Tisyn workflows one stable capability surface for "open a coding session, send a prompt, fork it, resume it, close it" without baking any particular backend into the workflow. Concrete backends such as Claude Code or Codex implement this contract in separate packages.
+
+## Where It Fits
+
+`@tisyn/code-agent` sits between authored workflows and backend-specific adapter packages.
+
+- `@tisyn/agent` provides the typed declaration machinery used to define the contract.
+- `@tisyn/code-agent` names the portable operations and shared result types.
+- `@tisyn/claude-code` and `@tisyn/codex` adapt real coding-agent backends to this contract.
+- `@tisyn/transport` installs those adapters as local or remote capabilities.
+
+Use this package when workflow code should depend on a generic "coding agent" capability instead of a specific vendor.
+
+## What It Provides
+
+The public surface exported from `src/index.ts` includes:
+
+- `CodeAgent` — the portable declared agent contract with `newSession`, `closeSession`, `prompt`, `fork`, and `openFork`
+- `SessionHandle` — workflow-visible session identifier
+- `PromptResult` — standard result for prompt operations
+- `ForkData` — handle data needed to reopen a forked session
+- `NewSessionConfig` — portable new-session input shape
+- `PromptArgs` — portable prompt input shape
+- `createMockCodeAgentTransport` — test helper for mocking a conforming code-agent transport
+- `MockCodeAgentConfig`, `MockOperationConfig` — mock transport configuration types
+
+## Contract Shape
+
+`CodeAgent` is declared as a normal Tisyn agent:
+
+- `newSession(config)` — create a backend session and return a `SessionHandle`
+- `closeSession(handle)` — close a session
+- `prompt(args)` — send a prompt to an existing session and return `PromptResult`
+- `fork(session)` — fork an existing session and return `ForkData`
+- `openFork(data)` — reopen a previously created fork and return a new `SessionHandle`
+
+The types in this package are intentionally small and portable. Backend-specific extensions belong in adapter packages, not in the shared contract.
+
+## Relationship to Other Packages
+
+- [`@tisyn/agent`](../agent/README.md) supplies the declaration and operation primitives.
+- [`@tisyn/claude-code`](../claude-code/README.md) implements this contract for Claude Code.
+- [`@tisyn/codex`](../codex/README.md) implements this contract for Codex.
+- [`@tisyn/transport`](../transport/README.md) carries these declared operations across local or remote boundaries.
+
+## Boundaries
+
+`@tisyn/code-agent` does not:
+
+- spawn subprocesses
+- speak vendor protocols
+- manage stdio or SDK integration
+- define vendor-specific result extensions
+
+It only defines the shared coding-agent contract that adapters implement.

--- a/packages/codex/README.md
+++ b/packages/codex/README.md
@@ -1,0 +1,67 @@
+# `@tisyn/codex`
+
+`@tisyn/codex` adapts OpenAI Codex to the portable `@tisyn/code-agent` contract.
+
+It gives Tisyn workflows a Codex-backed coding-agent implementation without forcing workflow code to know whether Codex is reached through the TypeScript SDK or the `codex exec` CLI.
+
+## Where It Fits
+
+`@tisyn/codex` occupies the same role for Codex that `@tisyn/claude-code` does for Claude Code.
+
+- `@tisyn/code-agent` defines the portable coding-agent contract.
+- `@tisyn/codex` implements that contract for Codex.
+- `@tisyn/transport` installs the returned binding into a local or remote Tisyn scope.
+
+Use this package when you want Codex to satisfy the standard coding-agent contract used by workflows.
+
+## What It Provides
+
+The public surface exported from `src/index.ts` includes:
+
+- `createSdkBinding` — create a `LocalAgentBinding` backed by `@openai/codex-sdk`
+- `createExecBinding` — create a `LocalAgentBinding` backed by `codex exec --json`
+- `CodexSdkConfig` — configuration for the SDK-backed adapter
+- `CodexExecConfig` — configuration for the CLI-backed adapter
+- `SessionHandle`, `PromptResult`, `ForkData` — portable contract types re-exported from `@tisyn/code-agent`
+
+## Adapter Modes
+
+### SDK binding
+
+`createSdkBinding()` is the conforming adapter.
+
+It creates persistent Codex threads and maps the portable contract onto SDK operations such as:
+
+- session creation
+- streamed prompt execution
+- session close
+
+This is the adapter to use when prompts in the same session must preserve conversation history.
+
+### Exec binding
+
+`createExecBinding()` is a convenience adapter around `codex exec --json`.
+
+It is intentionally weaker:
+
+- each prompt runs in its own subprocess
+- no conversation history is preserved between prompts
+- it does not fully satisfy the portable `CodeAgent` contract's sequential-session expectations
+
+It is useful for CI-like workflows where each prompt is independent, but it is not the contract-faithful backend.
+
+## Relationship to Other Packages
+
+- [`@tisyn/code-agent`](../code-agent/README.md) defines the contract this package implements.
+- [`@tisyn/transport`](../transport/README.md) consumes the returned bindings.
+- [`@tisyn/agent`](../agent/README.md) remains the declaration layer beneath the contract.
+
+## Boundaries
+
+`@tisyn/codex` does not:
+
+- define the shared coding-agent contract
+- define the Tisyn protocol or session model
+- guarantee every Codex invocation mode is equally capable
+
+It exists to make Codex usable behind the `CodeAgent` contract, with the SDK adapter as the primary conforming path.

--- a/packages/spec-workflows/README.md
+++ b/packages/spec-workflows/README.md
@@ -1,0 +1,65 @@
+# `@tisyn/spec-workflows`
+
+`@tisyn/spec-workflows` packages the authored workflows used to draft, amend, review, and verify the Tisyn specification corpus.
+
+It exists because the corpus pipeline needs workflow-shaped entrypoints and agent wiring that sit above `@tisyn/spec`'s pure data/model logic. `@tisyn/spec` knows how to acquire, assemble, compare, and validate corpus data; this package turns that capability into runnable workflows and workflow-local bindings.
+
+## Where It Fits
+
+`@tisyn/spec-workflows` sits above the corpus library and below operator-facing CLI runs.
+
+- `@tisyn/spec` owns corpus acquisition, comparison, readiness, and authoring-context assembly.
+- `@tisyn/config` supplies the workflow descriptors and runtime wiring vocabulary.
+- `@tisyn/agent`, `@tisyn/transport`, and `@tisyn/claude-code` provide the capability boundaries these workflows call through.
+- `@tisyn/cli` executes these workflows through `tsn run`.
+
+Use this package when you want to run the spec-authoring pipeline itself, not when you just need the underlying corpus library APIs.
+
+## What It Provides
+
+The public surface exported from `src/index.ts` includes:
+
+- `draftSpec` — assemble authoring context for a new or expanded spec
+- `amendSpec` — assemble amendment context for an existing spec/section
+- `reviewSpec` — assemble review context for a target spec
+- `draftTestPlan` — assemble authoring context for a test plan
+- `consistencyCheck` — run a consistency-oriented assembly/check workflow
+
+These are the simple acquire-and-assemble workflows intended to be imported as library entrypoints.
+
+## Workflow Modules vs. Exported Helpers
+
+This package also contains full workflow descriptor modules that are intentionally not re-exported from `src/index.ts`, such as:
+
+- `verify-corpus.ts`
+- `claude-reviewer.ts`
+- `filesystem-agent.ts`
+- `corpus-agent.ts`
+- `output-agent.ts`
+
+Those files are meant to be executed directly with `tsn run` or loaded as workflow descriptors. They combine:
+
+- authored generator bodies
+- ambient agent contracts
+- config/workflow descriptor wiring
+- runtime journal and transport setup
+
+Keeping them as direct workflow modules avoids pulling workflow-descriptor wiring into ordinary library imports.
+
+## Relationship to Other Packages
+
+- [`@tisyn/spec`](../spec/README.md) is the core corpus/model package this package orchestrates.
+- [`@tisyn/config`](../config/README.md) defines the workflow descriptor vocabulary used by runnable workflow modules.
+- [`@tisyn/claude-code`](../claude-code/README.md) provides the Claude-backed coding agent used by reviewer/verification flows.
+- [`@tisyn/transport`](../transport/README.md) installs those bindings into execution scopes.
+- [`@tisyn/agent`](../agent/README.md) provides the typed capability declarations used inside the workflows.
+
+## Boundaries
+
+`@tisyn/spec-workflows` does not:
+
+- own the corpus data model
+- replace the lower-level `@tisyn/spec` APIs
+- define the general Tisyn runtime or transport systems
+
+It exists to package the corpus-oriented workflows and the workflow-local wiring needed to run them.


### PR DESCRIPTION
## Summary

- add README files for `@tisyn/claude-code`, `@tisyn/code-agent`, `@tisyn/codex`, and `@tisyn/spec-workflows`
- align the new docs with the stronger package README pattern already used in the repo
- explain for each package what it does, why it exists, how it relates to other packages, and what functionality it provides

## Impact

This fills the remaining package-level documentation gaps so every workspace package has a README with the same basic orientation structure.

## Validation

- no code or behavior changes
- no tests run (docs-only change)