### PR TITLE
Implement inline-lane subscription ownership

### DIFF
--- a/.changeset/effects-inline-stream-ownership.md
+++ b/.changeset/effects-inline-stream-ownership.md
@@ -1,0 +1,21 @@
+---
+"@tisyn/effects": patch
+---
+
+Extend the internal `DispatchContext` seam with
+`readonly ownerCoroutineId: string` so the runtime can
+propagate capability-ownership identity through the
+dispatch chain (inline lanes inherit the caller's owner;
+`invoke` children reset to the child's own coroutineId).
+
+`DispatchContext` is exported only from
+`@tisyn/effects/internal` and has no stable-surface
+contract; external consumers only interact with it via
+`DispatchContext.with(undefined, ...)` to isolate agent
+bodies, which is unchanged. The `invokeInline` public
+helper signature is unchanged.
+
+Paired with the runtime-side implementation that lifts
+`stream.subscribe` / `stream.next` rejection inside
+`invokeInline` bodies. See
+`tisyn-inline-invocation-specification.md` §12.

--- a/.changeset/runtime-inline-stream-ownership.md
+++ b/.changeset/runtime-inline-stream-ownership.md
@@ -1,0 +1,46 @@
+---
+"@tisyn/runtime": patch
+---
+
+Lift the Phase 5B rejection of `stream.subscribe` and
+`stream.next` inside `invokeInline` bodies by implementing the
+owner-coroutineId counter model from
+`tisyn-inline-invocation-specification.md` §12.
+
+- **Shared subscription counter across inline siblings and
+  caller.** Subscription tokens are now allocated from a
+  counter keyed by the dispatch chain's **owner coroutineId** —
+  the original caller's coroutineId, captured once at the
+  outermost `invokeInline` and inherited unchanged through
+  nested inline calls. Sibling inline lanes and the caller
+  itself share a single token namespace, so a handle acquired
+  inside an inline body can be used by another sibling inline
+  lane or by the caller after the inline returns, without
+  spurious `SubscriptionCapabilityError` ancestry failures or
+  token collisions.
+- **`invoke` children keep their own namespace.** Per §12.8,
+  an `invoke` child is its own owner: tokens allocated inside
+  the child are prefixed with the child's coroutineId, and the
+  caller cannot use handles that escape an `invoke` child
+  (ancestry check correctly fails).
+- **`stream.next` ancestry check compares owner identity**
+  (not journal coroutineId). For ordinary dispatch where owner
+  equals coroutineId, behavior is byte-identical to the prior
+  release — no fixture changes in the stream-iteration or
+  replay-dispatch suites.
+- **Journal shape unchanged.** Stream YieldEvents continue to
+  journal under the inline lane's coroutineId; owner identity
+  lives only in runtime context and inside the opaque
+  subscription-handle token string (which already encoded a
+  coroutineId in the prior format). No new durable event
+  kinds, no `ownerCoroutineId` field on `YieldEvent`, no
+  kernel/compiler/IR changes.
+
+Compound externals inside inline bodies (`scope`, `spawn`,
+`join`, `resource`, `timebox`, `all`, `race`) remain rejected
+with a clear error — lifting those is a follow-up phase.
+
+Non-breaking for existing workloads: ordinary dispatch and
+`invoke`-child subscription tokens keep their
+`sub:<coroutineId>:<n>` shape. Semantics per
+`tisyn-inline-invocation-specification.md` §12.

--- a/packages/effects/src/internal/dispatch-context.ts
+++ b/packages/effects/src/internal/dispatch-context.ts
@@ -32,6 +32,19 @@ import type { InvokeOpts } from "../dispatch.js";
  */
 export interface DispatchContext {
   readonly coroutineId: string;
+  /**
+   * Runtime-only identity used for capability ownership and shared
+   * subscription-counter allocation. Equals `coroutineId` for ordinary
+   * dispatch and for `invoke` children (the child's own coroutineId
+   * becomes its own owner). Inherited unchanged from the outermost
+   * `invokeInline`'s caller for inline lanes — sibling inline lanes
+   * and the caller itself share a single owner coroutineId, and thus
+   * a single subscription-token counter. See
+   * `tisyn-inline-invocation-specification.md` §12.3, §12.8.
+   *
+   * Not written into YieldEvents or any durable stream data.
+   */
+  readonly ownerCoroutineId: string;
   invoke<T = Val>(fn: FnNode, args: readonly Val[], opts?: InvokeOpts): Operation<T>;
   invokeInline<T = Val>(fn: FnNode, args: readonly Val[], opts?: InvokeOpts): Operation<T>;
 }

--- a/packages/effects/src/invoke-inline.ts
+++ b/packages/effects/src/invoke-inline.ts
@@ -32,13 +32,16 @@ import type { InvokeOpts } from "./dispatch.js";
  * only.
  *
  * See `tisyn-inline-invocation-specification.md` for the full
- * normative contract. Phase 5B runtime scope: standard-effect
- * dispatch inside the body, nested `invokeInline` / `invoke` calls
- * reached through standard-effect middleware. `stream.subscribe` /
- * `stream.next` and all compound externals (`scope`, `spawn`, `join`,
- * `resource`, `timebox`, `all`, `race`) inside an inline body are
- * rejected with a clear error in this phase; runtime follow-ups will
- * lift those restrictions.
+ * normative contract. The current runtime phase supports standard-
+ * effect dispatch inside the body, nested `invokeInline` / `invoke`
+ * calls reached through standard-effect middleware, and
+ * `stream.subscribe` / `stream.next` with owner-coroutineId counter
+ * allocation (§12.4) — sibling inline lanes and the original caller
+ * share a single subscription counter, so handles acquired inside
+ * inline bodies compose with each other and with the caller
+ * (§12.7). Compound externals (`scope`, `spawn`, `join`, `resource`,
+ * `timebox`, `all`, `race`) inside an inline body are still rejected
+ * with a clear error; follow-up runtime phases will lift those.
  */
 export function* invokeInline<T = Val>(
   fn: FnNode,

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -83,6 +83,16 @@ interface DriveContext {
   journal: DurableEvent[];
   /** Stream subscription map shared across all coroutines in the execution. */
   subscriptions: Map<string, SubscriptionEntry>;
+  /**
+   * Subscription-token counters keyed by owner coroutineId. All dispatch
+   * sites that share an owner — the owner's own coroutine plus every inline
+   * lane whose captured owner is that coroutine — allocate subscription
+   * tokens from the same counter entry. Ensures token uniqueness across
+   * sibling inline lanes and across the caller/lane boundary, per
+   * `tisyn-inline-invocation-specification.md` §12.4. Runtime state only;
+   * never journaled.
+   */
+  subscriptionCounters: Map<string, number>;
 }
 
 /**
@@ -202,13 +212,15 @@ function mapChildResultToOperationOutcome<T>(r: EventResult): T {
 
 function buildDispatchContext(args: {
   coroutineId: string;
+  ownerCoroutineId: string;
   parentEnv: Env;
   driveContext: DriveContext;
   allocateChildId: () => string;
 }): DispatchContext {
-  const { coroutineId, parentEnv, driveContext, allocateChildId } = args;
+  const { coroutineId, ownerCoroutineId, parentEnv, driveContext, allocateChildId } = args;
   const self: DispatchContext = {
     coroutineId,
+    ownerCoroutineId,
     *invoke<T>(fn: FnNode, invokeArgs: readonly Val[], opts?: InvokeOpts): Operation<T> {
       // §5.3.3: may only be called while the SAME ctx is the currently-active
       // DispatchContext. Stale/captured/agent-handler reuse fails here and
@@ -263,10 +275,17 @@ function buildDispatchContext(args: {
       // +1 at the moment of the accepted call.
       const laneId = allocateChildId();
 
+      // v6 §12.3 capture-and-propagate: inherit owner from the active
+      // ctx. For the outermost invokeInline `self.ownerCoroutineId ===
+      // self.coroutineId`, so this captures the caller's coroutineId;
+      // for nested inline, it propagates the already-captured owner.
+      const laneOwner = self.ownerCoroutineId;
+
       const laneEnv = extendMulti(parentEnv, [...fn.params], invokeArgs as Val[]);
       const laneKernel = evaluate(fn.body as Expr, laneEnv);
 
-      const driveLane = () => driveInlineBody<T>(laneKernel, laneId, laneEnv, driveContext);
+      const driveLane = () =>
+        driveInlineBody<T>(laneKernel, laneId, laneEnv, driveContext, laneOwner);
 
       if (opts?.overlay) {
         return yield* withOverlayFrame(opts.overlay, driveLane);
@@ -281,12 +300,17 @@ function buildDispatchContext(args: {
 
 /**
  * Drive a compiled `Fn` as an inline lane under its caller's Effection
- * scope. Implements the Phase 5B subset of
+ * scope. Implements the relevant parts of
  * `tisyn-inline-invocation-specification.md` v6:
  *
- * - Standard-effect dispatches (agent effects + `__config`) journal
- *   under `laneId` via the shared `dispatchStandardEffect` helper and
- *   participate in replay on the lane's independent cursor.
+ * - Standard-effect dispatches (agent effects + `__config` + the
+ *   `stream.subscribe` / `stream.next` intrinsics) journal under
+ *   `laneId` via the shared `dispatchStandardEffect` helper and
+ *   participate in replay on the lane's independent cursor. The
+ *   stream intrinsics allocate subscription tokens from the **owner's**
+ *   shared counter (§12.4) rather than the lane's own counter, so
+ *   sibling inline lanes and the original caller can use each other's
+ *   handles without collisions (§12.7).
  * - Lane has its own `childSpawnCount` starting at 0 (v6 §7.3); nested
  *   `invokeInline` / `invoke` from middleware handling the body's
  *   dispatched effects allocate from this per-lane counter.
@@ -295,23 +319,20 @@ function buildDispatchContext(args: {
  *   directly to the caller's middleware frame.
  * - Compound externals (`scope`, `spawn`, `join`, `resource`,
  *   `timebox`, `all`, `race`) inside an inline body are rejected with
- *   a clear error: Phase 5B runtime scope does NOT run them under
+ *   a clear error: this runtime phase does NOT run them under
  *   inline-lane semantics yet.
- * - `stream.subscribe` and `stream.next` inside an inline body are
- *   rejected with a clear error: v6 §12.4 requires owner-coroutineId
- *   counter allocation for the deterministic token; Phase 5B defers
- *   that and rejects the effect ids rather than producing journal
- *   entries that would violate the landed spec.
  */
 function* driveInlineBody<T = Val>(
   kernel: Generator<EffectDescriptor, Val, Val>,
   laneId: string,
   env: Env,
   ctx: DriveContext,
+  ownerCoroutineId: string,
 ): Operation<T> {
-  // Own childSpawnCount per v6 §7.3.
+  // Own childSpawnCount per v6 §7.3. Subscription counter state lives on
+  // `ctx.subscriptionCounters[ownerCoroutineId]`, shared with the caller
+  // and any sibling/nested inline lanes whose captured owner matches.
   let inlineChildSpawnCount = 0;
-  let subscriptionCounter = 0; // Never consumed: stream effects rejected below.
   let nextValue: Val = null;
   let pendingStep: IteratorResult<EffectDescriptor, Val> | null = null;
 
@@ -327,43 +348,28 @@ function* driveInlineBody<T = Val>(
 
     const descriptor = step.value as EffectDescriptor;
 
-    // Compound-external descriptors are out of scope for this phase (see
-    // decision log §4 of the Phase 5B plan). Reject uniformly with a
-    // clear error that names the descriptor id.
+    // Compound-external descriptors are out of scope for this phase.
+    // Reject uniformly with a clear error that names the descriptor id.
     if (isCompoundExternal(descriptor.id)) {
       throw new Error(
         `invokeInline body dispatched compound external '${descriptor.id}'; ` +
-          `compound primitives inside inline bodies are deferred (Phase 5B scope; ` +
-          `see tisyn-inline-invocation-specification.md §11)`,
+          `compound primitives inside inline bodies are deferred ` +
+          `(see tisyn-inline-invocation-specification.md §11)`,
       );
     }
 
-    // Stream intrinsics require owner-coroutineId counter allocation
-    // per v6 §12.4 which is deferred. Reject both effect ids rather
-    // than emitting lane-local tokens that would violate the spec.
-    if (descriptor.id === "stream.subscribe" || descriptor.id === "stream.next") {
-      throw new Error(
-        `invokeInline body dispatched '${descriptor.id}'; stream effects inside ` +
-          `inline bodies require owner-counter semantics ` +
-          `(tisyn-inline-invocation-specification.md §12.4) which are deferred ` +
-          `in Phase 5B. Use plain agent effects inside the inline body for now.`,
-      );
-    }
-
-    // Agent effects and `__config` go through the shared helper. The
-    // lane's independent coroutineId + its own allocator are threaded
-    // through here so nested invoke/invokeInline calls from middleware
-    // handling the body's dispatched effects allocate from the lane.
+    // Agent effects, `__config`, and stream intrinsics all go through the
+    // shared helper. The lane's journal coroutineId is `laneId`; the
+    // owner coroutineId captured at the outermost `invokeInline` (and
+    // inherited unchanged through nested inline) drives subscription-
+    // token allocation and `stream.next` ancestry — v6 §12.3–§12.7.
     const { result } = yield* dispatchStandardEffect({
       descriptor,
       coroutineId: laneId,
+      ownerCoroutineId,
       env,
       ctx,
       allocateChildId: () => `${laneId}.${inlineChildSpawnCount++}`,
-      allocateSubscriptionToken: () => `sub:${laneId}:${subscriptionCounter++}`,
-      advanceSubscriptionCounter: () => {
-        subscriptionCounter++;
-      },
     });
 
     if (result.status === "ok") {
@@ -509,6 +515,7 @@ export function* execute(options: ExecuteOptions): Operation<ExecuteResult> {
       stream,
       journal,
       subscriptions: new Map(),
+      subscriptionCounters: new Map(),
     };
 
     let result: EventResult;
@@ -582,8 +589,6 @@ function* driveKernel(
   let pendingStep: IteratorResult<EffectDescriptor, Val> | null = null;
   // Unified counter for all compound-external children (scope, all, race, spawn) — replay-safe.
   let childSpawnCount = 0;
-  // Per-coroutine subscription counter for deterministic token generation.
-  let subscriptionCounter = 0;
   // Spawn/join tracking
   const spawnedTasks = new Map<string, { operation: Operation<EventResult> }>();
   const joinedTasks = new Set<string>();
@@ -849,16 +854,18 @@ function* driveKernel(
         }
 
         // ── Standard effect dispatch (helper-unified) ──
+        // Ordinary driveKernel dispatch: owner == coroutineId (§12.8
+        // says `invoke` children get their own coroutineId as owner,
+        // which is exactly what this driveKernel call represents — its
+        // coroutineId was allocated by a parent and is this kernel's own
+        // identity).
         const { result: effectResult } = yield* dispatchStandardEffect({
           descriptor,
           coroutineId,
+          ownerCoroutineId: coroutineId,
           env,
           ctx,
           allocateChildId: () => `${coroutineId}.${childSpawnCount++}`,
-          allocateSubscriptionToken: () => `sub:${coroutineId}:${subscriptionCounter++}`,
-          advanceSubscriptionCounter: () => {
-            subscriptionCounter++;
-          },
         });
 
         if (effectResult.status === "ok") {
@@ -1259,8 +1266,6 @@ function* orchestrateResourceChild(
 
   // Shared across init and cleanup phases for deterministic coroutineId allocation
   let childSpawnCount = 0;
-  // Per-resource subscription counter for deterministic token generation
-  let subscriptionCounter = 0;
 
   // ── INIT PHASE ──
   // Drive kernel to provide in its own scope. When the scope exits (at provide
@@ -1392,16 +1397,14 @@ function* orchestrateResourceChild(
         }
 
         // ── Standard effect dispatch (helper-unified, resource init) ──
+        // Resource child is an ordinary coroutine with owner == childId.
         const { result: effectResult } = yield* dispatchStandardEffect({
           descriptor,
           coroutineId: childId,
+          ownerCoroutineId: childId,
           env: childEnv,
           ctx,
           allocateChildId: () => `${childId}.${childSpawnCount++}`,
-          allocateSubscriptionToken: () => `sub:${childId}:${subscriptionCounter++}`,
-          advanceSubscriptionCounter: () => {
-            subscriptionCounter++;
-          },
         });
 
         if (effectResult.status === "ok") {
@@ -1598,16 +1601,17 @@ function* orchestrateResourceChild(
         }
 
         // ── Standard effect dispatch (helper-unified, resource cleanup) ──
+        // ── Standard effect dispatch (helper-unified, resource cleanup) ──
+        // Resource child cleanup body runs under the same coroutineId +
+        // owner as the init body: both are ordinary dispatches from the
+        // resource child's perspective.
         const { result: effectResult } = yield* dispatchStandardEffect({
           descriptor,
           coroutineId: childId,
+          ownerCoroutineId: childId,
           env: childEnv,
           ctx,
           allocateChildId: () => `${childId}.${childSpawnCount++}`,
-          allocateSubscriptionToken: () => `sub:${childId}:${subscriptionCounter++}`,
-          advanceSubscriptionCounter: () => {
-            subscriptionCounter++;
-          },
         });
 
         if (effectResult.status === "ok") {
@@ -1664,16 +1668,40 @@ function* orchestrateResourceChild(
 interface DispatchStandardEffectParams {
   descriptor: EffectDescriptor;
   coroutineId: string;
+  /**
+   * Runtime-only owner identity for this dispatch. Used for
+   * subscription-token counter allocation (§12.4) and `stream.next`
+   * ancestry checks (§12.7). Equals `coroutineId` for ordinary
+   * dispatch; equals the original caller's coroutineId for inline
+   * lanes (`tisyn-inline-invocation-specification.md` §12.3).
+   */
+  ownerCoroutineId: string;
   env: Env;
   ctx: DriveContext;
   allocateChildId: () => string;
-  /** Allocate the next subscription token on the live `stream.subscribe` path. */
-  allocateSubscriptionToken: () => string;
-  /**
-   * Advance the caller's subscription counter on a replayed `stream.subscribe`
-   * success. Prevents token reuse when execution later reaches the live frontier.
-   */
-  advanceSubscriptionCounter: () => void;
+}
+
+/**
+ * Allocate the next subscription token for `owner` and advance the
+ * owner's shared counter in `ctx.subscriptionCounters`. Token format
+ * is `sub:<owner>:<n>` — same structure as pre-Phase-5C, but under
+ * inline-lane dispatches `<owner>` is the inherited owner coroutineId
+ * rather than the journal coroutineId.
+ */
+function allocateSubscriptionToken(ctx: DriveContext, owner: string): string {
+  const n = ctx.subscriptionCounters.get(owner) ?? 0;
+  ctx.subscriptionCounters.set(owner, n + 1);
+  return `sub:${owner}:${n}`;
+}
+
+/**
+ * Advance the owner's subscription counter without emitting a token —
+ * used on replay of `stream.subscribe` so the live frontier can't
+ * reuse an already-consumed token.
+ */
+function advanceSubscriptionCounter(ctx: DriveContext, owner: string): void {
+  const n = ctx.subscriptionCounters.get(owner) ?? 0;
+  ctx.subscriptionCounters.set(owner, n + 1);
 }
 
 interface DispatchStandardEffectResult {
@@ -1712,15 +1740,7 @@ interface DispatchStandardEffectResult {
 function* dispatchStandardEffect(
   params: DispatchStandardEffectParams,
 ): Operation<DispatchStandardEffectResult> {
-  const {
-    descriptor,
-    coroutineId,
-    env,
-    ctx,
-    allocateChildId,
-    allocateSubscriptionToken,
-    advanceSubscriptionCounter,
-  } = params;
+  const { descriptor, coroutineId, ownerCoroutineId, env, ctx, allocateChildId } = params;
 
   const description = parseEffectId(descriptor.id);
   const stored = ctx.replayIndex.peekYield(coroutineId);
@@ -1753,7 +1773,8 @@ function* dispatchStandardEffect(
       ctx.replayIndex.consumeYield(coroutineId);
 
       // stream.subscribe replay: restore subscription map entry from stored
-      // handle AND advance counter so the live frontier does not reuse tokens.
+      // handle AND advance the owner's shared counter (§12.4) so the live
+      // frontier does not reuse a token.
       if (descriptor.id === "stream.subscribe" && stored.result.status === "ok") {
         const handle = stored.result.value as Record<string, unknown> | null;
         if (handle && typeof handle === "object" && "__tisyn_subscription" in handle) {
@@ -1761,7 +1782,7 @@ function* dispatchStandardEffect(
             subscription: null,
             sourceDefinition: descriptor.data,
           });
-          advanceSubscriptionCounter();
+          advanceSubscriptionCounter(ctx, ownerCoroutineId);
         }
       }
 
@@ -1789,7 +1810,7 @@ function* dispatchStandardEffect(
       if (descriptor.id === "__config") {
         resultValue = (yield* ConfigContext.expect()) as Val;
       } else if (descriptor.id === "stream.subscribe") {
-        const token = allocateSubscriptionToken();
+        const token = allocateSubscriptionToken(ctx, ownerCoroutineId);
         const sourceData = descriptor.data as unknown[];
         const source = sourceData[0];
         const sub = yield* source as Operation<{
@@ -1809,11 +1830,16 @@ function* dispatchStandardEffect(
           throw new RuntimeBugError("stream.next: argument is not a valid subscription handle");
         }
         const token = handle.__tisyn_subscription as string;
-        // RV1: ancestor-or-equal coroutineId check
-        const handleCid = token.split(":")[1]!;
-        if (coroutineId !== handleCid && !coroutineId.startsWith(handleCid + ".")) {
+        // Ancestry check (§12.7). Compare the token's embedded owner
+        // against the current dispatch's owner, not the journal
+        // coroutineId. This lets sibling inline lanes (shared owner)
+        // use each other's handles and the caller reuse handles
+        // acquired inside inline bodies, while keeping `invoke`
+        // children's handles (own owner) scoped to the child subtree.
+        const handleOwner = token.split(":")[1]!;
+        if (ownerCoroutineId !== handleOwner && !ownerCoroutineId.startsWith(handleOwner + ".")) {
           throw new SubscriptionCapabilityError(
-            `stream.next: handle from '${handleCid}' cannot be used from '${coroutineId}'`,
+            `stream.next: handle from '${handleOwner}' cannot be used from '${ownerCoroutineId}'`,
           );
         }
         const entry = ctx.subscriptions.get(token);
@@ -1880,6 +1906,7 @@ function* dispatchStandardEffect(
   // middleware gains invoke capability (§9.5.7).
   const dispatchCtx = buildDispatchContext({
     coroutineId,
+    ownerCoroutineId,
     parentEnv: env,
     driveContext: ctx,
     allocateChildId,

--- a/packages/runtime/src/inline-invocation.test.ts
+++ b/packages/runtime/src/inline-invocation.test.ts
@@ -1,22 +1,26 @@
 /**
- * Inline invocation — core runtime slice tests (Phase 5B, Refs #122).
+ * Inline invocation runtime tests (Refs #122).
  *
- * Covers the IL-* subset from `tisyn-inline-invocation-test-plan.md` that is
- * implementable under the Phase 5B scope: basic invocation (§6), allocator
- * and lane-id format (§7), journal shape (§8), ordering (§10), replay (§9),
- * call-site rejection (§6.2), nested inline (§7.6), and `invoke` inside
- * inline (§11.3).
+ * Covers the IL-* subset from `tisyn-inline-invocation-test-plan.md`
+ * that is implementable today:
+ *
+ *  - Basic invocation (§6), allocator and lane-id format (§7), journal
+ *    shape (§8), ordering (§10), replay (§9), call-site rejection
+ *    (§6.2), nested inline (§7.6), and `invoke` inside inline (§11.3).
+ *  - Capability ownership and counter allocation (§12): owner-
+ *    coroutineId shared subscription counter, sibling-lane handle
+ *    reuse, caller-after-return handle reuse, `invoke`-child isolated
+ *    namespace, replay counter reconstruction.
  *
  * Out of scope — not tested here:
- *   - stream.subscribe / stream.next inside inline bodies (rejected loudly
- *     by driveInlineBody; owner-counter semantics §12.4 deferred).
  *   - Compound externals (scope/spawn/join/resource/timebox/all/race)
- *     inside inline bodies (rejected loudly).
+ *     inside inline bodies (still rejected loudly by driveInlineBody).
  *   - IL-INT-*, IL-RD-*, IL-EX-*, and the full 31-test minimum subset.
  */
 
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
+import type { Operation } from "effection";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import type { DurableEvent, YieldEvent, CloseEvent } from "@tisyn/kernel";
 import { Fn, Eval, Ref, Arr, Q, Try } from "@tisyn/ir";
@@ -824,5 +828,594 @@ describe("invokeInline — core runtime slice", () => {
     expect(laneYields).toHaveLength(1);
     expect(laneYields[0]!.description).toEqual({ type: "failing", name: "op" });
     expect(laneYields[0]!.result.status).toBe("error");
+  });
+
+  // ── Capability ownership + counter allocation (§12, IH13) ──
+
+  // Mock Effection-compatible stream for inline tests. Emits `items` in order
+  // then signals `done: true`. Matches the shape used by stream-iteration.test.ts.
+  function mockStream(
+    items: Val[],
+  ): Operation<{ next(): Operation<IteratorResult<Val, unknown>> }> {
+    let idx = 0;
+    return {
+      *[Symbol.iterator]() {
+        return {
+          next(): Operation<IteratorResult<Val, unknown>> {
+            return {
+              *[Symbol.iterator]() {
+                if (idx < items.length) {
+                  return { done: false as const, value: items[idx++] as Val };
+                }
+                return { done: true as const, value: undefined };
+              },
+            } as Operation<IteratorResult<Val, unknown>>;
+          },
+        };
+      },
+    } as Operation<{ next(): Operation<IteratorResult<Val, unknown>> }>;
+  }
+
+  // IR builders scoped to stream tests.
+  const streamSubscribe = (sourceName: string): Val =>
+    ({ tisyn: "eval", id: "stream.subscribe", data: [Ref(sourceName)] }) as unknown as Val;
+  const streamNext = (handleName: string): Val =>
+    ({ tisyn: "eval", id: "stream.next", data: [Ref(handleName)] }) as unknown as Val;
+
+  // Helper: Fn([], stream.subscribe([Ref(sourceName)])) — returns the handle.
+  const subscribeBodyFn = (sourceName: string): TisynFn<[], Val> =>
+    Fn<[], Val>([], streamSubscribe(sourceName) as unknown as Val) as unknown as TisynFn<[], Val>;
+
+  // Helper: Fn(["h"], stream.next([Ref("h")])) — expects a handle arg.
+  const nextBodyFn: TisynFn<[Val], Val> = Fn<[Val], Val>(
+    ["h"],
+    streamNext("h") as unknown as Val,
+  ) as unknown as TisynFn<[Val], Val>;
+
+  it("IL-CO-001: sibling inline lanes share owner — B can use A's handle", function* () {
+    // Inline A subscribes; inline B uses the handle. Both triggered by
+    // sequential caller effects, each handled by middleware that invokes
+    // the corresponding body.
+    let handleFromA: Val | undefined;
+    let nextResultInB: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.triggerA") {
+          handleFromA = yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+          return null as Val;
+        }
+        if (effectId === "parent.triggerB") {
+          nextResultInB = yield* invokeInline<Val>(asFn(nextBodyFn), [handleFromA as Val]);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // IR: let _ = parent.triggerA in parent.triggerB
+    const ir = {
+      tisyn: "eval",
+      id: "let",
+      data: {
+        tisyn: "quote",
+        expr: {
+          name: "_",
+          value: { tisyn: "eval", id: "parent.triggerA", data: [] },
+          body: { tisyn: "eval", id: "parent.triggerB", data: [] },
+        },
+      },
+    };
+
+    const { journal } = yield* execute({
+      ir: ir as never,
+      env: { source: mockStream([42]) as unknown as Val },
+    });
+
+    // stream.subscribe journaled under lane A (root.0).
+    const subEvent = yields(journal).find(
+      (e) => e.description.type === "stream" && e.description.name === "subscribe",
+    );
+    expect(subEvent?.coroutineId).toBe("root.0");
+    // stream.next journaled under lane B (root.1).
+    const nextEvent = yields(journal).find(
+      (e) => e.description.type === "stream" && e.description.name === "next",
+    );
+    expect(nextEvent?.coroutineId).toBe("root.1");
+    // No ancestry failure and the iteration returned 42.
+    expect(nextResultInB).toEqual({ done: false, value: 42 });
+    // Handle token prefix uses owner (root), not lane id.
+    expect((handleFromA as Record<string, unknown>).__tisyn_subscription).toMatch(/^sub:root:\d+$/);
+  });
+
+  it("IL-CO-002: nested inline subscribes; caller uses handle after inline returns", function* () {
+    // Outer inline invokes inner inline, which subscribes and returns the
+    // handle. Outer returns the handle. Middleware captures it, then the
+    // caller's kernel dispatches stream.next with that handle.
+    const outerBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      Eval<Val>("outer.trigger", Q([])),
+    ) as unknown as TisynFn<[], Val>;
+
+    let outerLaneHandle: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.acquire") {
+          outerLaneHandle = yield* invokeInline<Val>(asFn(outerBody), []);
+          return outerLaneHandle as Val;
+        }
+        if (effectId === "outer.trigger") {
+          // Middleware handling the inner-level effect invokes the
+          // innermost inline lane which does the actual subscribe.
+          return yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // IR: let h = parent.acquire in stream.next([h])
+    const ir = {
+      tisyn: "eval",
+      id: "let",
+      data: {
+        tisyn: "quote",
+        expr: {
+          name: "h",
+          value: { tisyn: "eval", id: "parent.acquire", data: [] },
+          body: { tisyn: "eval", id: "stream.next", data: [Ref("h")] },
+        },
+      },
+    };
+
+    const { result, journal } = yield* execute({
+      ir: ir as never,
+      env: { source: mockStream([99]) as unknown as Val },
+    });
+
+    // Caller's stream.next succeeded — ancestry passed (owner is root at
+    // both sites: the outer invokeInline inherited, the inner one too).
+    expect(result).toEqual({ status: "ok", value: { done: false, value: 99 } });
+
+    // The subscribe event is under the innermost lane (root.0.0).
+    const subEvent = yields(journal).find(
+      (e) => e.description.type === "stream" && e.description.name === "subscribe",
+    );
+    expect(subEvent?.coroutineId).toBe("root.0.0");
+    // The next event is under the caller (root).
+    const nextEvent = yields(journal).find(
+      (e) => e.description.type === "stream" && e.description.name === "next",
+    );
+    expect(nextEvent?.coroutineId).toBe("root");
+  });
+
+  it("IL-CO-003: stream.subscribe YieldEvent journals under laneId with owner-keyed token", function* () {
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.trigger") {
+          yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { journal } = yield* execute({
+      ir: effectIR("parent", "trigger") as never,
+      env: { source: mockStream([]) as unknown as Val },
+    });
+
+    const subEvent = yields(journal).find(
+      (e) => e.description.type === "stream" && e.description.name === "subscribe",
+    );
+    expect(subEvent).toBeDefined();
+    // Journal identity: lane coroutineId, NOT the caller's.
+    expect(subEvent?.coroutineId).toBe("root.0");
+    // Token prefix: owner coroutineId (the caller, root), not the lane id.
+    const handle = (subEvent!.result as { status: "ok"; value: Record<string, unknown> }).value;
+    expect(handle.__tisyn_subscription).toMatch(/^sub:root:\d+$/);
+  });
+
+  it("IL-CO-007: YieldEvent shape unchanged — no ownerCoroutineId field", function* () {
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.trigger") {
+          yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const stream = new InMemoryStream();
+    yield* execute({
+      ir: effectIR("parent", "trigger") as never,
+      stream,
+      env: { source: mockStream([]) as unknown as Val },
+    });
+    const persisted = yield* stream.readAll();
+
+    const subEvent = persisted.find(
+      (e) =>
+        e.type === "yield" &&
+        (e as YieldEvent).description.type === "stream" &&
+        (e as YieldEvent).description.name === "subscribe",
+    );
+    expect(subEvent).toBeDefined();
+    // Normative durable-event keys only — no runtime-only owner field
+    // leaks into the stream.
+    const keys = Object.keys(subEvent as object).sort();
+    expect(keys).toEqual(["coroutineId", "description", "result", "type"]);
+  });
+
+  it("IL-CO-011: caller + two sibling inline lanes allocate unique owner-counter tokens", function* () {
+    // IR: caller subscribe, then two sequential inline subscribes via
+    // middleware triggers.
+    const ir = {
+      tisyn: "eval",
+      id: "let",
+      data: {
+        tisyn: "quote",
+        expr: {
+          name: "h0",
+          value: streamSubscribe("source"),
+          body: {
+            tisyn: "eval",
+            id: "let",
+            data: {
+              tisyn: "quote",
+              expr: {
+                name: "_1",
+                value: { tisyn: "eval", id: "parent.triggerA", data: [] },
+                body: { tisyn: "eval", id: "parent.triggerB", data: [] },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.triggerA") {
+          yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+          return null as Val;
+        }
+        if (effectId === "parent.triggerB") {
+          yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { journal } = yield* execute({
+      ir: ir as never,
+      env: { source: mockStream([]) as unknown as Val },
+    });
+
+    const subEvents = yields(journal).filter(
+      (e) => e.description.type === "stream" && e.description.name === "subscribe",
+    );
+    expect(subEvents).toHaveLength(3);
+
+    const tokens = subEvents.map(
+      (e) =>
+        (e.result as { status: "ok"; value: { __tisyn_subscription: string } }).value
+          .__tisyn_subscription,
+    );
+    // All three tokens distinct.
+    expect(new Set(tokens).size).toBe(3);
+    // All three share the owner (root), allocated sequentially from one counter.
+    expect(tokens).toEqual(["sub:root:0", "sub:root:1", "sub:root:2"]);
+
+    // Subscribe events under root (caller), root.0 (lane A), root.1 (lane B).
+    expect(subEvents.map((e) => e.coroutineId)).toEqual(["root", "root.0", "root.1"]);
+  });
+
+  it("IL-CO-012: sibling lane can use another sibling lane's handle via shared owner", function* () {
+    // Lane A subscribes and returns handle H; lane B uses H to take one
+    // item. Both lanes share the same owner (caller = root), so ancestry
+    // passes and the tokens belong to the same counter family.
+    let handleFromA: Val | undefined;
+    let itemInB: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.triggerA") {
+          handleFromA = yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+          return null as Val;
+        }
+        if (effectId === "parent.triggerB") {
+          // Lane B subscribes first (T2) then uses H from A.
+          const bBodySubscribeThenUseA: TisynFn<[Val], Val> = Fn<[Val], Val>(["h"], {
+            tisyn: "eval",
+            id: "let",
+            data: {
+              tisyn: "quote",
+              expr: {
+                name: "_own",
+                value: streamSubscribe("source"),
+                body: streamNext("h"),
+              },
+            },
+          } as unknown as Val) as unknown as TisynFn<[Val], Val>;
+          itemInB = yield* invokeInline<Val>(asFn(bBodySubscribeThenUseA), [handleFromA as Val]);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const ir = {
+      tisyn: "eval",
+      id: "let",
+      data: {
+        tisyn: "quote",
+        expr: {
+          name: "_",
+          value: { tisyn: "eval", id: "parent.triggerA", data: [] },
+          body: { tisyn: "eval", id: "parent.triggerB", data: [] },
+        },
+      },
+    };
+
+    const { journal } = yield* execute({
+      ir: ir as never,
+      env: { source: mockStream([7]) as unknown as Val },
+    });
+
+    // Ancestry passed: lane B successfully pulled from lane A's handle.
+    expect(itemInB).toEqual({ done: false, value: 7 });
+
+    // Two subscribes → two tokens, pairwise distinct, both under root owner.
+    const subEvents = yields(journal).filter(
+      (e) => e.description.type === "stream" && e.description.name === "subscribe",
+    );
+    expect(subEvents).toHaveLength(2);
+    const tokens = subEvents.map(
+      (e) =>
+        (e.result as { status: "ok"; value: { __tisyn_subscription: string } }).value
+          .__tisyn_subscription,
+    );
+    expect(tokens).toEqual(["sub:root:0", "sub:root:1"]);
+  });
+
+  it("IL-CO-013: replay advances owner counter; post-replay live token continues the sequence", function* () {
+    // Live run: caller sub (T0), parent.triggerA (inline sub — T1), caller sub (T2).
+    // Same nested-let structure as IL-CO-011 but the final body is a third
+    // caller-level stream.subscribe rather than a second trigger effect, so
+    // the IR itself evaluates to the third handle.
+    const ir = {
+      tisyn: "eval",
+      id: "let",
+      data: {
+        tisyn: "quote",
+        expr: {
+          name: "h0",
+          value: streamSubscribe("source"),
+          body: {
+            tisyn: "eval",
+            id: "let",
+            data: {
+              tisyn: "quote",
+              expr: {
+                name: "_1",
+                value: { tisyn: "eval", id: "parent.triggerA", data: [] },
+                body: streamSubscribe("source"),
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const run = function* (stream: InMemoryStream) {
+      yield* Effects.around({
+        *dispatch([effectId, data]: [string, Val], next) {
+          if (effectId === "parent.triggerA") {
+            yield* invokeInline<Val>(asFn(subscribeBodyFn("source")), []);
+            return null as Val;
+          }
+          return yield* next(effectId, data);
+        },
+      });
+      yield* Effects.around(
+        {
+          *dispatch([_e, _d]: [string, Val]) {
+            return null as Val;
+          },
+        },
+        { at: "min" },
+      );
+      return yield* execute({
+        ir: ir as never,
+        stream,
+        env: { source: mockStream([]) as unknown as Val },
+      });
+    };
+
+    const stream = new InMemoryStream();
+    const first = yield* run(stream);
+    const second = yield* run(stream);
+
+    // Byte-identical journals — owner counter reconstructed deterministically.
+    expect(second.journal).toEqual(first.journal);
+
+    const subEvents = yields(first.journal).filter(
+      (e) => e.description.type === "stream" && e.description.name === "subscribe",
+    );
+    const tokens = subEvents.map(
+      (e) =>
+        (e.result as { status: "ok"; value: { __tisyn_subscription: string } }).value
+          .__tisyn_subscription,
+    );
+    // All three sequentially from owner root's shared counter.
+    expect(tokens).toEqual(["sub:root:0", "sub:root:1", "sub:root:2"]);
+  });
+
+  it("IL-CO-014: invoke child uses its own subscription namespace (token owner = child coroutineId)", function* () {
+    // `invoke` child subscribes inside its own coroutine. Per v6 §12.8
+    // the child's own coroutineId is its own owner — so the subscription
+    // token must be prefixed with the child's coroutineId, not the
+    // caller's. We cannot smuggle the handle out of the child (RV3 on
+    // close values, RV2 on capture-effect data), so we inspect the
+    // child's stream.subscribe YieldEvent directly from the journal.
+    //
+    // Ancestry-failure when a foreign coroutine tries to use a handle is
+    // already covered by the existing stream-iteration RV1 tests; this
+    // test pins the Phase 5C invariant that `invoke` children get a
+    // fresh subscription namespace rather than inheriting the caller's
+    // owner.
+    const childBody: TisynFn<[], Val> = Fn<[], Val>([], {
+      tisyn: "eval",
+      id: "let",
+      data: {
+        tisyn: "quote",
+        expr: {
+          name: "_h",
+          value: streamSubscribe("source"),
+          body: Q(null),
+        },
+      },
+    } as unknown as Val) as unknown as TisynFn<[], Val>;
+
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.childSub") {
+          yield* invoke<Val>(asFn(childBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { journal } = yield* execute({
+      ir: effectIR("parent", "childSub") as never,
+      env: { source: mockStream([]) as unknown as Val },
+    });
+
+    // Subscribe YieldEvent under the invoke child's coroutineId.
+    const childSubEvent = yields(journal).find(
+      (e) =>
+        e.coroutineId === "root.0" &&
+        e.description.type === "stream" &&
+        e.description.name === "subscribe",
+    );
+    expect(childSubEvent).toBeDefined();
+    const handle = (
+      childSubEvent!.result as {
+        status: "ok";
+        value: { __tisyn_subscription: string };
+      }
+    ).value;
+    // Token prefix is the invoke child's own coroutineId — NOT the
+    // caller's root. §12.8: invoke resets owner to its own id.
+    expect(handle.__tisyn_subscription).toMatch(/^sub:root\.0:\d+$/);
+    expect(handle.__tisyn_subscription.startsWith("sub:root:")).toBe(false);
+  });
+
+  // ── Regression: compound externals still rejected inside inline ──
+
+  it("regression: resource inside inline body still rejects with clear error", function* () {
+    // IR: resource body inside inline body.
+    const resourceInner = {
+      tisyn: "eval",
+      id: "resource",
+      data: {
+        tisyn: "quote",
+        expr: { body: { tisyn: "eval", id: "provide", data: 0 } },
+      },
+    };
+    const bodyWithResource: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceInner as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    yield* Effects.around({
+      *dispatch([effectId, data]: [string, Val], next) {
+        if (effectId === "parent.trigger") {
+          yield* invokeInline<Val>(asFn(bodyWithResource), []);
+          return null as Val;
+        }
+        return yield* next(effectId, data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result } = yield* execute({
+      ir: effectIR("parent", "trigger") as never,
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.message).toContain("resource");
+      expect(result.error.message).toContain(
+        "compound primitives inside inline bodies are deferred",
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

Middleware that runs steps inside `invokeInline` bodies can now
acquire and pass streaming handles across inline calls. Sibling
inline lanes and the caller share one subscription namespace, so
a handle allocated inside an inline body composes with other
sibling lanes and with the caller after the inline returns —
without spurious `SubscriptionCapabilityError` ancestry failures
or token collisions.

This lifts the Phase 5B rejection of `stream.subscribe` /
`stream.next` inside inline bodies by implementing the
inline-invocation spec's §12 dual-identity model.

## Design (runtime-only)

- **Journal identity** — stream YieldEvents still journal under
  the inline lane's coroutineId. Unchanged.
- **Owner coroutineId** — runtime context on the internal
  `DispatchContext` seam, never written to durable events. For
  ordinary dispatch, owner == coroutineId. For inline lanes,
  owner is inherited from the outermost `invokeInline`'s caller,
  through nested inline calls. `invoke` children reset owner to
  the child's own coroutineId (§12.8).
- **Subscription counter** — centralized in `DriveContext`,
  keyed by owner coroutineId. Tokens are
  `sub:<owner>:<n>`. Under ordinary dispatch the prefix is
  identical to the prior release; no stream-iteration or
  replay-dispatch fixtures change.
- **`stream.next` ancestry check** — compares owner identity,
  not journal coroutineId. Sibling lanes (same owner) pass;
  caller-using-invoke-child handle fails.

## What's still deferred

- **Compound externals inside inline bodies** (`scope`, `spawn`,
  `join`, `resource`, `timebox`, `all`, `race`) remain rejected
  uniformly with a clear error. Lifting those is the next
  follow-up phase.
- **Invoke-continuity for other coroutineId-keyed capability
  families** — if a future capability family is added with its
  own counter, the §12.2 general default rule will apply to it
  when introduced. No current capability outside subscriptions
  needs updating.

## Changes

- `@tisyn/effects/internal` — `DispatchContext` gains
  `readonly ownerCoroutineId: string` (internal seam, no
  stable-surface impact). No changeset.
- `@tisyn/runtime` — dispatch helper takes owner, derives
  token allocator from `DriveContext.subscriptionCounters`,
  ancestry check uses owner identity, `driveInlineBody`
  threads owner and no longer rejects stream intrinsics.
  Patch-level changeset with impact-first wording.
- `packages/runtime/src/inline-invocation.test.ts` — 8 new
  IL-CO-* cases (001, 002, 003, 007, 011, 012, 013, 014) plus
  a compound-external rejection regression.

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (root; matches CI): all suites green,
      runtime now 285 tests (was 276 + 9 new IL-CO tests).
- [x] `inline-invocation.test.ts` — 28 tests pass (19 Phase 5B
      + 9 new)
- [x] `stream-iteration.test.ts`, `replay-dispatch.test.ts`,
      `nested-invocation.test.ts` — all green (no fixture
      changes needed; ordinary-dispatch tokens byte-identical).
- [x] Grep sanity: no residual "inline bodies require
      owner-counter" / stream rejection language; no
      `ownerCoroutineId` leakage outside runtime + effects
      internal seam + tests.

## Context

- Refs #122 (original tracking issue; closed with PR #130).
- Context: PR #131 (core inline lane runtime slice — Phase
  5B; shipped rejection of stream intrinsics pending this
  phase).
- Context: PR #130 (inline-invocation spec baseline — the §12
  Capability Ownership clauses being implemented here).