### PR TITLE
Specify inline invocation lanes and caller-owned capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ For the detailed agent model and API examples, see [`@tisyn/agent`](./packages/a
 | [Claude Code Specification](./specs/tisyn-claude-code-specification.md) | Claude Code transport adapter bindings: ACP stdio and SDK adapters, protocol translation, operations, and lifecycle |
 | [Claude Code Test Plan](./specs/tisyn-claude-code-test-plan.md) | Conformance test plan for the Claude Code transport adapter layer |
 | [Resource Specification](./specs/tisyn-resource-specification.md) | `resource(...)` and `provide(...)` scope-creating primitives for managed initialization and cleanup |
+| [Inline Invocation Specification](./specs/tisyn-inline-invocation-specification.md) | `invokeInline(...)` shared-lifetime step execution, inline-lane identity, capability/counter ownership semantics |
+| [Inline Invocation Test Plan](./specs/tisyn-inline-invocation-test-plan.md) | Conformance test plan for the inline invocation specification |
 | [Stream Iteration Specification](./specs/tisyn-stream-iteration-specification.md) | Authored `for (const x of yield* each(expr))`, `stream.subscribe`, `stream.next`, and subscription-handle runtime rules |
 | [Browser Contract Specification](./specs/tisyn-browser-contract-specification.md) | Browser transport boundary with `navigate`, batched in-browser `execute`, and transport-configured local capability composition |
 | [Timebox Specification](./specs/tisyn-timebox-specification.md) | `timebox` compound external: deadline-bounded execution returning completed/timeout result |

--- a/specs/tisyn-compound-concurrency-specification.md
+++ b/specs/tisyn-compound-concurrency-specification.md
@@ -267,6 +267,10 @@ The `spawn_index` is the child's position in the `exprs` array of the originatin
 
 **Invariant I-ID:** Given the same IR and journal, task IDs MUST be identical across runs.
 
+Additionally, the unified `childSpawnCount` allocator is advanced by inline invocation. Each accepted `invokeInline(fn, args, opts?)` call from a valid dispatch-boundary call site (per `tisyn-inline-invocation-specification.md` §6.2) MUST advance the parent's `childSpawnCount` by exactly `+1`. The allocated coroutineId uses the standard `parentId.{k}` format and names an **inline lane** — a durable replay identity for journaling the inline body's effects. Unlike coroutineIds allocated by `invoke`, `spawn`, `resource`, `scope`, `timebox`, `all`, or `race`, the inline lane's coroutineId does not create a new Effection scope boundary and does not produce a `CloseEvent`. A rejected `invokeInline` call (invalid call site, invalid input) MUST NOT advance the allocator. Invariant I-ID applies uniformly: for the same IR, inputs, and middleware code, inline lane IDs allocated by `invokeInline` MUST be byte-identical across original run and replay, interleaved deterministically with IDs allocated by all other allocation origins.
+
+This amendment does not change the unified allocator's mechanics, counter format, or I-ID invariant. It adds `invokeInline` as a new allocation origin alongside the existing set, and documents that the allocated ID is an inline lane — not a child scope.
+
 ### 4.3 Task State Machine
 
 ```

--- a/specs/tisyn-inline-invocation-specification.md
+++ b/specs/tisyn-inline-invocation-specification.md
@@ -1,0 +1,427 @@
+# Tisyn Inline Invocation Specification
+
+**Status.** Normative. Draft.
+**Depends on.**
+  - `tisyn-kernel-specification.md` (evaluation model; no amendment).
+  - `tisyn-scoped-effects-specification.md` (§3 Dispatch Boundary; §5.2 max/min priority; §9.5 structural replay substitution; companion test MR-002, Core tier).
+  - `tisyn-compound-concurrency-specification.md` (§4.2 unified allocator; §9 ordering; §10 replay cursors; synchronized amendment at §17.4).
+  - `tisyn-nested-invocation-specification.md` (sibling primitive; strict non-overlap).
+  - `tisyn-stream-iteration-specification.md` (capability-ancestry and subscription-counter rules; synchronized amendment at §17.3).
+**Complements.** `tisyn-nested-invocation-specification.md`.
+**Depended on by.** None in MVP.
+**Exports (terminology).** *inline invocation*, *inline caller*, *inline body*, *inline lane*, *nested inline invocation*, *journal coroutineId*, *owner coroutineId*.
+
+---
+
+## 1. Overview
+
+**Inline invocation** is a runtime-controlled mechanism by which dispatch-boundary middleware MAY evaluate a compiled `Fn` under the caller's lifetime region — sharing the caller's Effection scope — while journaling the inline body's effects under a distinct **inline lane** in the durable stream.
+
+Inline invocation exists to support shared-lifetime step execution: multi-step rounds where step 1 lazily creates resources that step 2 must reuse.
+
+**Nested inline invocation is in scope for MVP.** When middleware handling an effect dispatched during an outer inline body's evaluation calls `invokeInline`, the call is valid (§7.6). This follows directly from the call-site rule.
+
+Inline invocation and nested invocation are **distinct primitives**. `invoke` for isolated execution; `invokeInline` for shared-lifetime execution. Neither is a mode of the other.
+
+---
+
+## 2. Primary Invariant: Distinct Durable Identity, Shared Lifetime
+
+Inline invocation separates two concerns that nested invocation bundles:
+
+- **Durable replay identity.** Effects journal under the inline lane's coroutineId. Replay cursor keyed to the lane. This is the **journal coroutineId**.
+
+- **Lifetime and ownership.** No new scope. Capability handles use the original caller's coroutineId for ownership and counter allocation. This is the **owner coroutineId**.
+
+Under `invoke`, both roles are the same value. Under `invokeInline`, they diverge. This dual-identity model is the defining invariant.
+
+This separation applies to the **inline body itself**. Child-bearing primitives retain their own semantics (§11).
+
+---
+
+## 3. Normative scope
+
+Defines: API and call-site preconditions; inline lane; dual-identity model; capability ownership and counter allocation (§12); call-site model and nested inline (§6, §7.6); lifetime model (§11); ordering, replay, error, cancellation; composition with §9.5.
+
+Does not define: kernel/compiler changes; new event kinds; concurrent `invokeInline` (§16); step orchestration.
+
+---
+
+## 4. Relationship to existing specs
+
+**Kernel, compiler, blocking-scope, spawn, resource, timebox specifications.** Unmodified.
+
+**Scoped-effects specification.** §9.5 three-lane replay applies. Cross-reference at §17.1.
+
+**Compound concurrency specification.** The unified child allocator (§4.2) is advanced by `+1` per accepted `invokeInline` call (§7.2). The allocated ID uses the standard `parentId.{k}` format and names an inline lane — not a child scope. Invariant I-ID applies. **Synchronized amendment at §17.4.**
+
+**Nested invocation specification.** Unmodified. `invoke` during inline-body evaluation retains full semantics (§11.3). Cross-reference at §17.2.
+
+**Stream iteration specification.** When capabilities are acquired during inline-body evaluation, the subscription counter is driven by the owner coroutineId. **Synchronized amendment at §17.3.**
+
+---
+
+## 5. Terminology
+
+**Inline invocation.** Evaluation of a compiled `Fn` body under the caller's lifetime region via `invokeInline(fn, args, opts?)` from dispatch-boundary code.
+
+**Inline caller.** The coroutine whose `DispatchContext` is active at the moment of the call.
+
+**Inline body.** The compiled `Fn` body. IR, kernel-evaluated. Can yield effect descriptors; cannot call host-side JavaScript.
+
+**Inline lane.** The coroutineId under which effects dispatched during inline-body evaluation are journaled. Durable replay identity only; does not create a scope boundary; does not produce a `CloseEvent`.
+
+**Journal coroutineId.** The lane ID. For: `YieldEvent` writes, replay cursor, divergence.
+
+**Owner coroutineId.** The original caller's coroutineId. For: capability ownership, ancestry checks, capability counter allocation (§12).
+
+**Nested inline invocation.** `invokeInline` from middleware handling an outer inline body's dispatched effect (§7.6). In MVP.
+
+---
+
+## 6. API
+
+### 6.1 Signature
+
+```
+invokeInline<T>(
+  fn: Fn<T>,
+  args: ReadonlyArray<Val>,
+  opts?: { overlay?: ScopedEffectOverlay; label?: string }
+): Operation<T>
+```
+
+Export package non-normative. Reads `DispatchContext`; MUST NOT introduce a separate context.
+
+### 6.2 Call-site preconditions
+
+6.2.1. **Host-dispatch-middleware-only** at every nesting level. Zero side effects on rejection.
+
+6.2.2. **Compiled `Fn` body cannot call directly.** Structurally impossible; if reached, rejected.
+
+6.2.3. Stale-context detection per `invoke` rules.
+
+6.2.4. SHOULD reuse `InvalidInvokeCallSiteError` / `InvalidInvokeInputError`. MUST surface primitive name.
+
+### 6.3 Input validity
+
+`fn` MUST be `Fn`. `args` MUST be `Val[]`. `opts.overlay` per scoped-effects §5. `opts.label` diagnostic only.
+
+### 6.4 Suspension
+
+Returns `Operation<T>` via `yield*`. Effection suspension; not kernel SUSPEND.
+
+---
+
+## 7. Inline Lane Identity and Allocator
+
+### 7.1 Why a distinct lane
+
+Dispatch middleware runs before the triggering `YieldEvent`. Inline-body effects MUST journal under a distinct coroutineId.
+
+### 7.2 Allocator advancement
+
+`invokeInline` MUST advance the caller's unified child allocator (`childSpawnCount` per compound concurrency §4.2) by exactly `+1` at the moment of the call, atomically, before evaluating the inline body. The resulting value `k` determines the inline lane ID. A rejected `invokeInline` call (per §6.2) MUST NOT advance the allocator.
+
+The allocated ID uses the `parentId.{k}` format and names an **inline lane** — a durable replay identity that does not create a scope boundary and does not produce a `CloseEvent`. This is a new allocation origin alongside `invoke`, `spawn`, `resource`, `scope`, `timebox`, `all`, and `race`. See §17.4 for the compound-concurrency synchronized amendment.
+
+### 7.3 Lane's own child allocator
+
+Own `childSpawnCount` starting at 0. Advanced by compound-external IR descriptors and by host-side `invoke`/`invokeInline` from middleware handling the body's dispatched effects.
+
+### 7.4 ID format
+
+`parentId.{k}` per compound concurrency §4.2. **Deterministic identification only; does not imply child-scope semantics.**
+
+### 7.5 Distinguishing inline lanes
+
+Absence of `CloseEvent` is a defining durable property. Runtime distinguishes from interrupted children via re-entry context.
+
+### 7.6 Nested inline invocation
+
+**In MVP.** Occurs when middleware handling an effect dispatched during an outer inline body's evaluation calls `invokeInline`.
+
+Mechanism: outer middleware A calls `invokeInline(outerFn)` → outer body dispatches E → middleware B handles E → B calls `invokeInline(innerFn)`. Valid because B is dispatch middleware.
+
+Properties: call-site rule unchanged; lane subtree (`caller.{k}.{m}`); no `CloseEvent` at any level; independent replay cursors; owner coroutineId inherited unchanged (§12.3). Lifetime at nested levels per §11.
+
+### 7.7 Determinism
+
+Lane IDs byte-identical across runs. I-ID of compound concurrency §4.2 applies uniformly across all allocation origins, including inline invocation.
+
+---
+
+## 8. Journal Model
+
+### 8.1 Effects under the lane
+
+`YieldEvent`s with `coroutineId = laneId`. Own yieldIndex.
+
+### 8.2 Triggering dispatch
+
+Written under caller's coroutineId after middleware returns. Records outer dispatch result; not the ordering anchor for inline-body events.
+
+### 8.3 Durable algebra
+
+`YieldEvent | CloseEvent` unmodified.
+
+### 8.4 No CloseEvent
+
+MUST NOT produce a `CloseEvent` for the inline lane, under any condition.
+
+### 8.5 No event for `invokeInline` itself
+
+### 8.6 Child-bearing primitives
+
+Produce own events per their specs. "No CloseEvent" applies to **the lane itself**.
+
+---
+
+## 9. Replay Model
+
+### 9.1 Replay
+
+Lane ID reconstructed from allocator. Replay boundary substitutes via lane cursor.
+
+### 9.2 Core property
+
+**Journal coroutineId distinct from caller's. Cursors coexist without divergence.**
+
+### 9.3 Max-region rerun
+
+Per §9.5.4.
+
+### 9.4 Crash recovery
+
+Lane has `YieldEvent`s but no `CloseEvent` by design. Middleware re-executes, `invokeInline` called, stored events replay, body transitions to live.
+
+### 9.5 Divergence
+
+Per-coroutineId. No inline-specific condition.
+
+### 9.6 Children and nested lanes
+
+Replay per own specs / per-coroutineId.
+
+---
+
+## 10. Ordering
+
+### 10.1 Per-coroutineId
+
+Lane yieldIndex and caller yieldIndex independent.
+
+### 10.2 Stream-append
+
+Inline-body events before triggering dispatch event.
+
+### 10.3 Sequential calls
+
+Strictly serialized.
+
+### 10.4 With `invoke`
+
+Each `+1`. Invoke has CloseEvent; inline does not.
+
+### 10.5 Compound concurrency §9
+
+Caller's CloseEvent MUST NOT precede lane's last YieldEvent.
+
+---
+
+## 11. Lifetime and Scope
+
+### 11.1 No new scope boundary
+
+### 11.2 Shared caller lifetime
+
+No intermediate scope. Children attach to caller's scope. Each primitive retains own semantics.
+
+### 11.3 `invoke` during inline-body evaluation
+
+Full nested-invocation semantics: own scope, own CloseEvent, child-owned resources, reified errors. Child ID `laneId.{m}`.
+
+### 11.4 `resource`
+
+Provide in caller scope. Cleanup at caller teardown.
+
+### 11.5 `spawn`
+
+Foreground child at caller scope. Produces CloseEvent.
+
+### 11.6 `timebox`, `all`, `race`
+
+Own compound-external semantics.
+
+### 11.7 Summary
+
+Only the **inline lane itself** has "no CloseEvent + shared lifetime." True at every nesting level.
+
+### 11.8 Cross-inline-call resource continuity
+
+Resources persist because they attach to the caller's scope.
+
+---
+
+## 12. Capability Ownership and Counter Allocation Under Inline Lanes
+
+### 12.1 The dual-identity model
+
+| Role | Value | Used for |
+|---|---|---|
+| **Journal coroutineId** | Inline lane ID | `YieldEvent` writes, replay cursor, divergence |
+| **Owner coroutineId** | Original caller's coroutineId | Capability ancestry, ownership, **counter allocation** |
+
+Under `invoke`, both are the same. Under `invokeInline`, they diverge.
+
+### 12.2 Scope of the rule
+
+Owner coroutineId drives **both ownership and counter allocation** for all coroutineId-keyed restricted capabilities acquired directly during inline-body evaluation. General default unless a capability family's own spec defines different semantics.
+
+Does **not** apply to: ordinary values; children created by child-bearing primitives (own counter per their own spec); resource lifetime (§11.4).
+
+### 12.3 Capture-and-propagate rule
+
+1. If active context already carries owner coroutineId (nested inline), inherit unchanged.
+2. If not (outermost), capture calling coroutine's own coroutineId.
+
+**Captured once at the outermost `invokeInline`; propagated unchanged through all nested levels.**
+
+### 12.4 Owner-based counter allocation
+
+Counter for deterministic tokens MUST be the counter associated with the owner coroutineId. All inline lanes under the same owner share a single capability counter. Unique, non-colliding tokens across sibling and nested lanes.
+
+Shared counter, but journal entries are not shared: each `stream.subscribe` YieldEvent is under the subscribing lane's journal coroutineId. The token inside the result is from the owner's counter.
+
+### 12.5 Replay reconstruction
+
+Lane cursors: per-coroutineId, independently. Owner counter: reconstructed by deterministic re-execution. Each replayed `stream.subscribe` advances the shared counter by the same amount. At the replay frontier, the counter is at the correct next value.
+
+### 12.6 Owner coroutineId is runtime context, not durable data
+
+Not written into `YieldEvent`s. Reconstructed by re-entry through the same `invokeInline` path. Shared capability counter also runtime state.
+
+### 12.7 Ancestry checks
+
+Handle owner = original caller. Using context owner = same caller (directly or via propagation). Check passes.
+
+### 12.8 `invoke` children
+
+Own coroutineId, own scope, own counter. §12.2 does not override.
+
+---
+
+## 13. Error Propagation
+
+### 13.1 Direct propagation
+
+Uncaught errors as original value, not reified.
+
+### 13.2 No CloseEvent on error
+
+### 13.3 Caught errors do not escape
+
+### 13.4 Flow-through
+
+### 13.5 Child errors per their own specs
+
+---
+
+## 14. Cancellation
+
+### 14.1 Propagates via caller's mechanism
+
+### 14.2 No detached lifetime
+
+### 14.3 `finally` blocks as part of caller's teardown
+
+---
+
+## 15. Conformance Hooks
+
+- **IH1.** Allocator `+1`. Lane ID `parentId.{k}`. Rejected calls do not advance.
+- **IH2.** Distinct durable identity. `YieldEvent`s under lane. Cursor independent.
+- **IH3.** No CloseEvent for the lane.
+- **IH4.** No event for the call itself.
+- **IH5.** Shared lifetime. No intermediate scope.
+- **IH6.** Primitive-specific semantics preserved.
+- **IH7.** Replay equivalence. Per-coroutineId cursors independent.
+- **IH8.** Error pass-through.
+- **IH9.** Invalid call sites zero-effect (including no allocator advancement).
+- **IH10.** Composition integrity with `invoke`.
+- **IH11.** Replay-dispatch composition via lane's journal coroutineId.
+- **IH12.** Call-site rule uniform at every nesting level.
+- **IH13.** Caller-owned capabilities. Owner coroutineId drives ownership AND counter allocation. Shared counter. Runtime context, not durable. Child-bearing primitives excluded.
+- **IH14.** Nested inline in MVP. Lane subtree, independent cursors, no CloseEvent, owner inherited.
+
+---
+
+## 16. Non-goals and deferred items
+
+- Concurrent `invokeInline` composition.
+- Compiler/IR surface.
+- Per-call timebox or agent rebinding.
+- Cross-boundary/remote inline.
+- Step orchestration layer.
+- `invokeInline` from non-`Effects.around({ dispatch })` sites.
+- Direct call from compiled `Fn` body.
+
+---
+
+## 17. Synchronized cross-spec amendments
+
+### 17.1 `tisyn-scoped-effects-specification.md` — §3
+
+> The runtime MAY expose `invokeInline(fn, args, opts?)` from `Effects.around({ dispatch })` middleware. Effects journal under a distinct inline lane coroutineId (journal identity); capability ownership and counter allocation use the original caller's coroutineId (owner identity). Owner coroutineId is runtime context, not durable data. The lane does not produce a `CloseEvent`. Child-bearing primitives retain own semantics. Participates in §9.5 replay. Nested inline permitted. Semantics: `tisyn-inline-invocation-specification.md`.
+
+### 17.2 `tisyn-nested-invocation-specification.md` — §15
+
+> Shared-lifetime inline execution is provided by `invokeInline` (`tisyn-inline-invocation-specification.md`). `invoke` from middleware handling inline-body dispatches retains full nested-invocation semantics.
+
+### 17.3 `tisyn-stream-iteration-specification.md` — subscription counter
+
+> When a `stream.subscribe` effect is dispatched during inline-body evaluation (as defined by `tisyn-inline-invocation-specification.md`), the subscription counter from which the deterministic token is allocated MUST be the counter associated with the owner coroutineId, not the journal coroutineId. The owner coroutineId is the original inline caller's coroutineId per inline-invocation §12.3. All inline lanes that share the same owner coroutineId share a single subscription counter, ensuring token uniqueness across sibling and nested inline invocations. The `YieldEvent` for the `stream.subscribe` effect is written under the journal coroutineId (the inline lane) per normal journaling rules; the token inside the event result is drawn from the owner's shared counter. On replay, the counter is reconstructed by deterministic re-execution of the same inline-invocation sequence. Capability ancestry checks use the owner coroutineId per inline-invocation §12.7.
+
+### 17.4 `tisyn-compound-concurrency-specification.md` — §4.2 (Unified child allocator)
+
+Add one paragraph parallel to the existing nested-invocation cross-reference:
+
+> The unified `childSpawnCount` allocator is also advanced by inline invocation. Each accepted `invokeInline(fn, args, opts?)` call from a valid dispatch-boundary call site (per `tisyn-inline-invocation-specification.md` §6.2) MUST advance the parent's `childSpawnCount` by exactly `+1`. The allocated coroutineId uses the standard `parentId.{k}` format and names an **inline lane** — a durable replay identity for journaling the inline body's effects. Unlike coroutineIds allocated by `invoke`, `spawn`, `resource`, `scope`, `timebox`, `all`, or `race`, the inline lane's coroutineId does not create a new Effection scope boundary and does not produce a `CloseEvent`. A rejected `invokeInline` call (invalid call site, invalid input) MUST NOT advance the allocator. Invariant I-ID applies uniformly: for the same IR, inputs, and middleware code, inline lane IDs allocated by `invokeInline` MUST be byte-identical across original run and replay, interleaved deterministically with IDs allocated by all other allocation origins.
+
+This amendment does not change the unified allocator's mechanics, counter format, or I-ID invariant. It adds `invokeInline` as a new allocation origin alongside the existing set, and documents that the allocated ID is an inline lane — not a child scope.
+
+---
+
+## 18. Contrast with `invoke`
+
+| Property | `invoke` | `invokeInline` |
+|---|---|---|
+| Allocator | `+1` | `+1` |
+| ID format | `parentId.{k}` | `parentId.{k}` |
+| Journal coroutineId | = child ID | = lane ID |
+| Owner coroutineId | = child ID (same) | = **original caller** |
+| Capability counter | Child's own | **Owner's shared counter** |
+| Scope | New | Caller's |
+| CloseEvent | Yes | **No** |
+| Resource lifetime | Child-owned | Caller-owned |
+| Error shape | Reified | Original |
+| Nested | N/A | In MVP; owner inherited |
+
+---
+
+## 19. Amended and unchanged sections inventory
+
+| Spec | Status |
+|---|---|
+| `tisyn-kernel-specification.md` | Unchanged |
+| `tisyn-compiler-specification.md` | Unchanged |
+| `tisyn-system-specification.md` | Unchanged |
+| `tisyn-compound-concurrency-specification.md` | **Amendment at §17.4** (inline invocation as allocation origin) |
+| `tisyn-scoped-effects-specification.md` | **Cross-reference at §17.1** |
+| `tisyn-nested-invocation-specification.md` | **Cross-reference at §17.2** |
+| `tisyn-stream-iteration-specification.md` | **Amendment at §17.3** (counter-selection rule) |
+| `tisyn-blocking-scope-specification.md` | Unchanged |
+| `tisyn-spawn-specification.md` | Unchanged |
+| `tisyn-resource-specification.md` | Unchanged |
+| `tisyn-timebox-specification.md` | Unchanged |
+| Durable event algebra | Unchanged |

--- a/specs/tisyn-inline-invocation-test-plan.md
+++ b/specs/tisyn-inline-invocation-test-plan.md
@@ -1,0 +1,386 @@
+# Tisyn Inline Invocation — Conformance Test Plan
+
+**Tests:** `tisyn-inline-invocation-specification.md`
+**Companion of.** `tisyn-inline-invocation-specification.md`
+**Complements.** `tisyn-nested-invocation-test-plan.md`
+**Depends on.**
+  - `tisyn-scoped-effects-test-plan.md` (MR-002; RD-*)
+  - `tisyn-compound-concurrency-specification.md` §4.2 (unified allocator; amended by inline-invocation §17.4)
+  - `tisyn-stream-iteration-specification.md` (capability ancestry; amended by inline-invocation §17.3)
+
+Test IDs use the prefix `IL-`.
+
+---
+
+## 1. Overview
+
+### 1.1 Scope
+
+- Primary invariant: distinct durable identity with shared lifetime (§2)
+- Dual-identity model: journal coroutineId vs. owner coroutineId (§12)
+- Capability ownership and counter allocation (§12)
+- Owner-based counter uniqueness and replay reconstruction (§12.4, §12.5)
+- Unified child allocator participation (§7.2; compound-concurrency §4.2 amendment at §17.4)
+- Inline lane identity (§7)
+- Call-site model (§6)
+- Nested inline — in MVP (§7.6)
+- Journal, replay, ordering, lifetime, error, cancellation
+- Composition with three-lane replay dispatch and with `invoke`
+- Regression
+
+### 1.2 Out of scope
+
+- `invoke` on its own; kernel; compiler; concurrent `invokeInline` (§16)
+
+### 1.3 Tiers
+
+- **Core.** MUST pass.
+- **Extended.** SHOULD pass.
+- **Diagnostic.** Non-normative.
+
+### 1.4 Observability
+
+Core = Workflow-visible or Journal-visible.
+
+---
+
+## 2. Primary Invariant (§2)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-PI-001 | Core | Journal + workflow | **Distinct durable identity AND shared lifetime.** | `invokeInline(fn)`: fn dispatches E, yields `resource` R. Later caller yield Y. Scope exits | (a) E under laneId. (b) R cleanup at caller teardown. (c) Y succeeds |
+| IL-PI-002 | Core | Journal | **Caller cursor and lane cursor coexist.** | Yield A; inline yields B, C; triggering D; yield E. Live; replay | Byte-identical. Caller: A, D, E. Lane: B, C |
+| IL-PI-003 | Core | Journal + workflow | **Resource continuity across siblings.** | Two calls. First yields `resource`. Second uses it. Exits | Distinct lanes. Cleanup at teardown. Second succeeds |
+
+---
+
+## 3. Basic Invocation (§6)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-B-001 | Core | Workflow | Returns `Operation<T>` | `[42]` | `42` |
+| IL-B-002 | Core | Workflow | Args bind | `Add [1,2]` | `3` |
+| IL-B-003 | Core | Workflow | `fn` must be `Fn` | Non-Fn | Error; zero effects |
+| IL-B-004 | Core | Workflow | `args` must be array | Non-array | Error |
+| IL-B-005 | Extended | Journal | `opts.label` not journaled | `{label:"x"}` | Not in journal |
+| IL-B-006 | Core | Workflow | `opts.overlay` validation | Malformed | Error |
+
+---
+
+## 4. Inline Lane Identity and Allocator (§7, compound-concurrency §4.2 amendment)
+
+These tests verify that `invokeInline` participates in the unified child allocator per compound-concurrency §4.2 (amended at inline-invocation §17.4), and that the allocated `parentId.{k}` ID is an inline lane — not a child scope.
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-A-001 | Core | Journal | **Advances unified allocator `+1`; allocated ID is an inline lane (no CloseEvent).** | `invokeInline(a)`, then `invoke(b)` | `.0` is inline lane (YieldEvents, no CloseEvent). `.1` is invoke child (YieldEvents + CloseEvent). Both from the same `childSpawnCount` sequence |
+| IL-A-002 | Core | Journal | Lane uses `parentId.{k}` format | Inspect | Matches compound-concurrency §4.2 format |
+| IL-A-003 | Core | Journal | Sequential calls → sequential IDs from unified allocator | Three `invokeInline` calls | `.0`, `.1`, `.2` — all lanes, all without CloseEvent |
+| IL-A-004 | Core | Journal | Children inside body allocate from lane's own allocator | Body yields `spawn(child)` | `laneId.0` |
+| IL-A-005 | Core | Journal | **I-ID: replay produces identical lane IDs.** | Live; replay | Byte-identical. Verifies I-ID applies to inline-lane allocation origin |
+| IL-A-006 | Core | Journal | **Mixed `invoke`/`invokeInline` interleave in unified allocator.** | `invokeInline(a)`, `invoke(b)`, `invokeInline(c)` | `.0` (lane, no Close), `.1` (child, Close), `.2` (lane, no Close) — unified counter, interleaved origins |
+
+---
+
+## 5. Call-Site Model (§6.2)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-V-001 | Core | Workflow + journal | **Rejected outside MW; allocator unchanged.** | Root generator calls `invokeInline` | Error; no allocator advancement; no journal entry |
+| IL-V-002 | Core | Workflow | Rejected from agent handler | | Error; zero effects |
+| IL-V-003 | Core | Workflow | Rejected from resolve MW | | Error |
+| IL-V-004 | Core | Workflow | Rejected from facade MW | | Error |
+| IL-V-005 | Extended | Workflow | Stale context | | Error |
+| IL-V-006 | Core | Workflow | Primitive distinguishability | Both errors | Distinguishable |
+| IL-V-007 | Core | Workflow | Direct from Fn body | | Impossible or rejected; zero effects |
+
+---
+
+## 6. Capability Ownership and Counter Allocation (§12, IH13)
+
+### 6.1 Sibling and caller reuse
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-001 | Core | Workflow + journal | **Subscription from A usable in B.** | A subscribes → H. B uses H | Ancestry passes via shared owner. Events under respective lanes |
+| IL-CO-002 | Core | Workflow + journal | **Nested inner subscription usable by caller.** | Inner subscribes → H. Caller uses after both return | Ancestry passes. H owner = original caller |
+
+### 6.2 Journal vs. ownership identity
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-003 | Core | Journal | **Journal under lane, not caller.** | Inline subscribes | `coroutineId = laneId` |
+| IL-CO-004 | Core | Workflow | **Ancestry via owner.** | Inline acquires H. Caller uses | Passes |
+
+### 6.3 Child-bearing primitive exclusion
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-005 | Core | Workflow + journal | **`invoke` child caps child-owned.** | Child subscribes → H2. Caller uses | FAILS. H2 owned by child |
+
+### 6.4 Capture-and-propagate
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-006 | Core | Workflow | **Owner at every level.** | Two levels. Inner acquires H. Outer uses | Succeeds |
+| IL-CO-008 | Core | Workflow | **Inner inherits outer's owner = caller.** | Verify H owner = C | Not lane |
+
+### 6.5 Owner runtime-only
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-007 | Core | Journal | **Not in journal.** | Inspect YieldEvent | No `ownerCoroutineId` field |
+| IL-CO-009 | Core | Journal + workflow | **Replay reconstructs owner.** | Inline acquires H. Live; replay. Caller uses on replay | Passes |
+
+### 6.6 Ordinary values
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-010 | Extended | Workflow | **Ordinary `Val` unaffected.** | Agent returns `{x:42}`. Caller uses | Usable |
+
+### 6.7 Owner-based counter allocation (§12.4)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CO-011 | Core | Journal + workflow | **Shared counter: unique tokens across caller + two lanes.** | Caller subscribes (T0). Inline A subscribes (T1). Inline B subscribes (T2) | T0, T1, T2 distinct. Sequential under one owner counter. Events under respective coroutineIds |
+| IL-CO-012 | Core | Workflow + journal | **Sibling reuse with shared counter.** | A subscribes → T1, H. B subscribes → T2. B uses H | T1≠T2. Ancestry passes |
+| IL-CO-013 | Core | Journal + workflow | **Replay counter reconstruction.** | Inline A subscribes (T1, replayed). After frontier, inline B subscribes live (T2) | T2≠T1. Owner counter advanced during replay. Deterministic |
+| IL-CO-014 | Core | Workflow + journal | **Child uses own counter.** | `invoke(child)` subscribes → TC. Then inline subscribes → TI | TC from child's counter. TI from owner's. Different namespaces |
+
+---
+
+## 7. Nested Inline (§7.6, IH14)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-NI-001 | Core | Journal | **Inner subtree.** | Outer→inner | `caller.{k}.{m}` |
+| IL-NI-002 | Core | Journal | **Both no CloseEvent.** | | None |
+| IL-NI-003 | Core | Journal | **Replay independently.** | Live; replay | Byte-identical |
+| IL-NI-004 | Core | Journal + workflow | **Resource from inner at caller scope.** | Inner `resource` R. Caller uses. Exits | R at caller teardown |
+| IL-NI-005 | Core | Journal | **Crash recovery through nested.** | Crash after inner's first yield | Replays; transitions |
+| IL-NI-006 | Core | Workflow | **Only from valid MW.** | Fn body tries | Rejected |
+| IL-NI-007 | Core | Workflow + journal | **`invoke` child in nested: child-owned.** | Child R2. Returns. R2 gone | At child close |
+
+---
+
+## 8. Journal Model (§8)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-J-001 | Core | Journal | Under lane | Two effects | Under laneId |
+| IL-J-002 | Core | Journal | Triggering after lane | | Lane first |
+| IL-J-003 | Core | Journal | No CloseEvent | Normal | None |
+| IL-J-004 | Core | Journal | No event for call | A; no-op; B | Caller: 0, 1 |
+| IL-J-005 | Core | Journal | Algebra unchanged | | `{Yield, Close}` |
+| IL-J-006 | Core | Journal | CloseEvent distinguishes | `invokeInline(a)`, `invoke(b)` | `.0` none; `.1` Close |
+
+---
+
+## 9. Primitive-Specific Child Semantics (§11, IH6)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-CS-001 | Core | Journal | `invoke` CloseEvent | Returns | Close under `laneId.{m}` |
+| IL-CS-002 | Core | Workflow + journal | `invoke` scope — child-owned | R gone after | At child close |
+| IL-CS-003 | Core | Workflow | `invoke` wraps errors | Throws | Reified |
+| IL-CS-004 | Core | Journal | `resource` CloseEvent | Exits | Child Close. Caller teardown |
+| IL-CS-005 | Core | Journal + workflow | `resource` provide in caller | After, uses | Usable |
+| IL-CS-006 | Core | Journal | `spawn` CloseEvent | Exits | Child Close |
+| IL-CS-007 | Core | Journal | Spawn at caller | Exits | Before caller Close |
+| IL-CS-008 | Core | Journal | **Only lane has "no Close + shared"** | `resource`, `invoke`, `spawn` | Lane: none. All children: Close |
+| IL-CS-009 | Extended | Journal | `timebox` | Timeout | Children Close |
+| IL-CS-010 | Core | Journal | **Nested inline no CloseEvent** | Outer→inner | Neither |
+
+---
+
+## 10. Replay (§9)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-R-001 | Core | Journal | Byte-identical | Live; replay | Identical |
+| IL-R-002 | Core | Journal | Durable Yield Rule | Fails live | Succeeds |
+| IL-R-003 | Core | Journal | Cursor independent | Mixed | Independent |
+| IL-R-004 | Core | Journal | Crash recovery | After first yield | Replays; transitions |
+| IL-R-005 | Core | Workflow + journal | Divergence under lane | Different effect | Under laneId |
+| IL-R-006 | Core | Journal | Mixed deterministic | Live; replay | Identical |
+| IL-R-007 | Core | Journal | Crash mid-body | After B, before D | B replays; D caller |
+| IL-R-008 | Core | Journal | Children per own specs | `invoke`, `resource` | Each cursor |
+
+---
+
+## 11. Ordering (§10)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-O-001 | Core | Journal | Lane before triggering | I; E | I first |
+| IL-O-002 | Core | Journal | Sequential serialized | X; Y | X first |
+| IL-O-003 | Core | Journal | yieldIndex contiguous | A; B(lane); C(trigger); D | Caller: 0,1,2. Lane: 0 |
+| IL-O-004 | Core | Journal | Caller Close after lane | Normal | Correct |
+
+---
+
+## 12. Lifetime (§11)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-L-001 | Core | Journal | Resource at caller exit | `resource`. Exits | Teardown |
+| IL-L-002 | Core | Journal | A→B reuse | Session | Succeeds |
+| IL-L-003 | Core | Journal | Spawn at caller | Exits | Before caller |
+| IL-L-004 | Core | Journal | No scope boundary | Acquires; returns; uses | No isolation |
+| IL-L-005 | Core | Journal | Reverse teardown | R1; A R2; B R3 | R3→R2→R1 |
+
+---
+
+## 13. Error (§13)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-E-001 | Core | Workflow | Original | `MyError` | `MyError` |
+| IL-E-002 | Core | Workflow | Contrast | Both | Original vs reified |
+| IL-E-003 | Core | Workflow | Caught | try/catch | Resolves |
+| IL-E-004 | Core | Workflow | Flow-through | Not caught | Terminates |
+| IL-E-005 | Core | Journal | No CloseEvent | Throws | None |
+| IL-E-006 | Core | Workflow | Non-Error | String | Propagates |
+| IL-E-007 | Core | Workflow | `invoke` child reified | Throws | Reified |
+
+---
+
+## 14. Cancellation (§14)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-X-001 | Core | Journal | Propagates | Suspended; cancelled | Caller Close; no lane Close |
+| IL-X-002 | Core | Workflow | No detached | Returns | No continuation |
+
+---
+
+## 15. Replay-Dispatch (§9.3, IH11)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-RD-001 | Core | Journal | Three-lane | Max; dispatches. Live; replay | Max reruns; doesn't refire |
+| IL-RD-002 | Core | Workflow | Via lane cursor | E. Live; replay | Lane cursor |
+| IL-RD-003 | Core | Journal | Resource-body inside inline | Init dispatches. Live; replay | Doesn't refire |
+| IL-RD-004 | Core | Journal | Nested three-lane | Inner dispatches | Inner cursor |
+
+---
+
+## 16. `invoke` Regression (IH10)
+
+| ID | Tier | Obs. | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| IL-N-001 | Core | Journal | CloseEvent | Single | Close |
+| IL-N-002 | Core | Workflow + journal | Scope | Child resource; returns | At child close |
+| IL-N-003 | Core | Journal | Error shape | Throws | Reified |
+| IL-N-004 | Core | Journal | Mixed | Three calls | Two Close; zero inline |
+
+---
+
+## 17. Interaction
+
+| ID | Tier | Obs. | Expected |
+|---|---|---|---|
+| IL-INT-SP-001 | Core | Journal | Spawn at caller exit |
+| IL-INT-SP-002 | Core | Journal | ID `laneId.{m}` |
+| IL-INT-RS-001 | Core | Journal | Resource cleanup at caller exit |
+| IL-INT-RS-002 | Core | Journal | ID `laneId.{m}` |
+| IL-INT-TB-001 | Extended | Journal | Per spec |
+| IL-INT-ST-001 | Core | Journal | Subscription replays correctly |
+
+---
+
+## 18. Regression
+
+| ID | Tier | Obs. | Expected |
+|---|---|---|---|
+| IL-EX-001 | Core | Journal | Crash-replay: identical |
+| IL-EX-002 | Core | Journal | Resource-recovery: identical |
+| IL-EX-003 | Core | Journal | Nested-invocation: identical |
+| IL-EX-004 | Core | Journal | RD-*: identical |
+
+---
+
+## 19. Minimum Acceptance Subset
+
+All 31 must pass. Tests 1–3: primary invariant. Tests 4–11: capability ownership and counter. Tests 12–15: nested inline. Tests 16–18: child semantics.
+
+| # | ID | What it proves |
+|---|---|---|
+| **1** | **IL-PI-001** | **Primary invariant** |
+| **2** | **IL-PI-002** | **Cursors coexist** |
+| **3** | **IL-PI-003** | **Resource continuity** |
+| **4** | **IL-CO-001** | **Subscription A usable in B** |
+| **5** | **IL-CO-002** | **Nested inner subscription usable by caller** |
+| **6** | **IL-CO-003** | **Journal under lane, not caller** |
+| **7** | **IL-CO-005** | **`invoke` child caps child-owned** |
+| **8** | **IL-CO-008** | **Capture-and-propagate** |
+| **9** | **IL-CO-009** | **Replay reconstructs owner** |
+| **10** | **IL-CO-011** | **Shared counter: unique tokens** |
+| **11** | **IL-CO-013** | **Replay counter reconstruction** |
+| **12** | **IL-NI-001** | **Inner subtree** |
+| **13** | **IL-NI-003** | **All lanes replay independently** |
+| **14** | **IL-NI-004** | **Resource from inner at caller scope** |
+| **15** | **IL-NI-007** | **`invoke` child in nested: child-owned** |
+| **16** | **IL-CS-001** | **`invoke` CloseEvent** |
+| **17** | **IL-CS-002** | **`invoke` child scope** |
+| **18** | **IL-CS-008** | **Only lane has "no Close + shared"** |
+| 19 | IL-B-001 | Returns `Operation<T>` |
+| 20 | IL-A-001 | Allocator + distinct lane (allocator amendment) |
+| 21 | IL-A-006 | Mixed allocator |
+| 22 | IL-J-001 | Effects under lane |
+| 23 | IL-J-003 | No CloseEvent |
+| 24 | IL-R-001 | Pure replay |
+| 25 | IL-R-004 | Crash recovery |
+| 26 | IL-E-001 | Error as original |
+| 27 | IL-V-001 | Invalid call site (no allocator advance) |
+| 28 | IL-V-007 | Direct from Fn body |
+| 29 | IL-RD-001 | Three-lane replay |
+| 30 | IL-CO-014 | Child uses own counter |
+| 31 | IL-EX-001 | Crash-replay green |
+
+---
+
+## 20. Coverage Summary
+
+### Conformance-hook coverage
+
+| Hook | Core tests |
+|---|---|
+| IH1 Allocator (§4.2 amendment) | IL-A-001–006, IL-V-001 |
+| IH2 Distinct identity | IL-PI-001, IL-PI-002, IL-J-001, IL-J-002, IL-A-002, IL-NI-001, IL-CO-003 |
+| IH3 No CloseEvent | IL-J-003, IL-J-006, IL-E-005, IL-X-001, IL-CS-008, IL-CS-010, IL-NI-002 |
+| IH4 No event for call | IL-J-004 |
+| IH5 Shared lifetime | IL-PI-001, IL-PI-003, IL-L-001–005, IL-CS-005, IL-CS-007, IL-NI-004 |
+| IH6 Primitive-specific | IL-CS-001–010, IL-R-008, IL-E-007, IL-NI-007, IL-CO-005, IL-CO-014 |
+| IH7 Replay | IL-PI-002, IL-R-001–008, IL-NI-003, IL-NI-005, IL-CO-009, IL-CO-013 |
+| IH8 Error | IL-E-001–007 |
+| IH9 Invalid sites (no allocator) | IL-B-003, IL-B-004, IL-B-006, IL-V-001–007 |
+| IH10 Composition | IL-A-006, IL-N-001–004 |
+| IH11 Replay-dispatch | IL-RD-001–004 |
+| IH12 Call-site | IL-V-001–007, IL-NI-006 |
+| IH13 Caps + counter | IL-CO-001–014 |
+| IH14 Nested MVP | IL-NI-001–007, IL-CS-010, IL-CO-002, IL-CO-006, IL-CO-008 |
+
+### Tier counts
+
+| Category | Core | Extended | Diagnostic | Total |
+|---|---|---|---|---|
+| Primary invariant | 3 | 0 | 0 | 3 |
+| Basic | 5 | 1 | 0 | 6 |
+| Allocator (§4.2 amendment) | 6 | 0 | 0 | 6 |
+| Call-site | 6 | 1 | 0 | 7 |
+| Capability ownership | 9 | 1 | 0 | 10 |
+| Owner counter | 4 | 0 | 0 | 4 |
+| Nested inline | 7 | 0 | 0 | 7 |
+| Journal | 6 | 0 | 0 | 6 |
+| Child semantics | 8 | 2 | 0 | 10 |
+| Replay | 8 | 0 | 0 | 8 |
+| Ordering | 4 | 0 | 0 | 4 |
+| Lifetime | 5 | 0 | 0 | 5 |
+| Error | 7 | 0 | 0 | 7 |
+| Cancellation | 2 | 0 | 0 | 2 |
+| Replay-dispatch | 4 | 0 | 0 | 4 |
+| `invoke` regression | 4 | 0 | 0 | 4 |
+| Interaction | 5 | 1 | 0 | 6 |
+| Existing regression | 4 | 0 | 0 | 4 |
+| **Total** | **97** | **6** | **0** | **103** |

--- a/specs/tisyn-nested-invocation-specification.md
+++ b/specs/tisyn-nested-invocation-specification.md
@@ -320,6 +320,8 @@ The following are explicitly out of scope for this specification version and MUS
 - `invoke` from any site other than an `Effects.around({ dispatch })` body. Facade `.around(...)` middleware, `resolve` middleware, agent operation handlers, IR middleware, and compiler-authored middleware are **not** invoking surfaces in this revision; calls from those sites MUST throw `InvalidInvokeCallSiteError`.
 - Subordinate remote execution as a feature. §14 records only compatibility anchors.
 
+**Relationship to inline invocation.** Shared-lifetime inline execution is provided by `invokeInline` (`tisyn-inline-invocation-specification.md`). `invoke` from middleware handling inline-body dispatches retains full nested-invocation semantics.
+
 ---
 
 ## 16. Synchronized cross-spec amendments

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -176,6 +176,8 @@ intercepts user-defined effect calls.
 > `Effects.around()` middleware applies at the shared dispatch
 > boundary regardless of which path an effect takes to reach it.
 
+> The runtime MAY expose `invokeInline(fn, args, opts?)` from `Effects.around({ dispatch })` middleware. Effects journal under a distinct inline lane coroutineId (journal identity); capability ownership and counter allocation use the original caller's coroutineId (owner identity). Owner coroutineId is runtime context, not durable data. The lane does not produce a `CloseEvent`. Child-bearing primitives retain own semantics. Participates in §9.5 replay. Nested inline permitted. Semantics: `tisyn-inline-invocation-specification.md`.
+
 ### 3.2 Effect ID Namespace
 
 Effects are identified by string IDs. The `tisyn.*` namespace
@@ -1007,17 +1009,17 @@ through a separate path that bypasses the replay boundary.
 
 ---
 
-> **Note (future extensions).** This specification defines
-> replay substitution against the current
+> **Note (future extensions and interactions).** This
+> specification defines replay substitution against the current
 > `YieldEvent | CloseEvent` durable algebra and
-> effect-description (type + name) cursor matching. Two future
-> extensions are expected to compose with this model without
-> changing §9.5.1–§9.5.7: (a) payload-sensitive cursor
-> matching, if and when a payload-fingerprint specification is
-> adopted, and (b) inline invocation, if and when an
-> inline-invocation specification is adopted. Neither
-> extension is specified here, and neither is required for
-> conformance to §9.5.
+> effect-description (type + name) cursor matching.
+> Payload-sensitive cursor matching is expected to compose with
+> this model without changing §9.5.1–§9.5.7, if and when a
+> payload-fingerprint specification is adopted. Inline
+> invocation is specified by
+> `tisyn-inline-invocation-specification.md`; effects dispatched
+> during inline-body evaluation participate in §9.5 replay per
+> that specification's §9 (Replay Model).
 
 ---
 

--- a/specs/tisyn-scoped-effects-test-plan.md
+++ b/specs/tisyn-scoped-effects-test-plan.md
@@ -496,10 +496,13 @@ regression, not removal regression.
 | RD-EX-005 | Core | Journal-visible | Full existing nested-invocation test plan passes | Identical journals |
 | RD-EX-006 | Core | Journal-visible | Full existing payload-sensitive divergence tests pass | Identical journals |
 
-> **Note.** Test IDs `RD-IL-*`, `RD-PD-*`, `RD-MX-003`, and
-> `RD-EX-004` are reserved for future phases that introduce
-> inline-invocation and payload-fingerprint specifications.
-> They are intentionally not defined in this test plan.
+> **Note.** Test IDs `RD-PD-*` and `RD-EX-004` are reserved
+> for a future payload-fingerprint specification and are
+> intentionally not defined in this test plan. Test IDs
+> `RD-IL-*` and `RD-MX-003` are deliberately not defined here
+> either; inline-invocation coverage lives in
+> `tisyn-inline-invocation-test-plan.md`, which is the
+> authoritative test plan for `invokeInline` semantics.
 
 ### 13.12 Minimum Acceptance Subset
 

--- a/specs/tisyn-scoped-effects-test-plan.md
+++ b/specs/tisyn-scoped-effects-test-plan.md
@@ -496,11 +496,12 @@ regression, not removal regression.
 | RD-EX-005 | Core | Journal-visible | Full existing nested-invocation test plan passes | Identical journals |
 | RD-EX-006 | Core | Journal-visible | Full existing payload-sensitive divergence tests pass | Identical journals |
 
-> **Note.** Test IDs `RD-PD-*` and `RD-EX-004` are reserved
-> for a future payload-fingerprint specification and are
-> intentionally not defined in this test plan. Test IDs
-> `RD-IL-*` and `RD-MX-003` are deliberately not defined here
-> either; inline-invocation coverage lives in
+> **Note.** Test IDs `RD-PD-*` are reserved for a future
+> payload-fingerprint specification and are intentionally not
+> defined in this test plan (payload-sensitive divergence
+> regression is already covered by `RD-EX-006`). Test IDs
+> `RD-IL-*`, `RD-MX-003`, and `RD-EX-004` are deliberately not
+> defined here either; inline-invocation coverage lives in
 > `tisyn-inline-invocation-test-plan.md`, which is the
 > authoritative test plan for `invokeInline` semantics.
 

--- a/specs/tisyn-stream-iteration-specification.md
+++ b/specs/tisyn-stream-iteration-specification.md
@@ -408,6 +408,10 @@ stream subscription handles.
 The string MUST be derived deterministically from `coroutineId`
 and a monotonic subscription counter within that coroutine.
 
+### 6.2.1 Subscription Counter Under Inline Invocation
+
+When a `stream.subscribe` effect is dispatched during inline-body evaluation (as defined by `tisyn-inline-invocation-specification.md`), the subscription counter from which the deterministic token is allocated MUST be the counter associated with the owner coroutineId, not the journal coroutineId. The owner coroutineId is the original inline caller's coroutineId per inline-invocation §12.3. All inline lanes that share the same owner coroutineId share a single subscription counter, ensuring token uniqueness across sibling and nested inline invocations. The `YieldEvent` for the `stream.subscribe` effect is written under the journal coroutineId (the inline lane) per normal journaling rules; the token inside the event result is drawn from the owner's shared counter. On replay, the counter is reconstructed by deterministic re-execution of the same inline-invocation sequence. Capability ancestry checks use the owner coroutineId per inline-invocation §12.7.
+
 ### 6.3 Restriction Table
 
 | Where | Permitted? | Enforced by |


### PR DESCRIPTION
## Summary

Adds shared-lifetime step execution to the Tisyn spec corpus.
Middleware can now run a sequence of inline bodies — each with its
own durable replay identity — while resources acquired in one step
stay available to subsequent steps. Inline lanes get distinct
journal coroutineIds for deterministic replay, but capability
ownership and subscription-counter allocation track the original
caller's coroutineId so tokens don't collide across sibling or
nested inline calls. This unlocks the middleware-as-orchestrator
pattern without changing `invoke`'s semantics.

This PR is spec-only. It makes the semantics normative so later
implementation phases can cite a settled document. No runtime code,
no package exports, no changeset.

Refs #122 (not Closes — implementation remains a separate phase).

## What changed

- **New: `specs/tisyn-inline-invocation-specification.md`** (v6,
  verbatim). Defines `invokeInline(fn, args, opts?)`, inline-lane
  identity, capability/counter ownership, replay model, ordering,
  lifetime, error propagation, cancellation, and synchronized
  cross-spec amendments.
- **New: `specs/tisyn-inline-invocation-test-plan.md`** (v6,
  verbatim). Conformance test plan for the spec.
- **Scoped-effects §3.1**: inserted the v6 §17.1 cross-reference
  blockquote after the compiled/facade-paths note.
- **Scoped-effects §9.5 forward-compat note**: rewritten. The
  payload-fingerprint extension stays "if and when"; the inline
  clause is replaced by a direct pointer at the now-landed spec.
- **Scoped-effects test plan forward-compat note**: split. `RD-IL-*`
  and `RD-MX-003` are re-framed as "coverage lives in the inline
  test plan"; `RD-PD-*` / `RD-EX-004` stay reserved for the unlanded
  payload-fingerprint spec.
- **Nested-invocation §15**: appended the v6 §17.2 relationship note.
  Shared-lifetime inline execution is provided by `invokeInline`;
  `invoke` inside inline-body dispatches retains full
  nested-invocation semantics.
- **Stream-iteration**: new **§6.2.1 Subscription Counter Under
  Inline Invocation**, text verbatim from v6 §17.3.
- **Compound-concurrency §4.2**: appended v6 §17.4 as a new
  paragraph after the I-ID invariant. Opening adjusted from v6's
  "also advanced by inline invocation" to "Additionally, ... is
  advanced by inline invocation" because the nested-invocation §16.2
  cross-reference v6 presupposes has not been landed on current
  main. Rest is verbatim.
- **README specs table**: two new rows for inline-invocation spec +
  test plan, grouped with Resource Specification.

## Non-goals (in this PR)

- No runtime code, no `@tisyn/*` exports.
- No package changeset (spec-only PR, matches Phase 2 precedent).
- No `runAsTerminal` / `RuntimeTerminal*` / `payloadSha` /
  `description.sha` content anywhere (grep-verified).
- No PR #123 artifacts — v6 supersedes that exploratory material.
- No implementation of `invokeInline`.
- No landing of `specs/tisyn-nested-invocation-specification.md`
  §16.1 / §16.2 cross-references (pre-existing unlanded amendments
  that v6 references but which are outside this PR's scope — a
  separate spec-maintenance PR).
- Does not close #122.

## Test plan

- [x] `pnpm run format:check` — green
- [x] `pnpm run build` — green
- [x] `pnpm run test` — all suites green (root workspace run, per
      `feedback_run_root_test_before_pr` memory)
- [x] Grep: zero matches for `runAsTerminal`, `RuntimeTerminal`,
      `payloadSha`, `description.sha` in the new inline files.
- [x] Grep: zero matches for `if and when an inline-invocation`
      anywhere in `specs/` after this PR.

Refs #122