### PR TITLE
Prepare framework handlers for replay boundary

### DIFF
--- a/.changeset/agent-dispatch-at-min-for-replay-boundary.md
+++ b/.changeset/agent-dispatch-at-min-for-replay-boundary.md
@@ -1,0 +1,27 @@
+---
+"@tisyn/agent": minor
+---
+
+**BREAKING:** `Agents.use()` and `implementAgent(...).install()` now
+register their dispatch middleware at `{ at: "min" }` (below user
+middleware) instead of the default max priority. User-installed
+`Effects.around` interceptors, including those installed after the
+agent binding, continue to observe and can transform a dispatch
+before the framework handler resolves it — the change to `min` makes
+the framework handler sit strictly below the user-middleware region.
+
+This prepares the ground for the replay-aware dispatch boundary
+planned in #125, which will sit between max-priority user middleware
+and min-priority framework handlers. No replay logic is introduced
+yet.
+
+`resolve` middleware (used by `useAgent` binding-probe) is **not**
+moved — it remains at default priority. The single previous
+`Effects.around({ dispatch, resolve })` registration is now split
+into two separate `Effects.around` calls so the priority change is
+scoped to dispatch only.
+
+Callers that already install their own `{ at: "min" }` core handlers
+downstream of `Agents.use` / `implementAgent` should note that two
+min-priority entries now coexist; relative ordering between them
+follows registration order.

--- a/.changeset/transport-dispatch-at-min-for-replay-boundary.md
+++ b/.changeset/transport-dispatch-at-min-for-replay-boundary.md
@@ -1,0 +1,28 @@
+---
+"@tisyn/transport": minor
+---
+
+**BREAKING:** `installRemoteAgent()` and `installAgentTransport()`
+now register their dispatch middleware at `{ at: "min" }` (below
+user middleware) instead of the default max priority. User-installed
+`Effects.around` interceptors, including those installed after the
+transport binding, continue to observe and can transform an outbound
+dispatch before the transport routes the request — the change to
+`min` makes the transport handler sit strictly below the
+user-middleware region.
+
+This prepares the ground for the replay-aware dispatch boundary
+planned in #125, which will sit between max-priority user middleware
+and min-priority framework handlers. No replay logic is introduced
+yet.
+
+`resolve` middleware (used by `useAgent` binding-probe) is **not**
+moved — it remains at default priority. The single previous
+`Effects.around({ dispatch, resolve })` registration in each
+install entry point is now split into two separate `Effects.around`
+calls so the priority change is scoped to dispatch only.
+
+Callers that already install their own `{ at: "min" }` core handlers
+downstream of `installRemoteAgent` / `installAgentTransport` should
+note that two min-priority entries now coexist; relative ordering
+between them follows registration order.

--- a/packages/agent/src/agents.test.ts
+++ b/packages/agent/src/agents.test.ts
@@ -7,6 +7,8 @@
  * AG-4: Child scope binding doesn't affect parent
  * AG-5: Root Effects.around() intercepts locally-bound agent dispatch
  * AG-6: Agents.use() for two different agents in same scope — both accessible
+ * AG-7: Default-priority middleware installed after Agents.use() observes dispatch
+ *       before the framework handler (phase-1 replay-boundary ordering prep, #125)
  */
 
 import { describe, it } from "@effectionx/vitest";
@@ -164,5 +166,34 @@ describe("Agents setup API", () => {
 
     expect(yield* calcFacade.add({ a: 5, b: 5 })).toBe(10);
     expect(yield* greeterFacade.greet({ name: "world" })).toBe("hello world");
+  });
+
+  // AG-7
+  it("default-priority middleware installed after Agents.use() observes dispatch first", function* () {
+    const calc = agent("calc-ag7", {
+      add: operation<{ a: number; b: number }, number>(),
+    });
+
+    const log: string[] = [];
+
+    yield* Agents.use(calc, {
+      *add({ a, b }) {
+        log.push("handler");
+        return a + b;
+      },
+    });
+
+    yield* Effects.around({
+      *dispatch([e, d]: [string, Val], next) {
+        log.push("interceptor");
+        return yield* next(e, d);
+      },
+    });
+
+    const facade = yield* useAgent(calc);
+    const result = yield* facade.add({ a: 3, b: 4 });
+
+    expect(result).toBe(7);
+    expect(log).toEqual(["interceptor", "handler"]);
   });
 });

--- a/packages/agent/src/agents.ts
+++ b/packages/agent/src/agents.ts
@@ -19,18 +19,24 @@ function* use<Ops extends Record<string, OperationSpec>>(
 ): Operation<void> {
   const { id } = declaration;
 
-  yield* Effects.around({
-    *dispatch([effectId, data]: [string, Val], next) {
-      const { type, name } = parseEffectId(effectId);
-      if (type === id) {
-        const handler = (handlers as Record<string, (args: Val) => Operation<Val>>)[name];
-        if (!handler) {
-          throw new Error(`Agent "${id}" has no handler for operation: ${name}`);
+  yield* Effects.around(
+    {
+      *dispatch([effectId, data]: [string, Val], next) {
+        const { type, name } = parseEffectId(effectId);
+        if (type === id) {
+          const handler = (handlers as Record<string, (args: Val) => Operation<Val>>)[name];
+          if (!handler) {
+            throw new Error(`Agent "${id}" has no handler for operation: ${name}`);
+          }
+          return yield* DispatchContext.with(undefined, () => handler(data));
         }
-        return yield* DispatchContext.with(undefined, () => handler(data));
-      }
-      return yield* next(effectId, data);
+        return yield* next(effectId, data);
+      },
     },
+    { at: "min" },
+  );
+
+  yield* Effects.around({
     *resolve([agentId]: [string], next) {
       if (agentId === id) {
         return true;

--- a/packages/agent/src/dispatch.test.ts
+++ b/packages/agent/src/dispatch.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
+import type { Val } from "@tisyn/ir";
 import { agent, operation, implementAgent } from "./index.js";
-import { dispatch } from "@tisyn/effects";
+import { dispatch, Effects } from "@tisyn/effects";
 
 describe("dispatch", () => {
   it("routes a call descriptor through installed middleware", function* () {
@@ -41,5 +42,37 @@ describe("dispatch", () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe("kaboom");
     }
+  });
+
+  // Phase-1 replay-boundary ordering prep (#125): default-priority middleware
+  // installed after impl.install() must observe dispatch before the framework
+  // handler, which now sits at { at: "min" }.
+  it("default-priority middleware installed after impl.install() observes dispatch first", function* () {
+    const math = agent("math-impl-order", {
+      double: operation<{ value: number }, number>(),
+    });
+
+    const log: string[] = [];
+
+    const impl = implementAgent(math, {
+      *double({ value }) {
+        log.push("handler");
+        return value * 2;
+      },
+    });
+
+    yield* impl.install();
+
+    yield* Effects.around({
+      *dispatch([e, d]: [string, Val], next) {
+        log.push("interceptor");
+        return yield* next(e, d);
+      },
+    });
+
+    const result = yield* dispatch(math.double({ value: 21 }));
+
+    expect(result).toBe(42);
+    expect(log).toEqual(["interceptor", "handler"]);
   });
 });

--- a/packages/agent/src/implementation.ts
+++ b/packages/agent/src/implementation.ts
@@ -28,18 +28,24 @@ export function implementAgent<Ops extends Record<string, OperationSpec>>(
     id,
     handlers,
     *install() {
-      yield* Effects.around({
-        *dispatch([effectId, data]: [string, Val], next) {
-          const { type, name } = parseEffectId(effectId);
-          if (type === id) {
-            const handler = (handlers as Record<string, (args: Val) => Operation<Val>>)[name];
-            if (!handler) {
-              throw new Error(`Agent "${id}" has no handler for operation: ${name}`);
+      yield* Effects.around(
+        {
+          *dispatch([effectId, data]: [string, Val], next) {
+            const { type, name } = parseEffectId(effectId);
+            if (type === id) {
+              const handler = (handlers as Record<string, (args: Val) => Operation<Val>>)[name];
+              if (!handler) {
+                throw new Error(`Agent "${id}" has no handler for operation: ${name}`);
+              }
+              return yield* DispatchContext.with(undefined, () => handler(data));
             }
-            return yield* DispatchContext.with(undefined, () => handler(data));
-          }
-          return yield* next(effectId, data);
+            return yield* next(effectId, data);
+          },
         },
+        { at: "min" },
+      );
+
+      yield* Effects.around({
         *resolve([agentId]: [string], next) {
           if (agentId === id) {
             return true;

--- a/packages/transport/src/cross-boundary-middleware.test.ts
+++ b/packages/transport/src/cross-boundary-middleware.test.ts
@@ -11,6 +11,10 @@
  * CBP-5: Middleware re-propagates to grandchild on re-delegation
  * CBP-6: Propagated middleware runs outermost — before child max and child min
  * CBP-7: Propagated middleware preserves standard (effectId, data) shape in child
+ * CBP-8: Default-priority middleware installed after installRemoteAgent observes
+ *        dispatch before the transport handler (phase-1 ordering prep, #125)
+ * CBP-9: Default-priority middleware installed after installAgentTransport observes
+ *        dispatch before the transport handler (phase-1 ordering prep, #125)
  */
 
 import { describe, it } from "@effectionx/vitest";
@@ -21,7 +25,7 @@ import type { Val } from "@tisyn/ir";
 import { Fn, Q, Throw, If, Eq, Ref, Eval } from "@tisyn/ir";
 import { agent, operation, implementAgent } from "@tisyn/agent";
 import { installCrossBoundaryMiddleware, Effects, dispatch } from "@tisyn/effects";
-import { installRemoteAgent } from "./install-remote.js";
+import { installRemoteAgent, installAgentTransport } from "./install-remote.js";
 import { createProtocolServer } from "./protocol-server.js";
 import { inprocessTransport } from "./transports/inprocess.js";
 import type {
@@ -339,6 +343,77 @@ describe("cross-boundary middleware", () => {
       };
       expect(result.receivedEffectId).toBe("cbp7.sentinel");
       expect(result.receivedData).toEqual({ x: 42 });
+    });
+  });
+
+  // CBP-8: installRemoteAgent now installs its dispatch at { at: "min" }, so a
+  // default-priority Effects.around installed *after* it must still observe the
+  // outbound dispatch before the transport routes the request.
+  it("default-priority middleware installed after installRemoteAgent observes dispatch first", function* () {
+    const calc = agent("calc-cbp8", {
+      add: operation<{ a: number; b: number }, number>(),
+    });
+
+    const factory = inprocessTransport(calc, {
+      *add({ a, b }: { a: number; b: number }) {
+        return a + b;
+      },
+    });
+
+    yield* scoped(function* () {
+      const log: string[] = [];
+
+      yield* installRemoteAgent(calc, factory);
+
+      yield* Effects.around({
+        *dispatch([e, d]: [string, Val], next) {
+          log.push(`before:${e}`);
+          const result = yield* next(e, d);
+          log.push(`after:${e}`);
+          return result;
+        },
+      });
+
+      const result = yield* dispatch(calc.add({ a: 3, b: 4 }));
+
+      expect(result).toBe(7);
+      expect(log).toEqual(["before:calc-cbp8.add", "after:calc-cbp8.add"]);
+    });
+  });
+
+  // CBP-9: same invariant for the agentId-string variant used by the runtime
+  // scope orchestrator and the CLI startup path.
+  it("default-priority middleware installed after installAgentTransport observes dispatch first", function* () {
+    // Declaration used only to build the inprocess server; installation is via
+    // the string-keyed installAgentTransport entry point.
+    const calc = agent("calc-cbp9", {
+      add: operation<{ a: number; b: number }, number>(),
+    });
+
+    const factory = inprocessTransport(calc, {
+      *add({ a, b }: { a: number; b: number }) {
+        return a + b;
+      },
+    });
+
+    yield* scoped(function* () {
+      const log: string[] = [];
+
+      yield* installAgentTransport("calc-cbp9", factory);
+
+      yield* Effects.around({
+        *dispatch([e, d]: [string, Val], next) {
+          log.push(`before:${e}`);
+          const result = yield* next(e, d);
+          log.push(`after:${e}`);
+          return result;
+        },
+      });
+
+      const result = yield* dispatch("calc-cbp9.add", { a: 3, b: 4 } as Val);
+
+      expect(result).toBe(7);
+      expect(log).toEqual(["before:calc-cbp9.add", "after:calc-cbp9.add"]);
     });
   });
 });

--- a/packages/transport/src/install-remote.ts
+++ b/packages/transport/src/install-remote.ts
@@ -30,47 +30,53 @@ export function* installAgentTransport(
     capabilities: { methods: [] },
   });
 
-  yield* Effects.around({
-    *dispatch([effectId, data]: [string, Val], next) {
-      const { type, name } = parseEffectId(effectId);
-      if (type === agentId) {
-        const requestId = `${agentId}:${requestCounter++}`;
-        const middleware = yield* getCrossBoundaryMiddleware();
-        const stream = session.execute(
-          executeRequest(requestId, {
-            executionId,
-            taskId: "root",
-            operation: name,
-            args: [data],
-            progressToken: requestId,
-            ...(middleware != null ? { middleware: middleware as unknown as Val } : {}),
-          }),
-        );
-        const sub = yield* stream;
-        for (;;) {
-          const item = yield* sub.next();
-          if (item.done) {
-            const result = item.value;
-            if (result.ok) {
-              return result.value as Val;
-            }
-            {
-              const err = new Error(result.error.message);
-              if (result.error.name) {
-                err.name = result.error.name;
+  yield* Effects.around(
+    {
+      *dispatch([effectId, data]: [string, Val], next) {
+        const { type, name } = parseEffectId(effectId);
+        if (type === agentId) {
+          const requestId = `${agentId}:${requestCounter++}`;
+          const middleware = yield* getCrossBoundaryMiddleware();
+          const stream = session.execute(
+            executeRequest(requestId, {
+              executionId,
+              taskId: "root",
+              operation: name,
+              args: [data],
+              progressToken: requestId,
+              ...(middleware != null ? { middleware: middleware as unknown as Val } : {}),
+            }),
+          );
+          const sub = yield* stream;
+          for (;;) {
+            const item = yield* sub.next();
+            if (item.done) {
+              const result = item.value;
+              if (result.ok) {
+                return result.value as Val;
               }
-              throw err;
+              {
+                const err = new Error(result.error.message);
+                if (result.error.name) {
+                  err.name = result.error.name;
+                }
+                throw err;
+              }
             }
-          }
-          const sink = yield* ProgressContext.get();
-          if (sink) {
-            const cid = (yield* CoroutineContext.get()) ?? "root";
-            sink({ token: requestId, effectId, coroutineId: cid, value: item.value });
+            const sink = yield* ProgressContext.get();
+            if (sink) {
+              const cid = (yield* CoroutineContext.get()) ?? "root";
+              sink({ token: requestId, effectId, coroutineId: cid, value: item.value });
+            }
           }
         }
-      }
-      return yield* next(effectId, data);
+        return yield* next(effectId, data);
+      },
     },
+    { at: "min" },
+  );
+
+  yield* Effects.around({
     *resolve([id]: [string], next) {
       if (id === agentId) {
         return true;
@@ -106,49 +112,55 @@ export function* installRemoteAgent<Ops extends Record<string, OperationSpec>>(
     },
   });
 
-  yield* Effects.around({
-    *dispatch([effectId, data]: [string, Val], next) {
-      const { type, name } = parseEffectId(effectId);
-      if (type === id) {
-        const requestId = `${id}:${requestCounter++}`;
-        const middleware = yield* getCrossBoundaryMiddleware();
+  yield* Effects.around(
+    {
+      *dispatch([effectId, data]: [string, Val], next) {
+        const { type, name } = parseEffectId(effectId);
+        if (type === id) {
+          const requestId = `${id}:${requestCounter++}`;
+          const middleware = yield* getCrossBoundaryMiddleware();
 
-        const stream = session.execute(
-          executeRequest(requestId, {
-            executionId,
-            taskId: "root",
-            operation: name,
-            args: [data],
-            progressToken: requestId,
-            ...(middleware != null ? { middleware: middleware as unknown as Val } : {}),
-          }),
-        );
+          const stream = session.execute(
+            executeRequest(requestId, {
+              executionId,
+              taskId: "root",
+              operation: name,
+              args: [data],
+              progressToken: requestId,
+              ...(middleware != null ? { middleware: middleware as unknown as Val } : {}),
+            }),
+          );
 
-        const sub = yield* stream;
-        for (;;) {
-          const item = yield* sub.next();
-          if (item.done) {
-            const result = item.value;
-            if (result.ok) {
-              return result.value as Val;
-            }
-            {
-              const err = new Error(result.error.message);
-              if (result.error.name) {
-                err.name = result.error.name;
+          const sub = yield* stream;
+          for (;;) {
+            const item = yield* sub.next();
+            if (item.done) {
+              const result = item.value;
+              if (result.ok) {
+                return result.value as Val;
               }
-              throw err;
+              {
+                const err = new Error(result.error.message);
+                if (result.error.name) {
+                  err.name = result.error.name;
+                }
+                throw err;
+              }
             }
-          }
-          const sink = yield* ProgressContext.get();
-          if (sink) {
-            const cid = (yield* CoroutineContext.get()) ?? "root";
-            sink({ token: requestId, effectId, coroutineId: cid, value: item.value });
+            const sink = yield* ProgressContext.get();
+            if (sink) {
+              const cid = (yield* CoroutineContext.get()) ?? "root";
+              sink({ token: requestId, effectId, coroutineId: cid, value: item.value });
+            }
           }
         }
-      }
-      return yield* next(effectId, data);
+        return yield* next(effectId, data);
+      },
     },
+    { at: "min" },
+  );
+
+  yield* Effects.around({
     *resolve([agentId]: [string], next) {
       if (agentId === id) {
         return true;


### PR DESCRIPTION
## Summary

Prepares the framework effect implementation handlers for the replay-aware
dispatch design in #125 by installing them at `{ at: "min" }` priority.

This keeps framework-owned terminal work below the future replay boundary
while leaving user/orchestration middleware in the default max region. No
replay-boundary logic is introduced in this PR.

## What changed

- `Agents.use` — dispatch middleware now installs at `{ at: "min" }`.
- `implementAgent(...).install` — dispatch middleware now installs at `{ at: "min" }`.
- `installAgentTransport` — dispatch middleware now installs at `{ at: "min" }`.
- `installRemoteAgent` — dispatch middleware now installs at `{ at: "min" }`.

`resolve` middleware is **not** moved. Each of the four call sites
previously registered dispatch and resolve in a single `Effects.around`
block; that registration is now split so only dispatch changes priority.
Resolve stays at default priority because it is a binding-probe lookup
for `useAgent`, not terminal work relevant to replay.

Four focused ordering regressions are added — one per moved call site —
asserting that a default-priority `Effects.around` installed **after**
the framework binding still observes dispatch before the handler runs.

## Non-goals

- No replay-boundary implementation.
- No `invokeInline` work.
- No dependency on PR #123.
- No three-lane `Effects` group implementation.
- No `@effectionx/context-api` preview dependency pinned — the existing
  published version already exposes `{ at: "min" | "max" }`, so the PR
  remains independently reviewable and landable.

## Test plan

- [x] `pnpm --filter @tisyn/agent test` — 54 passed (was 51 + 3 new ordering cases)
- [x] `pnpm --filter @tisyn/transport test` — 109 passed (was 107 + 2 new ordering cases)
- [x] `pnpm --filter @tisyn/runtime test` — 248 passed, unchanged
- [x] `pnpm run build` — green across workspace

Refs #125