### PR TITLE
Implement inline-lane resource continuity

### DIFF
--- a/.changeset/effects-inline-resource-continuity.md
+++ b/.changeset/effects-inline-resource-continuity.md
@@ -1,0 +1,17 @@
+---
+"@tisyn/effects": patch
+---
+
+Update the `invokeInline` public JSDoc to document the new
+runtime support: `resource` inside an inline body now provides
+in the caller's scope and cleans up at caller teardown (§11.4,
+§11.8). The public signature is unchanged.
+
+The doc also notes the remaining rejections — the six
+non-resource compound externals (`scope`, `spawn`, `join`,
+`timebox`, `all`, `race`), and `resource` inside an inline
+body invoked from a resource-init or resource-cleanup dispatch
+context (nested resources inside a resource body remain
+unsupported).
+
+Paired with the runtime-side implementation.

--- a/.changeset/runtime-inline-resource-continuity.md
+++ b/.changeset/runtime-inline-resource-continuity.md
@@ -1,0 +1,33 @@
+---
+"@tisyn/runtime": patch
+---
+
+Lift the Phase 5B rejection of `resource` inside `invokeInline`
+bodies by completing the spec's §11.4 / §11.8 contract.
+
+- **Provide in caller scope, cleanup at caller teardown.** A
+  resource acquired inside an inline body now registers with
+  the caller's resource list (the same list that holds the
+  caller's ordinary resources), so reverse-order teardown runs
+  as a single caller-level sequence. Sibling inline lanes and
+  post-return caller code can reuse the resource until the
+  caller exits. The resource child still produces its own
+  `CloseEvent` under `laneId.{m}`; the inline lane itself
+  still produces no `CloseEvent`.
+- **Allocator discipline preserved.** The resource child id is
+  allocated from the inline lane's own `inlineChildSpawnCount`;
+  a rejected call does not advance the lane's allocator.
+- **Nested resources still unsupported.** `invokeInline` called
+  from a resource-init or resource-cleanup dispatch context
+  continues to reject an inline-body `resource` yield with a
+  clear error — preserving the existing "Nested resource is
+  not supported" rule. `invokeInline` itself remains usable
+  from those contexts for non-resource effects.
+- **Other compound externals still rejected.** `scope`,
+  `spawn`, `join`, `timebox`, `all`, `race` inside inline
+  bodies remain rejected with a clear error naming the
+  descriptor id; those remain follow-up phases.
+
+No kernel/compiler/IR/durable-event-algebra changes. No new
+public API. Semantics per
+`tisyn-inline-invocation-specification.md` §11.

--- a/packages/effects/src/invoke-inline.ts
+++ b/packages/effects/src/invoke-inline.ts
@@ -34,14 +34,18 @@ import type { InvokeOpts } from "./dispatch.js";
  * See `tisyn-inline-invocation-specification.md` for the full
  * normative contract. The current runtime phase supports standard-
  * effect dispatch inside the body, nested `invokeInline` / `invoke`
- * calls reached through standard-effect middleware, and
+ * calls reached through standard-effect middleware,
  * `stream.subscribe` / `stream.next` with owner-coroutineId counter
- * allocation (§12.4) — sibling inline lanes and the original caller
- * share a single subscription counter, so handles acquired inside
- * inline bodies compose with each other and with the caller
- * (§12.7). Compound externals (`scope`, `spawn`, `join`, `resource`,
+ * allocation (§12.4), and `resource` with provide-in-caller-scope
+ * and cleanup-at-caller-teardown semantics (§11.4, §11.8) — sibling
+ * inline lanes and post-return caller code can reuse a resource
+ * acquired inside an inline body until the caller itself exits.
+ * Non-resource compound externals (`scope`, `spawn`, `join`,
  * `timebox`, `all`, `race`) inside an inline body are still rejected
  * with a clear error; follow-up runtime phases will lift those.
+ * `resource` inside an inline body invoked from a resource-init or
+ * resource-cleanup dispatch context also remains rejected — nested
+ * resources inside a resource body are unsupported.
  */
 export function* invokeInline<T = Val>(
   fn: FnNode,

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -161,6 +161,29 @@ interface ResourceChild {
   waitCleanup: Operation<void>;
 }
 
+/**
+ * Registration target for a `resource` yielded from inside an
+ * `invokeInline` body. Per `tisyn-inline-invocation-specification.md`
+ * §11.4 + §11.8, a resource acquired inside an inline body attaches
+ * to the caller's scope — but only when the hosting dispatch context
+ * is a caller `driveKernel`. When the hosting context is a
+ * resource-init or resource-cleanup phase inside
+ * `orchestrateResourceChild`, nested resources are unsupported (the
+ * ordinary-yield nested-resource path throws
+ * `RuntimeBugError("Nested resource is not supported")`); the inline
+ * path preserves that rejection via a `"reject"` target so inline
+ * invocation cannot silently bypass it.
+ */
+type InlineResourceTarget =
+  | {
+      kind: "caller-scope";
+      register(child: ResourceChild): void;
+    }
+  | {
+      kind: "reject";
+      reason: string;
+    };
+
 // ── Nested invocation helpers ──
 
 function isFnNode(value: unknown): value is FnNode {
@@ -216,8 +239,16 @@ function buildDispatchContext(args: {
   parentEnv: Env;
   driveContext: DriveContext;
   allocateChildId: () => string;
+  inlineResourceTarget: InlineResourceTarget;
 }): DispatchContext {
-  const { coroutineId, ownerCoroutineId, parentEnv, driveContext, allocateChildId } = args;
+  const {
+    coroutineId,
+    ownerCoroutineId,
+    parentEnv,
+    driveContext,
+    allocateChildId,
+    inlineResourceTarget,
+  } = args;
   const self: DispatchContext = {
     coroutineId,
     ownerCoroutineId,
@@ -285,7 +316,14 @@ function buildDispatchContext(args: {
       const laneKernel = evaluate(fn.body as Expr, laneEnv);
 
       const driveLane = () =>
-        driveInlineBody<T>(laneKernel, laneId, laneEnv, driveContext, laneOwner);
+        driveInlineBody<T>(
+          laneKernel,
+          laneId,
+          laneEnv,
+          driveContext,
+          laneOwner,
+          inlineResourceTarget,
+        );
 
       if (opts?.overlay) {
         return yield* withOverlayFrame(opts.overlay, driveLane);
@@ -317,10 +355,19 @@ function buildDispatchContext(args: {
  * - Lane produces NO `CloseEvent` — ever. Normal completion returns
  *   the kernel's final value directly; uncaught errors propagate
  *   directly to the caller's middleware frame.
- * - Compound externals (`scope`, `spawn`, `join`, `resource`,
- *   `timebox`, `all`, `race`) inside an inline body are rejected with
- *   a clear error: this runtime phase does NOT run them under
- *   inline-lane semantics yet.
+ * - `resource` inside an inline body provides in the caller's scope
+ *   and cleans up at caller teardown (§11.4 + §11.8). The resource
+ *   child is allocated `laneId.{m}` from the lane's own
+ *   `inlineChildSpawnCount`, produces its own `CloseEvent` under
+ *   that id, and registers with the caller's `resourceChildren`
+ *   array via the `InlineResourceTarget` passed from the hosting
+ *   dispatch. When the hosting dispatch is a resource-init or
+ *   resource-cleanup phase, the target rejects instead — preserving
+ *   the ordinary-yield nested-resource rejection.
+ * - The remaining six compound externals (`scope`, `spawn`, `join`,
+ *   `timebox`, `all`, `race`) inside an inline body are still
+ *   rejected with a clear error: this runtime phase does NOT run
+ *   them under inline-lane semantics yet.
  */
 function* driveInlineBody<T = Val>(
   kernel: Generator<EffectDescriptor, Val, Val>,
@@ -328,6 +375,7 @@ function* driveInlineBody<T = Val>(
   env: Env,
   ctx: DriveContext,
   ownerCoroutineId: string,
+  inlineResourceTarget: InlineResourceTarget,
 ): Operation<T> {
   // Own childSpawnCount per v6 §7.3. Subscription counter state lives on
   // `ctx.subscriptionCounters[ownerCoroutineId]`, shared with the caller
@@ -348,12 +396,89 @@ function* driveInlineBody<T = Val>(
 
     const descriptor = step.value as EffectDescriptor;
 
-    // Compound-external descriptors are out of scope for this phase.
-    // Reject uniformly with a clear error that names the descriptor id.
+    // §11.4 + §11.8: `resource` inside an inline body provides in
+    // the caller's scope and cleans up at caller teardown — but only
+    // when the hosting dispatch context is a caller `driveKernel`.
+    // When invokeInline was called from middleware running on a
+    // resource-init / resource-cleanup dispatch, the target rejects,
+    // preserving the ordinary-yield "Nested resource is not supported"
+    // rule. Non-resource compound externals stay rejected uniformly.
     if (isCompoundExternal(descriptor.id)) {
+      if (descriptor.id === "resource") {
+        if (inlineResourceTarget.kind === "reject") {
+          // Do NOT advance the lane's child-spawn counter for a
+          // rejected call (matches "rejected calls do not advance
+          // allocators"); do NOT start `orchestrateResourceChild`.
+          throw new Error(inlineResourceTarget.reason);
+        }
+        const compoundData = descriptor.data as {
+          __tisyn_inner: { body: Expr };
+          __tisyn_env: Env;
+        };
+        const childId = `${laneId}.${inlineChildSpawnCount++}`;
+        const childEnv = compoundData.__tisyn_env;
+        const childResourceKernel = evaluate(compoundData.__tisyn_inner.body, childEnv);
+        const {
+          operation: provideOp,
+          resolve: provideRes,
+          reject: provideRej,
+        } = withResolvers<Val>();
+        const { operation: teardownOp, resolve: teardownRes } = withResolvers<void>();
+        const { operation: cleanupOp, resolve: cleanupRes } = withResolvers<void>();
+
+        yield* spawn(function* () {
+          yield* orchestrateResourceChild(
+            childResourceKernel,
+            childId,
+            childEnv,
+            ctx,
+            provideRes,
+            provideRej,
+            teardownOp,
+            cleanupRes,
+          );
+        });
+
+        let resourceValue: Val = null;
+        let resourceErr: Error | null = null;
+        try {
+          resourceValue = yield* provideOp;
+        } catch (e) {
+          resourceErr = e instanceof Error ? e : new Error(String(e));
+        }
+
+        if (resourceErr === null) {
+          // §11.4: register with CALLER's resourceChildren array so
+          // cleanup runs at caller teardown alongside caller resources.
+          inlineResourceTarget.register({
+            childId,
+            signalTeardown: teardownRes,
+            waitCleanup: cleanupOp,
+          });
+          nextValue = resourceValue;
+          continue;
+        }
+        // Init failed — route through kernel.throw with the three
+        // outcomes. Do NOT run teardownResourceChildren (lane has no
+        // teardown; the caller's teardown will pick up anything we
+        // already registered).
+        const throwResult = kernel.throw(resourceErr);
+        if (throwResult.done) {
+          return (throwResult.value ?? null) as T;
+        }
+        pendingStep = throwResult;
+        nextValue = null;
+        continue;
+      }
+      // `scope`, `spawn`, `join`, `timebox`, `all`, `race` — still
+      // deferred. Reject uniformly with a clear error naming the id.
+      // (`provide` is only legal inside a resource init body; a
+      // bare `provide` yield here is caller IR misuse rather than an
+      // unsupported inline compound, so it also hits this branch.)
       throw new Error(
         `invokeInline body dispatched compound external '${descriptor.id}'; ` +
-          `compound primitives inside inline bodies are deferred ` +
+          `compound primitives 'scope', 'spawn', 'join', 'timebox', 'all', 'race' ` +
+          `inside inline bodies are deferred ` +
           `(see tisyn-inline-invocation-specification.md §11)`,
       );
     }
@@ -370,6 +495,11 @@ function* driveInlineBody<T = Val>(
       env,
       ctx,
       allocateChildId: () => `${laneId}.${inlineChildSpawnCount++}`,
+      // Thread the caller's target unchanged — nested `invokeInline`
+      // invoked from middleware on a lane-dispatch inherits the
+      // outermost caller's registration destination, so sibling lanes
+      // and nested lanes all register with the same caller's array.
+      inlineResourceTarget,
     });
 
     if (result.status === "ok") {
@@ -866,6 +996,15 @@ function* driveKernel(
           env,
           ctx,
           allocateChildId: () => `${coroutineId}.${childSpawnCount++}`,
+          // §11.4: caller `driveKernel` hosts the dispatch — inline
+          // bodies invoked from middleware here attach resources to
+          // THIS kernel's `resourceChildren`.
+          inlineResourceTarget: {
+            kind: "caller-scope",
+            register: (child) => {
+              resourceChildren.push(child);
+            },
+          },
         });
 
         if (effectResult.status === "ok") {
@@ -1405,6 +1544,18 @@ function* orchestrateResourceChild(
           env: childEnv,
           ctx,
           allocateChildId: () => `${childId}.${childSpawnCount++}`,
+          // Nested resources inside a resource body are unsupported
+          // (cf. the ordinary-yield rejection in the compound
+          // interception block of this same phase). Inline invocation
+          // MUST NOT silently bypass that rule.
+          inlineResourceTarget: {
+            kind: "reject",
+            reason:
+              "invokeInline body dispatched 'resource' from inside a resource " +
+              "init dispatch context; nested resources inside a resource body " +
+              "are not supported " +
+              "(see tisyn-inline-invocation-specification.md §11.4)",
+          },
         });
 
         if (effectResult.status === "ok") {
@@ -1601,7 +1752,6 @@ function* orchestrateResourceChild(
         }
 
         // ── Standard effect dispatch (helper-unified, resource cleanup) ──
-        // ── Standard effect dispatch (helper-unified, resource cleanup) ──
         // Resource child cleanup body runs under the same coroutineId +
         // owner as the init body: both are ordinary dispatches from the
         // resource child's perspective.
@@ -1612,6 +1762,17 @@ function* orchestrateResourceChild(
           env: childEnv,
           ctx,
           allocateChildId: () => `${childId}.${childSpawnCount++}`,
+          // Nested resources inside a resource body are unsupported —
+          // same rule as the init-phase target. Preserves the existing
+          // rejection against inline invocation silently bypassing it.
+          inlineResourceTarget: {
+            kind: "reject",
+            reason:
+              "invokeInline body dispatched 'resource' from inside a resource " +
+              "cleanup dispatch context; nested resources inside a resource body " +
+              "are not supported " +
+              "(see tisyn-inline-invocation-specification.md §11.4)",
+          },
         });
 
         if (effectResult.status === "ok") {
@@ -1679,6 +1840,15 @@ interface DispatchStandardEffectParams {
   env: Env;
   ctx: DriveContext;
   allocateChildId: () => string;
+  /**
+   * Where to register a resource acquired inside an `invokeInline`
+   * body. `"caller-scope"` pushes into the hosting caller's
+   * `resourceChildren`; `"reject"` throws — preserving the existing
+   * nested-resource rejection when the host is a resource-init or
+   * resource-cleanup dispatch (`tisyn-inline-invocation-specification.md`
+   * §11.4 + §11.8). Unused by ordinary (non-inline) dispatch paths.
+   */
+  inlineResourceTarget: InlineResourceTarget;
 }
 
 /**
@@ -1740,7 +1910,15 @@ interface DispatchStandardEffectResult {
 function* dispatchStandardEffect(
   params: DispatchStandardEffectParams,
 ): Operation<DispatchStandardEffectResult> {
-  const { descriptor, coroutineId, ownerCoroutineId, env, ctx, allocateChildId } = params;
+  const {
+    descriptor,
+    coroutineId,
+    ownerCoroutineId,
+    env,
+    ctx,
+    allocateChildId,
+    inlineResourceTarget,
+  } = params;
 
   const description = parseEffectId(descriptor.id);
   const stored = ctx.replayIndex.peekYield(coroutineId);
@@ -1910,6 +2088,7 @@ function* dispatchStandardEffect(
     parentEnv: env,
     driveContext: ctx,
     allocateChildId,
+    inlineResourceTarget,
   });
 
   const runtimeCtxValue: RuntimeDispatchValue = { coroutineId, ctx };

--- a/packages/runtime/src/inline-invocation.test.ts
+++ b/packages/runtime/src/inline-invocation.test.ts
@@ -11,11 +11,15 @@
  *    coroutineId shared subscription counter, sibling-lane handle
  *    reuse, caller-after-return handle reuse, `invoke`-child isolated
  *    namespace, replay counter reconstruction.
+ *  - Lifetime (§11) — `resource` inside an inline body provides in
+ *    the caller's scope and cleans up at caller teardown. IL-PI-*,
+ *    IL-L-*, IL-CS-*, IL-RD-* subset.
  *
  * Out of scope — not tested here:
- *   - Compound externals (scope/spawn/join/resource/timebox/all/race)
- *     inside inline bodies (still rejected loudly by driveInlineBody).
- *   - IL-INT-*, IL-RD-*, IL-EX-*, and the full 31-test minimum subset.
+ *   - Non-resource compound externals (scope/spawn/join/timebox/all/
+ *     race) inside inline bodies (still rejected loudly by
+ *     driveInlineBody).
+ *   - IL-INT-*, IL-EX-*, and the full 31-test minimum subset.
  */
 
 import { describe, it } from "@effectionx/vitest";
@@ -1371,30 +1375,281 @@ describe("invokeInline — core runtime slice", () => {
     expect(handle.__tisyn_subscription.startsWith("sub:root:")).toBe(false);
   });
 
-  // ── Regression: compound externals still rejected inside inline ──
+  // ── Phase 5D: inline-body `resource` continuity (IL-PI / IL-L / IL-CS / IL-RD) ──
 
-  it("regression: resource inside inline body still rejects with clear error", function* () {
-    // IR: resource body inside inline body.
-    const resourceInner = {
+  // IR helpers for inline-resource tests (mirror resource.test.ts shapes).
+  const resourceIR = (body: unknown) =>
+    ({
       tisyn: "eval",
       id: "resource",
-      data: {
-        tisyn: "quote",
-        expr: { body: { tisyn: "eval", id: "provide", data: 0 } },
-      },
-    };
-    const bodyWithResource: TisynFn<[], Val> = Fn<[], Val>(
+      data: { tisyn: "quote", expr: { body } },
+    }) as unknown as Val;
+
+  const provideIR = (value: unknown) =>
+    ({
+      tisyn: "eval",
+      id: "provide",
+      data: value,
+    }) as unknown as Val;
+
+  const seqIR = (...exprs: unknown[]) =>
+    ({
+      tisyn: "eval",
+      id: "seq",
+      data: { tisyn: "quote", expr: { exprs } },
+    }) as unknown as Val;
+
+  it("IL-PI-001: primary invariant — E under laneId, R cleanup at caller teardown, Y succeeds", function* () {
+    // Inline body: dispatch effect E, then acquire resource R. E is a
+    // direct effect of the inline body (journals under laneId); R's
+    // init body provides "session-handle" and its cleanup dispatches
+    // session.close at caller teardown. The Fn returns R's provide value.
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
       [],
-      resourceInner as unknown as Val,
+      seqIR(
+        effectIR("setup", "touch"),
+        resourceIR(
+          Try(provideIR("session-handle"), undefined, undefined, effectIR("session", "close")),
+        ),
+      ) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let capturedHandle: Val | undefined;
+    let usedHandle: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          capturedHandle = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        if (effectId === "caller.use") {
+          usedHandle = capturedHandle;
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({
+      ir: seqIR(effectIR("caller", "go"), effectIR("caller", "use")) as never,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(usedHandle).toBe("session-handle");
+
+    // E (setup.touch) journals under the inline lane, not root.
+    const setupYields = yields(journal).filter(
+      (e) => e.description.type === "setup" && e.description.name === "touch",
+    );
+    expect(setupYields).toHaveLength(1);
+    expect(setupYields[0]!.coroutineId).toBe("root.0");
+
+    // R's cleanup effect (session.close) fires at caller teardown.
+    const cleanupYields = yields(journal).filter(
+      (e) => e.description.type === "session" && e.description.name === "close",
+    );
+    expect(cleanupYields).toHaveLength(1);
+    // Cleanup runs under the resource child's coroutineId (root.0.0).
+    expect(cleanupYields[0]!.coroutineId).toBe("root.0.0");
+
+    // Resource child produces its own CloseEvent under root.0.0.
+    const resourceCloses = closes(journal).filter((e) => e.coroutineId === "root.0.0");
+    expect(resourceCloses).toHaveLength(1);
+    expect(resourceCloses[0]!.result.status).toBe("ok");
+
+    // Inline lane produces NO CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("IL-PI-003 / IL-L-002: resource continuity across sibling inline lanes", function* () {
+    // A: inline lane that acquires a resource whose provide value is "session-xyz".
+    // B: inline lane that reads the stored handle via middleware and returns it.
+    // Both called sequentially from caller middleware.
+    const inlineA: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(
+        Try(provideIR("session-xyz"), undefined, undefined, effectIR("session", "close")),
+      ) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    const inlineB: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      effectIR("session", "read") as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let aHandle: Val | undefined;
+    let bReadBack: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          aHandle = yield* invokeInline<Val>(asFn(inlineA), []);
+          bReadBack = yield* invokeInline<Val>(asFn(inlineB), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([effectId, _d]: [string, Val]) {
+          if (effectId === "session.read") {
+            return aHandle as Val;
+          }
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(aHandle).toBe("session-xyz");
+    expect(bReadBack).toBe("session-xyz");
+
+    // Distinct lane IDs root.0 (A) and root.1 (B). A's resource child is root.0.0.
+    const sessionReadYields = yields(journal).filter(
+      (e) => e.description.type === "session" && e.description.name === "read",
+    );
+    expect(sessionReadYields).toHaveLength(1);
+    expect(sessionReadYields[0]!.coroutineId).toBe("root.1");
+
+    const resourceCloses = closes(journal).filter((e) => e.coroutineId === "root.0.0");
+    expect(resourceCloses).toHaveLength(1);
+
+    // Cleanup fires at caller teardown (after B's session.read).
+    const cleanupYields = yields(journal).filter(
+      (e) => e.description.type === "session" && e.description.name === "close",
+    );
+    expect(cleanupYields).toHaveLength(1);
+    // session.close fires after session.read in journal order.
+    const readIdx = journal.indexOf(sessionReadYields[0]!);
+    const closeIdx = journal.indexOf(cleanupYields[0]!);
+    expect(closeIdx).toBeGreaterThan(readIdx);
+  });
+
+  it("IL-L-005: mixed caller + inline resources tear down in reverse acquisition order", function* () {
+    // Caller acquires R1 directly; inline A acquires R2; inline B acquires R3.
+    // On caller teardown, cleanup fires R3 → R2 → R1.
+    const inlineA: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(
+        Try(provideIR("a"), undefined, undefined, effectIR("cleanup", "r2")),
+      ) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    const inlineB: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(
+        Try(provideIR("b"), undefined, undefined, effectIR("cleanup", "r3")),
+      ) as unknown as Val,
     ) as unknown as TisynFn<[], Val>;
 
     yield* Effects.around({
-      *dispatch([effectId, data]: [string, Val], next) {
-        if (effectId === "parent.trigger") {
-          yield* invokeInline<Val>(asFn(bodyWithResource), []);
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          yield* invokeInline<Val>(asFn(inlineA), []);
+          yield* invokeInline<Val>(asFn(inlineB), []);
           return null as Val;
         }
-        return yield* next(effectId, data);
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Caller IR: acquire R1 directly in root's driveKernel, then trigger
+    // caller.go (whose middleware runs inline A and inline B). R1 is
+    // acquired BEFORE the inline calls so its registration predates R2/R3.
+    // Seq discards R1's provide value; the resource is still registered
+    // with root's `resourceChildren` for reverse-order cleanup.
+    const ir = seqIR(
+      resourceIR(Try(provideIR("r1"), undefined, undefined, effectIR("cleanup", "r1"))),
+      effectIR("caller", "go"),
+    );
+
+    const { result, journal } = yield* execute({ ir: ir as never });
+    expect(result.status).toBe("ok");
+
+    const cleanupYields = yields(journal).filter((e) => e.description.type === "cleanup");
+    expect(cleanupYields.map((e) => e.description.name)).toEqual(["r3", "r2", "r1"]);
+  });
+
+  it("IL-CS-004: resource child produces its own CloseEvent under laneId.{m}; inline lane has none", function* () {
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(provideIR(42)) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { journal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+    });
+
+    // Resource child close under lane.0 (root.0.0).
+    const resourceCloses = closes(journal).filter((e) => e.coroutineId === "root.0.0");
+    expect(resourceCloses).toHaveLength(1);
+    expect(resourceCloses[0]!.result.status).toBe("ok");
+
+    // Lane itself emits no CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("IL-CS-005: resource provide value is usable by caller code after inline returns", function* () {
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(provideIR("the-value")) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let fromInline: Val | undefined;
+    let usedLater: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.acquire") {
+          fromInline = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        if (effectId === "caller.use") {
+          usedLater = fromInline;
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
       },
     });
     yield* Effects.around(
@@ -1407,14 +1662,239 @@ describe("invokeInline — core runtime slice", () => {
     );
 
     const { result } = yield* execute({
-      ir: effectIR("parent", "trigger") as never,
+      ir: seqIR(effectIR("caller", "acquire"), effectIR("caller", "use")) as never,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(fromInline).toBe("the-value");
+    expect(usedLater).toBe("the-value");
+  });
+
+  it("IL-RD-003: resource init body inside inline does not refire live on replay", function* () {
+    // Live run with journal capture.
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(seqIR(effectIR("resource-init", "setup"), provideIR("ready"))) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let liveFireCount = 0;
+
+    const buildAgents = () =>
+      function* () {
+        yield* Effects.around({
+          *dispatch([effectId, _data]: [string, Val], next) {
+            if (effectId === "caller.go") {
+              yield* invokeInline<Val>(asFn(inlineBody), []);
+              return null as Val;
+            }
+            return yield* next(effectId, _data);
+          },
+        });
+        yield* Effects.around(
+          {
+            *dispatch([effectId, _d]: [string, Val]) {
+              if (effectId === "resource-init.setup") {
+                liveFireCount++;
+              }
+              return null as Val;
+            },
+          },
+          { at: "min" },
+        );
+      };
+
+    const stream = new InMemoryStream();
+    const live = buildAgents();
+    yield* live();
+
+    const { result: liveResult, journal: liveJournal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+      stream,
+    });
+    expect(liveResult.status).toBe("ok");
+    expect(liveFireCount).toBe(1);
+
+    // Replay with same stream. Init body MUST NOT refire live.
+    liveFireCount = 0;
+    const { result: replayResult, journal: replayJournal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+      stream,
+    });
+    expect(replayResult.status).toBe("ok");
+    // Replay: the init body's setup effect is replayed from journal, not re-dispatched live.
+    expect(liveFireCount).toBe(0);
+    // Journals are byte-identical.
+    expect(replayJournal).toEqual(liveJournal);
+
+    // Sanity: init body's setup effect journaled under lane's resource child.
+    const setupYields = yields(liveJournal).filter(
+      (e) => e.description.type === "resource-init" && e.description.name === "setup",
+    );
+    expect(setupYields).toHaveLength(1);
+    expect(setupYields[0]!.coroutineId).toBe("root.0.0");
+  });
+
+  // ── Regression: non-resource compound externals still rejected ──
+
+  it("regression: scope inside inline body still rejects with clear error", function* () {
+    const scopeInner = {
+      tisyn: "eval",
+      id: "scope",
+      data: {
+        tisyn: "quote",
+        expr: { handler: null, bindings: {}, body: Q(0) },
+      },
+    };
+    const bodyWithScope: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      scopeInner as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          yield* invokeInline<Val>(asFn(bodyWithScope), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result } = yield* execute({
+      ir: effectIR("caller", "go") as never,
     });
 
     expect(result.status).toBe("error");
     if (result.status === "error") {
-      expect(result.error.message).toContain("resource");
+      expect(result.error.message).toContain("'scope'");
+      // The narrowed message names the six still-rejected compounds.
+      expect(result.error.message).toContain("'scope', 'spawn', 'join', 'timebox', 'all', 'race'");
+      // And does NOT list 'resource' in that set.
+      expect(result.error.message).not.toContain("'resource'");
+    }
+  });
+
+  // ── Regression: inline-body `resource` from resource-init / cleanup contexts still rejects ──
+
+  it("regression: invokeInline body `resource` from resource-init middleware rejects", function* () {
+    // Inner inline body yields a resource.
+    const innerInline: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(provideIR("nested")) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let outerInitFired = 0;
+    let resourceSpawnCid: string | null = null;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "outer-init.go") {
+          outerInitFired++;
+          // Inside a resource-init dispatch — invokeInline should work for
+          // non-resource effects but must reject an inline-body `resource`.
+          yield* invokeInline<Val>(asFn(innerInline), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Outer IR: resource whose init body yields outer-init.go then provides.
+    const outerIr = resourceIR(seqIR(effectIR("outer-init", "go"), provideIR(0)));
+
+    const { result, journal } = yield* execute({ ir: outerIr as never });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
       expect(result.error.message).toContain(
-        "compound primitives inside inline bodies are deferred",
+        "nested resources inside a resource body are not supported",
+      );
+      expect(result.error.message).toContain("resource init dispatch context");
+    }
+
+    // `outer-init.go` middleware fired (so invokeInline from init-phase
+    // middleware is NOT wholesale rejected — only the inline-body
+    // `resource` yield is).
+    expect(outerInitFired).toBe(1);
+
+    // Inner inline's resource child MUST NOT have started — no yields,
+    // no close under any descendant of the rejected lane. Lane was
+    // `root.0` (A's resource child), invokeInline advanced A's init
+    // allocator, so the rejected inline lane would be `root.0.1` and
+    // its resource child would be `root.0.1.0`. Neither id appears.
+    expect(yields(journal).some((e) => e.coroutineId === "root.0.1.0")).toBe(false);
+    expect(closes(journal).some((e) => e.coroutineId === "root.0.1.0")).toBe(false);
+
+    // Reference resourceSpawnCid to avoid unused-var lint.
+    expect(resourceSpawnCid).toBeNull();
+  });
+
+  it("regression: invokeInline body `resource` from resource-cleanup middleware rejects", function* () {
+    // Outer resource whose cleanup path triggers an effect whose middleware
+    // calls invokeInline with a body that yields `resource` — must reject.
+    const innerInline: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(provideIR("nested-cleanup")) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let cleanupFired = 0;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "outer-cleanup.go") {
+          cleanupFired++;
+          yield* invokeInline<Val>(asFn(innerInline), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Outer: resource(Try(provide(0), finally: outer-cleanup.go))
+    const outerIr = resourceIR(
+      Try(provideIR(0), undefined, undefined, effectIR("outer-cleanup", "go")),
+    );
+
+    const { journal } = yield* execute({ ir: outerIr as never });
+
+    // The cleanup-phase target rejects the inner inline body's `resource`
+    // yield. That throws inside orchestrateResourceChild's cleanup loop,
+    // which writes an error CloseEvent for the resource child (root.0).
+    // Middleware still fires once before the rejection surfaces.
+    expect(cleanupFired).toBe(1);
+    const outerResourceCloses = closes(journal).filter((e) => e.coroutineId === "root.0");
+    expect(outerResourceCloses).toHaveLength(1);
+    expect(outerResourceCloses[0]!.result.status).toBe("error");
+    if (outerResourceCloses[0]!.result.status === "error") {
+      expect(outerResourceCloses[0]!.result.error.message).toContain(
+        "nested resources inside a resource body are not supported",
+      );
+      expect(outerResourceCloses[0]!.result.error.message).toContain(
+        "resource cleanup dispatch context",
       );
     }
   });


### PR DESCRIPTION
## Summary

Step middleware can now acquire a browser/session resource
inside an `invokeInline` body and have it outlive the inline
return. Sibling inline lanes and caller code that runs after
the inline returns can reuse the resource until the caller
itself exits, at which point cleanup runs in the normal
reverse-order sequence alongside the caller's ordinary
resources. This directly unblocks the original browser
orchestration use case that motivated inline invocation.

Implements the inline-invocation spec's §11.4 + §11.8
contract (provide-in-caller-scope, cleanup-at-caller-teardown).

## Design

- **Explicit `InlineResourceTarget` on the internal dispatch
  seam.** A discriminated union with two variants:
  `"caller-scope"` (registers a resource into the hosting
  caller's `resourceChildren`) and `"reject"` (throws with a
  fixed rejection message). Caller `driveKernel` passes
  `"caller-scope"`; `orchestrateResourceChild` init and
  cleanup phases pass `"reject"`. The type-system split makes
  the two modes explicit at every call site.
- **Resource child id = `laneId.{m}`.** Allocated from the
  inline lane's own `inlineChildSpawnCount` (matches §11.3's
  rule for `invoke`-inside-inline). A rejected call does not
  advance the lane's allocator.
- **Journal/event shape unchanged.** Resource child still
  produces its own `CloseEvent` under `laneId.{m}`. Inline
  lane still produces no `CloseEvent`. No new event kinds or
  fields.
- **Nested-resource rule preserved.** The ordinary-yield rule
  ("Nested resource is not supported") inside a resource body
  is preserved through inline invocation. `invokeInline` from
  resource-init / resource-cleanup middleware still works for
  non-resource effects — only the inline-body `resource`
  yield is rejected in those contexts.

## What's still deferred

- **Six remaining compound externals inside inline bodies** —
  `scope`, `spawn`, `join`, `timebox`, `all`, `race`. Rejected
  uniformly with a clear error naming the descriptor id. Each
  will be a follow-up phase.

## Changes

- `@tisyn/runtime` — `InlineResourceTarget` union added;
  threaded through `dispatchStandardEffect` +
  `buildDispatchContext` + `driveInlineBody`; caller dispatch
  site passes caller-scope target, resource-init and
  resource-cleanup sites pass reject targets; driveInlineBody
  branches `descriptor.id === 'resource'` before the catch-all
  compound-external rejection; other six compounds still
  rejected. Patch changeset with impact-first wording.
- `@tisyn/effects` — JSDoc on `invokeInline` updated to
  mention `resource` is now supported inside inline bodies
  (§11.4) and the resource-child-context carve-out. Public
  signature unchanged; no changeset.
- `packages/runtime/src/inline-invocation.test.ts` — 7 new
  positive cases (IL-PI-001, IL-PI-003, IL-L-002, IL-L-005,
  IL-CS-004, IL-CS-005, IL-RD-003), 1 still-rejected
  compound-external regression (`scope`), and 2
  resource-child-context rejection regressions (init-phase +
  cleanup-phase). The Phase 5C resource-rejection regression
  is replaced.

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (root; matches CI): all suites green;
      runtime now 293 tests (up from 285).
- [x] `inline-invocation.test.ts` — 36 tests pass (28 pre-5D
      + 9 new − 1 deleted 5C regression).
- [x] `resource.test.ts`, `replay-dispatch.test.ts`,
      `nested-invocation.test.ts`, `stream-iteration.test.ts`
      — unchanged green.
- [x] Grep sanity checks: old uniform rejection text gone;
      new narrowed message present exactly once; old 5C
      resource-regression test name gone.

## Context

- Refs #122 (original tracking issue; closed with PR #130).
- Context: PR #131 (core inline lane runtime slice — Phase
  5B).
- Context: PR #132 (inline stream ownership — Phase 5C).