### PR TITLE
Prepare replay-aware Effects middleware lanes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "postinstall": "node scripts/patch-context-api-preview.mjs",
     "build": "tsc --build",
     "test": "pnpm -r run test && pnpm run test:oxlint-plugin",
     "test:oxlint-plugin": "node --test tools/oxlint/test/*.test.mjs",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effectionx/context-api": "^0.5.3",
+    "@effectionx/context-api": "https://pkg.pr.new/@effectionx/context-api@215",
     "@effectionx/middleware": "^0.1.1",
     "@tisyn/effects": "workspace:*",
     "@tisyn/ir": "workspace:*",

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@effectionx/context-api": "^0.5.3",
+    "@effectionx/context-api": "https://pkg.pr.new/@effectionx/context-api@215",
     "@effectionx/middleware": "^0.1.1",
     "@tisyn/ir": "workspace:*",
     "@tisyn/kernel": "workspace:*"

--- a/packages/effects/src/dispatch.ts
+++ b/packages/effects/src/dispatch.ts
@@ -18,30 +18,65 @@ export interface InvokeOpts {
 // Effects API
 // ---------------------------------------------------------------------------
 
-const EffectsApi = createApi("Effects", {
-  *dispatch(effectId: string, _data: Val): Operation<Val> {
-    if (effectId === "sleep") {
-      const ms = (_data as unknown[])[0] as number;
-      yield* effectionSleep(ms);
-      return null as Val;
-    }
-    throw new Error(`No agent registered for effect: ${effectId}`);
+/**
+ * @internal
+ *
+ * Three-lane middleware composition for the Effects API. The `replay`
+ * lane sits between `max` (user/orchestration middleware) and `min`
+ * (framework implementations) and is reserved for the runtime's
+ * replay-substitution boundary. The `replay` lane is not addressable
+ * through the public `Effects.around` API; it is reached through
+ * `@tisyn/effects/internal` by workspace code only.
+ */
+export const EffectsApi = createApi(
+  "Effects",
+  {
+    *dispatch(effectId: string, _data: Val): Operation<Val> {
+      if (effectId === "sleep") {
+        const ms = (_data as unknown[])[0] as number;
+        yield* effectionSleep(ms);
+        return null as Val;
+      }
+      throw new Error(`No agent registered for effect: ${effectId}`);
+    },
+    *resolve(_agentId: string): Operation<boolean> {
+      return false;
+    },
+    *sleep(ms: number): Operation<Val> {
+      return yield* dispatch("sleep", [ms] as unknown as Val);
+    },
   },
-  *resolve(_agentId: string): Operation<boolean> {
-    return false;
+  {
+    groups: [
+      { name: "max", mode: "append" },
+      { name: "replay", mode: "prepend" },
+      { name: "min", mode: "prepend" },
+    ] as const,
   },
-  *sleep(ms: number): Operation<Val> {
-    return yield* dispatch("sleep", [ms] as unknown as Val);
-  },
-});
+);
+
+type PublicAroundOptions = { at: "max" | "min" };
+
+function publicAround(
+  handlers: Parameters<typeof EffectsApi.around>[0],
+  options?: PublicAroundOptions,
+): Operation<void> {
+  if (options != null && options.at !== "max" && options.at !== "min") {
+    throw new Error(`Effects.around: { at } must be "max" or "min"`);
+  }
+  return EffectsApi.around(handlers, options);
+}
 
 export const Effects: {
   operations: typeof EffectsApi.operations;
-  around: typeof EffectsApi.around;
+  around: (
+    handlers: Parameters<typeof EffectsApi.around>[0],
+    options?: PublicAroundOptions,
+  ) => Operation<void>;
   sleep: typeof EffectsApi.operations.sleep;
 } = {
   operations: EffectsApi.operations,
-  around: EffectsApi.around,
+  around: publicAround,
   sleep: EffectsApi.operations.sleep,
 };
 

--- a/packages/effects/src/internal/index.ts
+++ b/packages/effects/src/internal/index.ts
@@ -7,3 +7,5 @@
  */
 export { DispatchContext } from "./dispatch-context.js";
 export { evaluateMiddlewareFn } from "./middleware-eval.js";
+export { installReplayDispatch } from "./replay.js";
+export type { ReplayDispatchMiddleware } from "./replay.js";

--- a/packages/effects/src/internal/replay.ts
+++ b/packages/effects/src/internal/replay.ts
@@ -1,0 +1,38 @@
+/**
+ * @internal
+ *
+ * Workspace-internal installer for the Effects `replay` middleware lane.
+ * Composes between user middleware (`max`) and framework implementations
+ * (`min`) in the dispatch chain. Not part of the stable public API of
+ * `@tisyn/effects`; see `./README.md`.
+ */
+
+import type { Operation } from "effection";
+import type { PropertyMiddleware } from "@effectionx/context-api";
+import type { Val } from "@tisyn/ir";
+import { EffectsApi } from "../dispatch.js";
+
+/**
+ * @internal
+ *
+ * Middleware signature for the Effects `dispatch` operation, suitable
+ * for installation into the `replay` lane.
+ */
+export type ReplayDispatchMiddleware = PropertyMiddleware<
+  { dispatch: (effectId: string, data: Val) => Operation<Val> },
+  "dispatch"
+>;
+
+/**
+ * @internal
+ *
+ * Install dispatch middleware into the runtime-internal `replay` lane
+ * of the Effects composition. The installed middleware composes after
+ * `max` frames and before `min` frames on any single dispatch.
+ *
+ * Phase 3 only wires the lane; runtime replay substitution is
+ * installed by a later phase.
+ */
+export function* installReplayDispatch(dispatch: ReplayDispatchMiddleware): Operation<void> {
+  yield* EffectsApi.around({ dispatch }, { at: "replay" });
+}

--- a/packages/effects/src/package-exports.test.ts
+++ b/packages/effects/src/package-exports.test.ts
@@ -54,6 +54,7 @@ describe("@tisyn/effects — package exports", () => {
       const names = Object.keys(primary);
       expect(names).not.toContain("DispatchContext");
       expect(names).not.toContain("evaluateMiddlewareFn");
+      expect(names).not.toContain("installReplayDispatch");
     });
 
     it("error constructors are real classes", () => {
@@ -71,13 +72,16 @@ describe("@tisyn/effects — package exports", () => {
       const names = Object.keys(internal).sort();
       expect(names).toContain("DispatchContext");
       expect(names).toContain("evaluateMiddlewareFn");
+      expect(names).toContain("installReplayDispatch");
     });
 
     it("source files carry @internal JSDoc tags", () => {
       const dcSource = readFileSync(resolve(pkgRoot, "src/internal/dispatch-context.ts"), "utf8");
       const mwSource = readFileSync(resolve(pkgRoot, "src/internal/middleware-eval.ts"), "utf8");
+      const rpSource = readFileSync(resolve(pkgRoot, "src/internal/replay.ts"), "utf8");
       expect(dcSource).toMatch(/@internal/);
       expect(mwSource).toMatch(/@internal/);
+      expect(rpSource).toMatch(/@internal/);
     });
 
     it("README.md documents non-stability", () => {

--- a/packages/effects/src/three-lane-composition.test.ts
+++ b/packages/effects/src/three-lane-composition.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Three-lane middleware composition tests for the replay-aware Effects
+ * substrate (#125, Phase 3).
+ *
+ * Covers scoped-effects test plan IDs from §13:
+ *
+ *   RD-CO-001 — max runs before min, then core
+ *   RD-CO-002 — multiple max frames install-order; multiple min frames reverse install-order
+ *   RD-CO-004 / RD-PL-001 — public Effects.around(..., { at: "replay" as any }) rejected
+ *   RD-PL-002 (companion) — rejection error does not name the internal group "replay"
+ *
+ * Plus the Phase 3-specific "internal replay lane exists and composes
+ * between max and min" assertion named in the Phase 3 handoff.
+ *
+ * NOTE — install order matters: the `min` group uses prepend mode, so
+ * the core handler MUST be installed first (becomes innermost in the
+ * min lane) and min middleware installed afterwards (prepended on top
+ * so it runs before core on dispatch). Reversing this places core
+ * outermost and short-circuits the min middleware.
+ */
+
+import { describe, it } from "@effectionx/vitest";
+import { expect } from "vitest";
+import type { Val } from "@tisyn/ir";
+import { Effects, dispatch } from "./index.js";
+import { installReplayDispatch } from "./internal/index.js";
+
+describe("three-lane middleware composition", () => {
+  // RD-CO-001
+  it("max runs before min, then core", function* () {
+    const log: string[] = [];
+
+    // Core first (innermost in min lane).
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          log.push("core");
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Min middleware prepends on top of core.
+    yield* Effects.around(
+      {
+        *dispatch([e, d]: [string, Val], next) {
+          log.push("min");
+          return yield* next(e, d);
+        },
+      },
+      { at: "min" },
+    );
+
+    // Max middleware.
+    yield* Effects.around({
+      *dispatch([e, d]: [string, Val], next) {
+        log.push("max");
+        return yield* next(e, d);
+      },
+    });
+
+    yield* dispatch("test.op", null);
+    expect(log).toEqual(["max", "min", "core"]);
+  });
+
+  // RD-CO-002
+  it("multiple max frames keep install order; multiple min frames run in reverse install order", function* () {
+    const log: string[] = [];
+
+    // Core first.
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          log.push("core");
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // m1 installed before m2; prepend means m2 becomes outermost in the min lane.
+    yield* Effects.around(
+      {
+        *dispatch([e, d]: [string, Val], next) {
+          log.push("m1");
+          return yield* next(e, d);
+        },
+      },
+      { at: "min" },
+    );
+    yield* Effects.around(
+      {
+        *dispatch([e, d]: [string, Val], next) {
+          log.push("m2");
+          return yield* next(e, d);
+        },
+      },
+      { at: "min" },
+    );
+
+    // M1 installed before M2; append means M1 stays outer in the max lane.
+    yield* Effects.around({
+      *dispatch([e, d]: [string, Val], next) {
+        log.push("M1");
+        return yield* next(e, d);
+      },
+    });
+    yield* Effects.around({
+      *dispatch([e, d]: [string, Val], next) {
+        log.push("M2");
+        return yield* next(e, d);
+      },
+    });
+
+    yield* dispatch("test.op", null);
+    expect(log).toEqual(["M1", "M2", "m2", "m1", "core"]);
+  });
+
+  // RD-CO-004 / RD-PL-001 + RD-PL-002 companion
+  it("public Effects.around with unknown { at } rejects without leaking the internal group name", function* () {
+    const log: string[] = [];
+
+    // Sentinel core anchor: must still fire after the rejected install.
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          log.push("sentinel");
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    try {
+      yield* Effects.around(
+        {
+          *dispatch([e, d]: [string, Val], next) {
+            log.push("should-not-install");
+            return yield* next(e, d);
+          },
+        },
+        // Caller uses an unsafe cast; public surface must reject.
+        { at: "replay" as unknown as "min" },
+      );
+      expect.unreachable("Effects.around should have thrown on unknown { at } value");
+    } catch (error) {
+      const message = (error as Error).message;
+      // Exact message — test will fail if the public error regresses to echo the input.
+      expect(message).toBe('Effects.around: { at } must be "max" or "min"');
+      // Internal group name must not leak to the public error surface.
+      expect(message.includes("replay")).toBe(false);
+    }
+
+    // Confirm the failed install left no middleware behind.
+    yield* dispatch("test.op", null);
+    expect(log).toEqual(["sentinel"]);
+  });
+
+  // Phase 3-specific: internal replay lane composes between max and min.
+  it("internal installReplayDispatch composes between max and min", function* () {
+    const log: string[] = [];
+
+    // Core first (innermost in min lane).
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          log.push("core");
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Min middleware on top of core.
+    yield* Effects.around(
+      {
+        *dispatch([e, d]: [string, Val], next) {
+          log.push("min");
+          return yield* next(e, d);
+        },
+      },
+      { at: "min" },
+    );
+
+    // Replay middleware via the internal installer (reaches the `replay` lane
+    // without the group name being addressable from user code).
+    yield* installReplayDispatch(function* ([e, d]: [string, Val], next) {
+      log.push("replay");
+      return yield* next(e, d);
+    });
+
+    // Max middleware.
+    yield* Effects.around({
+      *dispatch([e, d]: [string, Val], next) {
+        log.push("max");
+        return yield* next(e, d);
+      },
+    });
+
+    yield* dispatch("test.op", null);
+    expect(log).toEqual(["max", "replay", "min", "core"]);
+  });
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effectionx/context-api": "^0.5.3",
+    "@effectionx/context-api": "https://pkg.pr.new/@effectionx/context-api@215",
     "@tisyn/agent": "workspace:*",
     "@tisyn/config": "workspace:*",
     "@tisyn/durable-streams": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
   packages/agent:
     dependencies:
       '@effectionx/context-api':
-        specifier: ^0.5.3
-        version: 0.5.3(effection@4.0.2)
+        specifier: https://pkg.pr.new/@effectionx/context-api@215
+        version: https://pkg.pr.new/@effectionx/context-api@215(effection@4.0.2)
       '@effectionx/middleware':
         specifier: ^0.1.1
         version: 0.1.1
@@ -458,8 +458,8 @@ importers:
   packages/effects:
     dependencies:
       '@effectionx/context-api':
-        specifier: ^0.5.3
-        version: 0.5.3(effection@4.0.2)
+        specifier: https://pkg.pr.new/@effectionx/context-api@215
+        version: https://pkg.pr.new/@effectionx/context-api@215(effection@4.0.2)
       '@effectionx/middleware':
         specifier: ^0.1.1
         version: 0.1.1
@@ -518,8 +518,8 @@ importers:
   packages/runtime:
     dependencies:
       '@effectionx/context-api':
-        specifier: ^0.5.3
-        version: 0.5.3(effection@4.0.2)
+        specifier: https://pkg.pr.new/@effectionx/context-api@215
+        version: https://pkg.pr.new/@effectionx/context-api@215(effection@4.0.2)
       '@tisyn/agent':
         specifier: workspace:*
         version: link:../agent
@@ -855,8 +855,9 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@effectionx/context-api@0.5.3':
-    resolution: {integrity: sha512-OqS/7RGZtIoiRsL6dwetKLvS8F3NLiVU3iKlBbqxI+NPKXs/ackKn294eGlHUHx49Y89fUVU6YPalj2UbxwBzA==}
+  '@effectionx/context-api@https://pkg.pr.new/@effectionx/context-api@215':
+    resolution: {tarball: https://pkg.pr.new/@effectionx/context-api@215}
+    version: 0.7.0
     peerDependencies:
       effection: ^3 || ^4
 
@@ -3063,7 +3064,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@effectionx/context-api@0.5.3(effection@4.0.2)':
+  '@effectionx/context-api@https://pkg.pr.new/@effectionx/context-api@215(effection@4.0.2)':
     dependencies:
       '@effectionx/middleware': 0.1.1
       effection: 4.0.2

--- a/scripts/patch-context-api-preview.mjs
+++ b/scripts/patch-context-api-preview.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Post-install workaround for @effectionx/context-api PR #215 preview
+ * (0.7.0 via pkg.pr.new).
+ *
+ * The preview ships mod.ts and exposes it via an
+ * `exports["."]["development"]` condition. When this workspace's
+ * Vitest + tsx setup spawns a real Node worker thread (packages/
+ * transport worker tests), the worker inherits tsx's `"development"`
+ * condition and Node tries to load mod.ts from inside node_modules,
+ * which fails (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING).
+ *
+ * Strip the `development` condition from the installed package
+ * manifest so Node falls through to `import` and loads dist/mod.js
+ * inside worker threads.
+ *
+ * pnpm's `readPackage` hook does not rewrite the on-disk manifest
+ * when a dependency is installed from a pkg.pr.new URL (verified on
+ * pnpm 9.15.9), so this runs as a workspace `prepare` / `pretest`
+ * step that touches the materialized package.json directly.
+ *
+ * Remove this workaround (and this script) once:
+ *   - PR #215 (thefrontside/effectionx) merges and releases a real
+ *     version without the `development` source-TS condition, AND
+ *   - all workspace package.json pins are updated to that version.
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const workspaceRoot = join(here, "..");
+const pnpmRoot = join(workspaceRoot, "node_modules", ".pnpm");
+
+let entries;
+try {
+  entries = readdirSync(pnpmRoot);
+} catch {
+  // node_modules/.pnpm is absent (pre-install). Nothing to do.
+  process.exit(0);
+}
+
+const targets = entries.filter((name) => name.startsWith("@effectionx+context-api@"));
+
+let patched = 0;
+for (const dirName of targets) {
+  const manifestPath = join(
+    pnpmRoot,
+    dirName,
+    "node_modules",
+    "@effectionx",
+    "context-api",
+    "package.json",
+  );
+
+  let manifestText;
+  try {
+    manifestText = readFileSync(manifestPath, "utf8");
+  } catch {
+    continue;
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestText);
+  } catch {
+    continue;
+  }
+
+  const dot = manifest.exports && manifest.exports["."];
+  if (!dot || typeof dot !== "object" || !("development" in dot)) {
+    continue;
+  }
+
+  delete dot.development;
+
+  const stat = statSync(manifestPath);
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+  // Preserve timestamps so pnpm's reproducibility checks don't trip.
+  const { atime, mtime } = stat;
+  try {
+    // Node's utimesSync is available on all platforms.
+    const { utimesSync } = await import("node:fs");
+    utimesSync(manifestPath, atime, mtime);
+  } catch {
+    // best-effort
+  }
+  patched++;
+}
+
+if (patched > 0) {
+  console.log(
+    `[patch-context-api-preview] stripped "development" exports condition from ${patched} install(s)`,
+  );
+}


### PR DESCRIPTION
## Summary

Prepares Tisyn to replay workflows without asking application or testkit
middleware to know about replay internals. Declares an internal `replay`
middleware lane in the Effects dispatch composition — sitting between
user middleware (`max`) and framework implementations (`min`) — so a
later runtime phase can install replay-substitution middleware into the
middle lane without changing user-facing API surface.

**Does not** implement replay substitution, payload hashing, or any
runtime replay behavior. Phase 3 only wires the composition substrate.

## What changed

- `packages/effects/src/dispatch.ts` — declares three groups on the
  `createApi` call: `max` (append), `replay` (prepend), `min` (prepend).
  Public `Effects.around` is narrowed to `{ at: "max" | "min" }` at the
  type level and guarded at runtime; a caller passing
  `{ at: "replay" as any }` is rejected with an error message that
  does not expose the internal group name.
- `packages/effects/src/internal/replay.ts` — new non-stable
  `installReplayDispatch` + `ReplayDispatchMiddleware` type, exported
  on the `@tisyn/effects/internal` workspace seam. Reserved for a
  future runtime phase to install replay-substitution middleware into
  the middle lane. Not user-facing.
- `packages/effects/src/three-lane-composition.test.ts` — new test
  file covering scoped-effects test plan §13.1 IDs: `RD-CO-001`
  (max-before-min-before-core), `RD-CO-002` (multiple-max install
  order, multiple-min reverse install order), `RD-CO-004` / `RD-PL-001`
  (public rejection of `{ at: "replay" }`) plus an `RD-PL-002`
  companion asserting the error does not leak the internal group name,
  and a Phase-3-specific composition test proving the internal replay
  lane slots correctly between max and min.
- `packages/effects/src/package-exports.test.ts` — asserts
  `installReplayDispatch` is exposed only on `./internal`, not on the
  primary barrel.

## Phase 1 behavior preserved

Framework handler installation sites — `Agents.use`,
`implementAgent(...).install`, `installAgentTransport`,
`installRemoteAgent` — continue to install their dispatch middleware at
`{ at: "min" }`, which now positions them below the internal replay
lane. No changes to agent/transport/runtime code were needed for type
compatibility. All Phase 1 ordering regressions still pass.

## Dependency caveat

This PR pins `@effectionx/context-api` at the PR #215 preview
(https://pkg.pr.new/@effectionx/context-api@215) in `@tisyn/effects`,
`@tisyn/agent`, and `@tisyn/runtime` to pick up the new
`createApi` options.groups API.

A `scripts/patch-context-api-preview.mjs` workaround runs at
`postinstall` to strip a `development` condition from the preview's
exports map. The preview ships `mod.ts` (source TypeScript) under that
condition, which Node's worker-thread module resolver tries to strip
types from and fails (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`)
inside `node_modules`. Removing the condition causes the worker to
resolve `dist/mod.js` instead. The workaround only touches the
materialized package.json in `node_modules/.pnpm/...`; it never
modifies the preview package's source.

**Before marking ready:** if PR #215 merges and a released version of
`@effectionx/context-api` is available, replace the `pkg.pr.new` pins
with the released version, delete the postinstall workaround and its
script, and drop this paragraph from the PR description.

## Non-goals

- No replay-substitution implementation. The internal replay lane is
  empty in Phase 3; a later phase installs the actual boundary.
- No payload hashing / SHA logic / `describeEffect`.
- No `invokeInline` implementation.
- No removal of any PR #123 prototype helpers (none exist on main).
- No change to agent/transport framework-handler installation beyond
  the handler chains already landed in Phase 1 (PR #126).
- This PR does not close #125.

## Test plan

- [x] `pnpm run build` — green
- [x] `pnpm run format:check` — green
- [x] `pnpm --filter @tisyn/effects test` — 12 passed (4 new + 8 existing)
- [x] `pnpm --filter @tisyn/agent test` — 54 passed, no regressions
- [x] `pnpm --filter @tisyn/transport test` — 109 passed, including the
      real-worker-thread tests that required the `development`
      condition workaround
- [x] `pnpm --filter @tisyn/runtime test` — 248 passed, no regressions
- [x] Manual grep: every `at: "replay"` occurrence is inside
      `packages/effects/` (internal module or test), never leaks into
      the rest of the workspace.

Refs #125