### PR TITLE
Implement inline-lane spawn and join

### DIFF
--- a/.changeset/effects-inline-spawn-join.md
+++ b/.changeset/effects-inline-spawn-join.md
@@ -5,9 +5,9 @@
 Update the `invokeInline` public JSDoc to document the new
 runtime support: `spawn` and `join` inside an inline body
 now attach to the hosting caller's Effection scope and
-shared task registry per §11.5, and sibling/caller code can
-resolve task handles acquired inside an inline body using
-the existing double-join semantics. The public signature is
-unchanged.
+share the hosting site's existing durable task table per
+§11.5, so sibling/caller code can resolve task handles
+acquired inside an inline body using the existing
+double-join semantics. The public signature is unchanged.
 
 Paired with the runtime-side implementation.

--- a/.changeset/effects-inline-spawn-join.md
+++ b/.changeset/effects-inline-spawn-join.md
@@ -1,0 +1,13 @@
+---
+"@tisyn/effects": patch
+---
+
+Update the `invokeInline` public JSDoc to document the new
+runtime support: `spawn` and `join` inside an inline body
+now attach to the hosting caller's Effection scope and
+shared task registry per §11.5, and sibling/caller code can
+resolve task handles acquired inside an inline body using
+the existing double-join semantics. The public signature is
+unchanged.
+
+Paired with the runtime-side implementation.

--- a/.changeset/runtime-inline-spawn-join.md
+++ b/.changeset/runtime-inline-spawn-join.md
@@ -1,0 +1,39 @@
+---
+"@tisyn/runtime": patch
+---
+
+Lift the Phase 5B rejection of `spawn` and `join` inside
+`invokeInline` bodies per the inline-invocation spec's §11.5.
+
+Step middleware can now start background child work from
+inside shared-lifetime inline execution and have the
+returned task handle be joinable from the inline body
+itself, sibling inline lanes, or later caller code —
+without creating an inline scope boundary.
+
+- **Spawn.** Inside an inline body, `spawn` allocates the
+  child id from the lane's own `inlineChildSpawnCount` in
+  `laneId.{m}` format and starts the child via
+  `driveKernel(childKernel, childId, childEnv, ctx)`. The
+  child task runs under the hosting caller's Effection scope
+  — spawned via `yield* spawn(...)` inside the ambient
+  middleware chain — and produces its normal `CloseEvent`
+  under `laneId.{m}`. The inline lane itself still produces
+  no `CloseEvent`.
+- **Join.** Handles resolve against the hosting caller's
+  shared `spawnedTasks` map; the double-join set is also
+  shared, so the existing "already been joined" error fires
+  whether both joins are from the inline body, from siblings,
+  or across the caller boundary.
+- **Resource-body hosts unchanged.** When a resource init or
+  cleanup body hosts the dispatch, inline-body spawn/join
+  attaches to THAT phase's spawn/join maps — mirroring where
+  ordinary-yield `spawn` from inside the resource body
+  already lands.
+
+`scope`, `timebox`, `all`, `race` inside inline bodies
+remain rejected with a clear error. Nested resources inside
+a resource body (from an inline-body `resource` yield in a
+resource-init/cleanup context) remain rejected per Phase 5D.
+No kernel/compiler/IR/durable-event-algebra changes; no
+public API changes; `invokeInline` signature unchanged.

--- a/.changeset/runtime-inline-spawn-join.md
+++ b/.changeset/runtime-inline-spawn-join.md
@@ -11,6 +11,13 @@ returned task handle be joinable from the inline body
 itself, sibling inline lanes, or later caller code —
 without creating an inline scope boundary.
 
+The implementation shares the hosting dispatch site's
+existing durable task table (the pair of `spawnedTasks` +
+`joinedTasks` maps already maintained by `driveKernel` and
+`orchestrateResourceChild` for ordinary-yield spawn/join)
+with inline evaluation. No new inline-specific bookkeeping
+system is introduced.
+
 - **Spawn.** Inside an inline body, `spawn` allocates the
   child id from the lane's own `inlineChildSpawnCount` in
   `laneId.{m}` format and starts the child via
@@ -21,14 +28,14 @@ without creating an inline scope boundary.
   under `laneId.{m}`. The inline lane itself still produces
   no `CloseEvent`.
 - **Join.** Handles resolve against the hosting caller's
-  shared `spawnedTasks` map; the double-join set is also
-  shared, so the existing "already been joined" error fires
-  whether both joins are from the inline body, from siblings,
-  or across the caller boundary.
+  `spawnedTasks` map; the double-join set is also shared, so
+  the existing "already been joined" error fires whether
+  both joins are from the inline body, from siblings, or
+  across the caller boundary.
 - **Resource-body hosts unchanged.** When a resource init or
   cleanup body hosts the dispatch, inline-body spawn/join
-  attaches to THAT phase's spawn/join maps — mirroring where
-  ordinary-yield `spawn` from inside the resource body
+  attaches to THAT phase's durable task table — mirroring
+  where ordinary-yield `spawn` from inside the resource body
   already lands.
 
 `scope`, `timebox`, `all`, `race` inside inline bodies

--- a/packages/effects/src/invoke-inline.ts
+++ b/packages/effects/src/invoke-inline.ts
@@ -38,11 +38,12 @@ import type { InvokeOpts } from "./dispatch.js";
  * `stream.subscribe` / `stream.next` with owner-coroutineId counter
  * allocation (§12.4), `resource` with provide-in-caller-scope and
  * cleanup-at-caller-teardown semantics (§11.4, §11.8), and
- * `spawn` / `join` with caller-scope lifetime and a shared task
- * registry (§11.5) — sibling inline lanes, post-return caller
- * code, and the inline body itself can all resolve task handles
- * acquired inside an inline body; double-join across the boundary
- * fails with the existing "already been joined" error. The
+ * `spawn` / `join` with caller-scope lifetime via the hosting
+ * site's durable task table (§11.5) — sibling inline lanes,
+ * post-return caller code, and the inline body itself can all
+ * resolve task handles acquired inside an inline body; double-join
+ * across the boundary fails with the existing "already been
+ * joined" error. The
  * remaining four compound externals (`scope`, `timebox`, `all`,
  * `race`) inside an inline body are still rejected with a clear
  * error; follow-up runtime phases will lift those. `resource`

--- a/packages/effects/src/invoke-inline.ts
+++ b/packages/effects/src/invoke-inline.ts
@@ -36,14 +36,17 @@ import type { InvokeOpts } from "./dispatch.js";
  * effect dispatch inside the body, nested `invokeInline` / `invoke`
  * calls reached through standard-effect middleware,
  * `stream.subscribe` / `stream.next` with owner-coroutineId counter
- * allocation (§12.4), and `resource` with provide-in-caller-scope
- * and cleanup-at-caller-teardown semantics (§11.4, §11.8) — sibling
- * inline lanes and post-return caller code can reuse a resource
- * acquired inside an inline body until the caller itself exits.
- * Non-resource compound externals (`scope`, `spawn`, `join`,
- * `timebox`, `all`, `race`) inside an inline body are still rejected
- * with a clear error; follow-up runtime phases will lift those.
- * `resource` inside an inline body invoked from a resource-init or
+ * allocation (§12.4), `resource` with provide-in-caller-scope and
+ * cleanup-at-caller-teardown semantics (§11.4, §11.8), and
+ * `spawn` / `join` with caller-scope lifetime and a shared task
+ * registry (§11.5) — sibling inline lanes, post-return caller
+ * code, and the inline body itself can all resolve task handles
+ * acquired inside an inline body; double-join across the boundary
+ * fails with the existing "already been joined" error. The
+ * remaining four compound externals (`scope`, `timebox`, `all`,
+ * `race`) inside an inline body are still rejected with a clear
+ * error; follow-up runtime phases will lift those. `resource`
+ * inside an inline body invoked from a resource-init or
  * resource-cleanup dispatch context also remains rejected — nested
  * resources inside a resource body are unsupported.
  */

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -184,6 +184,26 @@ type InlineResourceTarget =
       reason: string;
     };
 
+/**
+ * Shared spawn/join state for an `invokeInline` body. Inline bodies
+ * do not maintain their own spawn/join tracking per §11.2 "no
+ * intermediate scope"; instead they read and write the HOSTING
+ * dispatch site's existing maps — `driveKernel`'s own
+ * `spawnedTasks` + `joinedTasks`, or `orchestrateResourceChild`'s
+ * init/cleanup-phase maps when the hosting dispatch is inside a
+ * resource body. The shared map/set gives sibling inline lanes and
+ * post-return caller code resolution parity with the hosting
+ * kernel's own spawn/join yields (§11.5).
+ *
+ * Runtime-internal only. No `kind` discriminant: every dispatch
+ * site passes a caller-scope registry because `spawn`/`join` are
+ * already supported by every current hosting site.
+ */
+interface InlineTaskRegistry {
+  spawnedTasks: Map<string, { operation: Operation<EventResult> }>;
+  joinedTasks: Set<string>;
+}
+
 // ── Nested invocation helpers ──
 
 function isFnNode(value: unknown): value is FnNode {
@@ -240,6 +260,7 @@ function buildDispatchContext(args: {
   driveContext: DriveContext;
   allocateChildId: () => string;
   inlineResourceTarget: InlineResourceTarget;
+  inlineTaskRegistry: InlineTaskRegistry;
 }): DispatchContext {
   const {
     coroutineId,
@@ -248,6 +269,7 @@ function buildDispatchContext(args: {
     driveContext,
     allocateChildId,
     inlineResourceTarget,
+    inlineTaskRegistry,
   } = args;
   const self: DispatchContext = {
     coroutineId,
@@ -323,6 +345,7 @@ function buildDispatchContext(args: {
           driveContext,
           laneOwner,
           inlineResourceTarget,
+          inlineTaskRegistry,
         );
 
       if (opts?.overlay) {
@@ -364,10 +387,20 @@ function buildDispatchContext(args: {
  *   dispatch. When the hosting dispatch is a resource-init or
  *   resource-cleanup phase, the target rejects instead — preserving
  *   the ordinary-yield nested-resource rejection.
- * - The remaining six compound externals (`scope`, `spawn`, `join`,
- *   `timebox`, `all`, `race`) inside an inline body are still
- *   rejected with a clear error: this runtime phase does NOT run
- *   them under inline-lane semantics yet.
+ * - `spawn` / `join` inside an inline body attach to the hosting
+ *   caller's Effection scope and shared task registry (§11.5).
+ *   Spawned child id is `laneId.{m}` from the lane's own
+ *   `inlineChildSpawnCount`; the child runs via a full
+ *   `driveKernel` and produces its own `CloseEvent` under that id.
+ *   Handles register in the hosting caller's `spawnedTasks` map so
+ *   sibling inline lanes, the original caller's own later code, or
+ *   the inline body itself can `join` them; the caller's
+ *   `joinedTasks` set is shared so a double-join across the
+ *   boundary fails with the existing "already been joined" error.
+ * - The remaining four compound externals (`scope`, `timebox`,
+ *   `all`, `race`) inside an inline body are still rejected with a
+ *   clear error: this runtime phase does NOT run them under
+ *   inline-lane semantics yet.
  */
 function* driveInlineBody<T = Val>(
   kernel: Generator<EffectDescriptor, Val, Val>,
@@ -376,6 +409,7 @@ function* driveInlineBody<T = Val>(
   ctx: DriveContext,
   ownerCoroutineId: string,
   inlineResourceTarget: InlineResourceTarget,
+  inlineTaskRegistry: InlineTaskRegistry,
 ): Operation<T> {
   // Own childSpawnCount per v6 §7.3. Subscription counter state lives on
   // `ctx.subscriptionCounters[ownerCoroutineId]`, shared with the caller
@@ -470,14 +504,119 @@ function* driveInlineBody<T = Val>(
         nextValue = null;
         continue;
       }
-      // `scope`, `spawn`, `join`, `timebox`, `all`, `race` — still
-      // deferred. Reject uniformly with a clear error naming the id.
-      // (`provide` is only legal inside a resource init body; a
-      // bare `provide` yield here is caller IR misuse rather than an
-      // unsupported inline compound, so it also hits this branch.)
+      if (descriptor.id === "spawn") {
+        // §11.5: spawn a foreground child at the HOSTING caller's
+        // Effection scope and task registry. Lane allocator advances
+        // by exactly +1 (matches the `resource` rule above).
+        const compoundData = descriptor.data as {
+          __tisyn_inner: { body: Expr };
+          __tisyn_env: Env;
+        };
+        const spawnChildId = `${laneId}.${inlineChildSpawnCount++}`;
+        const childEnv = compoundData.__tisyn_env;
+        const spawnChildKernel = evaluate(compoundData.__tisyn_inner.body, childEnv);
+        const {
+          operation: joinOp,
+          resolve: joinResolve,
+          reject: joinReject,
+        } = withResolvers<EventResult>();
+        // Register in the hosting site's shared spawnedTasks so
+        // sibling inline lanes and post-return caller code can
+        // resolve this handle.
+        inlineTaskRegistry.spawnedTasks.set(spawnChildId, { operation: joinOp });
+
+        yield* spawn(function* () {
+          try {
+            const childResult = yield* driveKernel(spawnChildKernel, spawnChildId, childEnv, ctx);
+            joinResolve(childResult);
+            if (childResult.status === "error") {
+              const errResult = childResult as {
+                status: "error";
+                error: { message: string; name?: string };
+              };
+              throw new EffectError(errResult.error.message, errResult.error.name);
+            }
+          } catch (e) {
+            const err = e instanceof Error ? e : new Error(String(e));
+            joinReject(err);
+            throw err; // R12: tear down hosting Effection scope on child failure
+          }
+        });
+
+        // R4: resume inline body immediately with the task handle.
+        nextValue = { __tisyn_task: spawnChildId } as Val;
+        continue;
+      }
+
+      if (descriptor.id === "join") {
+        const compoundData = descriptor.data as { __tisyn_inner: Val };
+        const taskHandle = compoundData.__tisyn_inner;
+
+        if (
+          taskHandle === null ||
+          typeof taskHandle !== "object" ||
+          typeof (taskHandle as Record<string, unknown>).__tisyn_task !== "string"
+        ) {
+          throw new RuntimeBugError("join: inner value is not a valid task handle");
+        }
+
+        const joinChildId = (taskHandle as { __tisyn_task: string }).__tisyn_task;
+
+        // R8: double-join — shared set with hosting caller, so a
+        // second join attempt from any lane or from caller code
+        // against the same handle fails.
+        if (inlineTaskRegistry.joinedTasks.has(joinChildId)) {
+          throw new RuntimeBugError(`join: task '${joinChildId}' has already been joined`);
+        }
+        inlineTaskRegistry.joinedTasks.add(joinChildId);
+
+        const entry = inlineTaskRegistry.spawnedTasks.get(joinChildId);
+        if (!entry) {
+          throw new RuntimeBugError(`join: no spawned task found for '${joinChildId}'`);
+        }
+
+        let childResult: EventResult;
+        try {
+          childResult = yield* entry.operation;
+        } catch (e) {
+          // Child task threw — route through kernel.throw with the
+          // three outcomes (uncaught re-throw / caught-return /
+          // caught-yield), same as other errors in driveInlineBody.
+          const err = e instanceof EffectError ? e : new EffectError(String(e));
+          const throwResult = kernel.throw(err);
+          if (throwResult.done) {
+            return (throwResult.value ?? null) as T;
+          }
+          pendingStep = throwResult;
+          nextValue = null;
+          continue;
+        }
+
+        if (childResult.status === "ok") {
+          nextValue = (childResult.value ?? null) as Val;
+          continue;
+        }
+        if (childResult.status === "cancelled") {
+          throw new InvocationCancelledError();
+        }
+        const err = new EffectError(childResult.error.message, childResult.error.name);
+        const throwResult = kernel.throw(err);
+        if (throwResult.done) {
+          return (throwResult.value ?? null) as T;
+        }
+        pendingStep = throwResult;
+        nextValue = null;
+        continue;
+      }
+
+      // `scope`, `timebox`, `all`, `race` — still deferred. Reject
+      // uniformly with a clear error naming the id. (`provide` is
+      // only legal inside a resource init body; a bare `provide`
+      // yield here is caller IR misuse rather than an unsupported
+      // inline compound, so it also hits this branch.)
       throw new Error(
         `invokeInline body dispatched compound external '${descriptor.id}'; ` +
-          `compound primitives 'scope', 'spawn', 'join', 'timebox', 'all', 'race' ` +
+          `compound primitives 'scope', 'timebox', 'all', 'race' ` +
           `inside inline bodies are deferred ` +
           `(see tisyn-inline-invocation-specification.md §11)`,
       );
@@ -500,6 +639,10 @@ function* driveInlineBody<T = Val>(
       // outermost caller's registration destination, so sibling lanes
       // and nested lanes all register with the same caller's array.
       inlineResourceTarget,
+      // Same inheritance for the task registry: sibling and nested
+      // inline lanes share the hosting caller's spawn/join maps so
+      // task handles are resolvable across lanes (§11.5).
+      inlineTaskRegistry,
     });
 
     if (result.status === "ok") {
@@ -1005,6 +1148,11 @@ function* driveKernel(
               resourceChildren.push(child);
             },
           },
+          // §11.5: inline-body spawn/join shares this kernel's own
+          // task registry so handles acquired inside an inline body
+          // are resolvable across sibling inline lanes and
+          // post-return caller code.
+          inlineTaskRegistry: { spawnedTasks, joinedTasks },
         });
 
         if (effectResult.status === "ok") {
@@ -1556,6 +1704,11 @@ function* orchestrateResourceChild(
               "are not supported " +
               "(see tisyn-inline-invocation-specification.md §11.4)",
           },
+          // §11.5: inline-body spawn/join from middleware running on
+          // a resource-init dispatch attaches to the init phase's
+          // shared task registry — matching where ordinary-yield
+          // `spawn` inside the resource init body already lands.
+          inlineTaskRegistry: { spawnedTasks, joinedTasks },
         });
 
         if (effectResult.status === "ok") {
@@ -1773,6 +1926,12 @@ function* orchestrateResourceChild(
               "are not supported " +
               "(see tisyn-inline-invocation-specification.md §11.4)",
           },
+          // §11.5: inline-body spawn/join from middleware running on
+          // a resource-cleanup dispatch attaches to the cleanup
+          // phase's shared task registry — matching where
+          // ordinary-yield `spawn` inside the cleanup body itself
+          // already lands.
+          inlineTaskRegistry: { spawnedTasks, joinedTasks },
         });
 
         if (effectResult.status === "ok") {
@@ -1849,6 +2008,17 @@ interface DispatchStandardEffectParams {
    * §11.4 + §11.8). Unused by ordinary (non-inline) dispatch paths.
    */
   inlineResourceTarget: InlineResourceTarget;
+  /**
+   * Shared `spawn` / `join` tracking for `invokeInline` bodies:
+   * pair of maps from the hosting dispatch site's own
+   * `driveKernel`-like scope. Inline-body spawn/join reads and
+   * writes these maps directly so sibling inline lanes and
+   * post-return caller code can resolve task handles registered
+   * inside an inline body, and double-join is detected across the
+   * shared boundary (§11.5). Unused by ordinary (non-inline)
+   * dispatch paths.
+   */
+  inlineTaskRegistry: InlineTaskRegistry;
 }
 
 /**
@@ -1918,6 +2088,7 @@ function* dispatchStandardEffect(
     ctx,
     allocateChildId,
     inlineResourceTarget,
+    inlineTaskRegistry,
   } = params;
 
   const description = parseEffectId(descriptor.id);
@@ -2089,6 +2260,7 @@ function* dispatchStandardEffect(
     driveContext: ctx,
     allocateChildId,
     inlineResourceTarget,
+    inlineTaskRegistry,
   });
 
   const runtimeCtxValue: RuntimeDispatchValue = { coroutineId, ctx };

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -185,21 +185,25 @@ type InlineResourceTarget =
     };
 
 /**
- * Shared spawn/join state for an `invokeInline` body. Inline bodies
- * do not maintain their own spawn/join tracking per §11.2 "no
- * intermediate scope"; instead they read and write the HOSTING
- * dispatch site's existing maps — `driveKernel`'s own
- * `spawnedTasks` + `joinedTasks`, or `orchestrateResourceChild`'s
- * init/cleanup-phase maps when the hosting dispatch is inside a
- * resource body. The shared map/set gives sibling inline lanes and
- * post-return caller code resolution parity with the hosting
- * kernel's own spawn/join yields (§11.5).
+ * Tisyn's durable task table for a given dispatch site. Maps the
+ * IR-level durable task id (the string inside a `{ __tisyn_task }`
+ * handle) to the live Effection join operation, and tracks the
+ * once-only `joinedTasks` set (R8). Bridges durable IR identity to
+ * live runtime operations; does NOT own scope or lifetime —
+ * Effection's `scoped(...)` owns those.
  *
- * Runtime-internal only. No `kind` discriminant: every dispatch
- * site passes a caller-scope registry because `spawn`/`join` are
- * already supported by every current hosting site.
+ * Every dispatch site that already supports spawn/join (root
+ * `driveKernel`, `orchestrateResourceChild` init and cleanup
+ * phases) maintains its own table locally. This interface is the
+ * typed reference through which an `invokeInline` body sees the
+ * hosting site's existing table — inline bodies do not maintain
+ * their own per §11.2 ("no intermediate scope"), so an inline-body
+ * `spawn` registers in, and an inline-body `join` resolves
+ * against, the host's table.
+ *
+ * Runtime-internal only. Not exported.
  */
-interface InlineTaskRegistry {
+interface DurableTaskTable {
   spawnedTasks: Map<string, { operation: Operation<EventResult> }>;
   joinedTasks: Set<string>;
 }
@@ -260,7 +264,7 @@ function buildDispatchContext(args: {
   driveContext: DriveContext;
   allocateChildId: () => string;
   inlineResourceTarget: InlineResourceTarget;
-  inlineTaskRegistry: InlineTaskRegistry;
+  durableTaskTable: DurableTaskTable;
 }): DispatchContext {
   const {
     coroutineId,
@@ -269,7 +273,7 @@ function buildDispatchContext(args: {
     driveContext,
     allocateChildId,
     inlineResourceTarget,
-    inlineTaskRegistry,
+    durableTaskTable,
   } = args;
   const self: DispatchContext = {
     coroutineId,
@@ -345,7 +349,7 @@ function buildDispatchContext(args: {
           driveContext,
           laneOwner,
           inlineResourceTarget,
-          inlineTaskRegistry,
+          durableTaskTable,
         );
 
       if (opts?.overlay) {
@@ -388,7 +392,7 @@ function buildDispatchContext(args: {
  *   resource-cleanup phase, the target rejects instead — preserving
  *   the ordinary-yield nested-resource rejection.
  * - `spawn` / `join` inside an inline body attach to the hosting
- *   caller's Effection scope and shared task registry (§11.5).
+ *   caller's Effection scope and durable task table (§11.5).
  *   Spawned child id is `laneId.{m}` from the lane's own
  *   `inlineChildSpawnCount`; the child runs via a full
  *   `driveKernel` and produces its own `CloseEvent` under that id.
@@ -409,7 +413,7 @@ function* driveInlineBody<T = Val>(
   ctx: DriveContext,
   ownerCoroutineId: string,
   inlineResourceTarget: InlineResourceTarget,
-  inlineTaskRegistry: InlineTaskRegistry,
+  durableTaskTable: DurableTaskTable,
 ): Operation<T> {
   // Own childSpawnCount per v6 §7.3. Subscription counter state lives on
   // `ctx.subscriptionCounters[ownerCoroutineId]`, shared with the caller
@@ -506,8 +510,9 @@ function* driveInlineBody<T = Val>(
       }
       if (descriptor.id === "spawn") {
         // §11.5: spawn a foreground child at the HOSTING caller's
-        // Effection scope and task registry. Lane allocator advances
-        // by exactly +1 (matches the `resource` rule above).
+        // Effection scope, registering in its durable task table.
+        // Lane allocator advances by exactly +1 (matches the
+        // `resource` rule above).
         const compoundData = descriptor.data as {
           __tisyn_inner: { body: Expr };
           __tisyn_env: Env;
@@ -523,7 +528,7 @@ function* driveInlineBody<T = Val>(
         // Register in the hosting site's shared spawnedTasks so
         // sibling inline lanes and post-return caller code can
         // resolve this handle.
-        inlineTaskRegistry.spawnedTasks.set(spawnChildId, { operation: joinOp });
+        durableTaskTable.spawnedTasks.set(spawnChildId, { operation: joinOp });
 
         yield* spawn(function* () {
           try {
@@ -565,12 +570,12 @@ function* driveInlineBody<T = Val>(
         // R8: double-join — shared set with hosting caller, so a
         // second join attempt from any lane or from caller code
         // against the same handle fails.
-        if (inlineTaskRegistry.joinedTasks.has(joinChildId)) {
+        if (durableTaskTable.joinedTasks.has(joinChildId)) {
           throw new RuntimeBugError(`join: task '${joinChildId}' has already been joined`);
         }
-        inlineTaskRegistry.joinedTasks.add(joinChildId);
+        durableTaskTable.joinedTasks.add(joinChildId);
 
-        const entry = inlineTaskRegistry.spawnedTasks.get(joinChildId);
+        const entry = durableTaskTable.spawnedTasks.get(joinChildId);
         if (!entry) {
           throw new RuntimeBugError(`join: no spawned task found for '${joinChildId}'`);
         }
@@ -639,10 +644,11 @@ function* driveInlineBody<T = Val>(
       // outermost caller's registration destination, so sibling lanes
       // and nested lanes all register with the same caller's array.
       inlineResourceTarget,
-      // Same inheritance for the task registry: sibling and nested
-      // inline lanes share the hosting caller's spawn/join maps so
-      // task handles are resolvable across lanes (§11.5).
-      inlineTaskRegistry,
+      // Same inheritance for the durable task table: sibling and
+      // nested inline lanes share the hosting caller's
+      // spawn/join maps so task handles are resolvable across
+      // lanes (§11.5).
+      durableTaskTable,
     });
 
     if (result.status === "ok") {
@@ -1149,10 +1155,10 @@ function* driveKernel(
             },
           },
           // §11.5: inline-body spawn/join shares this kernel's own
-          // task registry so handles acquired inside an inline body
-          // are resolvable across sibling inline lanes and
+          // durable task table so handles acquired inside an inline
+          // body are resolvable across sibling inline lanes and
           // post-return caller code.
-          inlineTaskRegistry: { spawnedTasks, joinedTasks },
+          durableTaskTable: { spawnedTasks, joinedTasks },
         });
 
         if (effectResult.status === "ok") {
@@ -1706,9 +1712,9 @@ function* orchestrateResourceChild(
           },
           // §11.5: inline-body spawn/join from middleware running on
           // a resource-init dispatch attaches to the init phase's
-          // shared task registry — matching where ordinary-yield
+          // durable task table — matching where ordinary-yield
           // `spawn` inside the resource init body already lands.
-          inlineTaskRegistry: { spawnedTasks, joinedTasks },
+          durableTaskTable: { spawnedTasks, joinedTasks },
         });
 
         if (effectResult.status === "ok") {
@@ -1928,10 +1934,10 @@ function* orchestrateResourceChild(
           },
           // §11.5: inline-body spawn/join from middleware running on
           // a resource-cleanup dispatch attaches to the cleanup
-          // phase's shared task registry — matching where
+          // phase's durable task table — matching where
           // ordinary-yield `spawn` inside the cleanup body itself
           // already lands.
-          inlineTaskRegistry: { spawnedTasks, joinedTasks },
+          durableTaskTable: { spawnedTasks, joinedTasks },
         });
 
         if (effectResult.status === "ok") {
@@ -2009,16 +2015,16 @@ interface DispatchStandardEffectParams {
    */
   inlineResourceTarget: InlineResourceTarget;
   /**
-   * Shared `spawn` / `join` tracking for `invokeInline` bodies:
-   * pair of maps from the hosting dispatch site's own
-   * `driveKernel`-like scope. Inline-body spawn/join reads and
-   * writes these maps directly so sibling inline lanes and
-   * post-return caller code can resolve task handles registered
-   * inside an inline body, and double-join is detected across the
-   * shared boundary (§11.5). Unused by ordinary (non-inline)
-   * dispatch paths.
+   * Reference to the hosting dispatch site's existing durable
+   * task table (`driveKernel`'s local `spawnedTasks` +
+   * `joinedTasks`, or `orchestrateResourceChild`'s
+   * init/cleanup-phase equivalents). Passed through so an
+   * `invokeInline` body can share the same table — an inline-
+   * body `spawn` registers in it, an inline-body `join` resolves
+   * against it, and R8 once-only join is enforced across the
+   * boundary (§11.5).
    */
-  inlineTaskRegistry: InlineTaskRegistry;
+  durableTaskTable: DurableTaskTable;
 }
 
 /**
@@ -2088,7 +2094,7 @@ function* dispatchStandardEffect(
     ctx,
     allocateChildId,
     inlineResourceTarget,
-    inlineTaskRegistry,
+    durableTaskTable,
   } = params;
 
   const description = parseEffectId(descriptor.id);
@@ -2260,7 +2266,7 @@ function* dispatchStandardEffect(
     driveContext: ctx,
     allocateChildId,
     inlineResourceTarget,
-    inlineTaskRegistry,
+    durableTaskTable,
   });
 
   const runtimeCtxValue: RuntimeDispatchValue = { coroutineId, ctx };

--- a/packages/runtime/src/inline-invocation.test.ts
+++ b/packages/runtime/src/inline-invocation.test.ts
@@ -14,9 +14,13 @@
  *  - Lifetime (§11) — `resource` inside an inline body provides in
  *    the caller's scope and cleans up at caller teardown. IL-PI-*,
  *    IL-L-*, IL-CS-*, IL-RD-* subset.
+ *  - Lifetime (§11.5) — `spawn` / `join` inside an inline body
+ *    attach to the hosting caller's Effection scope and task
+ *    registry. IL-CS-006/007/008 + sibling/caller join continuity +
+ *    double-join + replay.
  *
  * Out of scope — not tested here:
- *   - Non-resource compound externals (scope/spawn/join/timebox/all/
+ *   - Non-resource/spawn/join compound externals (scope/timebox/all/
  *     race) inside inline bodies (still rejected loudly by
  *     driveInlineBody).
  *   - IL-INT-*, IL-EX-*, and the full 31-test minimum subset.
@@ -1775,10 +1779,12 @@ describe("invokeInline — core runtime slice", () => {
     expect(result.status).toBe("error");
     if (result.status === "error") {
       expect(result.error.message).toContain("'scope'");
-      // The narrowed message names the six still-rejected compounds.
-      expect(result.error.message).toContain("'scope', 'spawn', 'join', 'timebox', 'all', 'race'");
-      // And does NOT list 'resource' in that set.
+      // The narrowed Phase 5E message names the four still-rejected compounds.
+      expect(result.error.message).toContain("'scope', 'timebox', 'all', 'race'");
+      // Does NOT list 'resource', 'spawn', or 'join' in that set.
       expect(result.error.message).not.toContain("'resource'");
+      expect(result.error.message).not.toContain("'spawn'");
+      expect(result.error.message).not.toContain("'join'");
     }
   });
 
@@ -1896,6 +1902,434 @@ describe("invokeInline — core runtime slice", () => {
       expect(outerResourceCloses[0]!.result.error.message).toContain(
         "resource cleanup dispatch context",
       );
+    }
+  });
+
+  // ── Phase 5E: inline-body `spawn` / `join` (IL-CS-006/007/008, L-003, RD-*) ──
+
+  const spawnIR = (body: unknown) =>
+    ({
+      tisyn: "eval",
+      id: "spawn",
+      data: { tisyn: "quote", expr: { body } },
+    }) as unknown as Val;
+
+  const joinByHandleIR = (handleRefName: string) =>
+    ({
+      tisyn: "eval",
+      id: "join",
+      data: { tisyn: "ref", name: handleRefName } as unknown,
+    }) as unknown as Val;
+
+  const letIR = (name: string, value: unknown, body: unknown) =>
+    ({
+      tisyn: "eval",
+      id: "let",
+      data: { tisyn: "quote", expr: { name, value, body } },
+    }) as unknown as Val;
+
+  it("IL-CS-006: inline body spawns + joins; child CloseEvent under laneId.{m}; lane has none", function* () {
+    // Inline body: `let t = spawn(42) in join(t)`. Returns child value.
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      letIR("t", spawnIR(Q(42)), joinByHandleIR("t")) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let inlineReturn: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          inlineReturn = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(inlineReturn).toBe(42);
+
+    // Spawned child's CloseEvent lives under root.0.0 (lane is root.0).
+    const childCloses = closes(journal).filter((e) => e.coroutineId === "root.0.0");
+    expect(childCloses).toHaveLength(1);
+    expect(childCloses[0]!.result.status).toBe("ok");
+
+    // Inline lane itself emits NO CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("IL-CS-007: spawned child attaches to caller lifetime and closes before caller close", function* () {
+    // Inline body spawns a child that yields one effect then returns 7;
+    // inline returns the task handle. Caller later joins the handle
+    // (via a JS-captured slot + readHandle agent effect) — that forces
+    // the child to complete inside the caller's scope. Assert: child's
+    // CloseEvent appears in the journal BEFORE the root's CloseEvent,
+    // and the inline lane itself has no CloseEvent.
+    const childBody = seqIR(effectIR("child", "work"), Q(7));
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      spawnIR(childBody as unknown as Val) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let handleSlot: Val = null;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          handleSlot = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        if (effectId === "caller.readHandle") {
+          return handleSlot;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Caller IR: seq(caller.go, let h = caller.readHandle in join(h))
+    const callerIr = seqIR(
+      effectIR("caller", "go"),
+      letIR("h", effectIR("caller", "readHandle"), joinByHandleIR("h")),
+    );
+
+    const { result, journal } = yield* execute({ ir: callerIr as never });
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value).toBe(7);
+    }
+
+    const childClose = closes(journal).find((e) => e.coroutineId === "root.0.0");
+    const rootClose = closes(journal).find((e) => e.coroutineId === "root");
+    expect(childClose).toBeDefined();
+    expect(rootClose).toBeDefined();
+    expect(childClose!.result.status).toBe("ok");
+    const childIdx = journal.indexOf(childClose!);
+    const rootIdx = journal.indexOf(rootClose!);
+    // Caller-scope lifetime: child closes before root.
+    expect(childIdx).toBeLessThan(rootIdx);
+    // Inline lane itself has no CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("IL-CS-008: inline lane has no CloseEvent; invoke/resource/spawn children all do", function* () {
+    // Three inline lanes in sequence:
+    //   A → invokes a child Fn (invoke → own CloseEvent)
+    //   B → acquires a resource R (→ own CloseEvent; lives until caller teardown)
+    //   C → spawns + joins a child (→ own CloseEvent)
+    // Assert: inline lanes root.0, root.1, root.2 have no CloseEvents;
+    // the three nested children all do.
+    const invokedChild: TisynFn<[], number> = Fn<[], number>([], Q(1));
+    const inlineA: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      effectIR("A", "invoke-now") as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+    const inlineB: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      resourceIR(provideIR(2)) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+    const inlineC: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      letIR("t", spawnIR(Q(3)), joinByHandleIR("t")) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          yield* invokeInline<Val>(asFn(inlineA), []);
+          yield* invokeInline<Val>(asFn(inlineB), []);
+          yield* invokeInline<Val>(asFn(inlineC), []);
+          return null as Val;
+        }
+        if (effectId === "A.invoke-now") {
+          // Middleware handling A's effect invokes a child Fn.
+          yield* invoke<Val>(asFn(invokedChild), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+    });
+    expect(result.status).toBe("ok");
+
+    // Inline lanes root.0 (A), root.1 (B), root.2 (C) — no CloseEvents.
+    for (const laneId of ["root.0", "root.1", "root.2"]) {
+      expect(closes(journal).some((e) => e.coroutineId === laneId)).toBe(false);
+    }
+
+    // invoke child (root.0.0, A's middleware allocates from A's childSpawnCount).
+    expect(closes(journal).some((e) => e.coroutineId === "root.0.0")).toBe(true);
+    // resource child (root.1.0).
+    expect(closes(journal).some((e) => e.coroutineId === "root.1.0")).toBe(true);
+    // spawn child (root.2.0).
+    expect(closes(journal).some((e) => e.coroutineId === "root.2.0")).toBe(true);
+  });
+
+  it("sibling/caller join continuity: inline A spawns, inline B joins via handle", function* () {
+    // Inline A: spawn(42) → returns task handle.
+    // Inline B: (ignored arg) joins the handle captured between calls.
+    // Caller middleware holds the handle between invocations.
+    const inlineA: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      spawnIR(Q(42)) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+    // B takes the handle as its one arg, joins it, returns the child value.
+    const inlineB: TisynFn<[Val], Val> = Fn<[Val], Val>(
+      ["h"] as [string],
+      {
+        tisyn: "eval",
+        id: "join",
+        data: { tisyn: "ref", name: "h" } as unknown,
+      } as unknown as Val,
+    ) as unknown as TisynFn<[Val], Val>;
+
+    let joinedValue: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          const handle = yield* invokeInline<Val>(asFn(inlineA), []);
+          joinedValue = yield* invokeInline<Val>(asFn(inlineB), [handle]);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result } = yield* execute({ ir: effectIR("caller", "go") as never });
+    expect(result.status).toBe("ok");
+    expect(joinedValue).toBe(42);
+  });
+
+  it("caller joins an inline-spawned handle after inline returns", function* () {
+    // Inline A spawns(42) and returns the handle; caller code then yields
+    // join(handle) directly from root's driveKernel. The root join walks
+    // the shared spawnedTasks and finds the inline-registered entry.
+    const inlineA: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      spawnIR(Q(42)) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let handleSlot: Val = null;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.spawnInline") {
+          handleSlot = yield* invokeInline<Val>(asFn(inlineA), []);
+          return null as Val;
+        }
+        if (effectId === "caller.readHandle") {
+          return handleSlot;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Caller: spawnInline; let h = readHandle in join(h)
+    const callerIr = seqIR(
+      effectIR("caller", "spawnInline"),
+      letIR("h", effectIR("caller", "readHandle"), joinByHandleIR("h")),
+    );
+
+    const { result } = yield* execute({ ir: callerIr as never });
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value).toBe(42);
+    }
+  });
+
+  it("double-join regression: joining an inline-spawned handle twice fails", function* () {
+    // Inline A spawns(42); caller joins (succeeds); caller joins again
+    // (fails with the shared double-join error).
+    const inlineA: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      spawnIR(Q(42)) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let handleSlot: Val = null;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.spawnInline") {
+          handleSlot = yield* invokeInline<Val>(asFn(inlineA), []);
+          return null as Val;
+        }
+        if (effectId === "caller.readHandle") {
+          return handleSlot;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    // Caller: spawn; h = read; join(h); join(h) (second join fails).
+    const callerIr = seqIR(
+      effectIR("caller", "spawnInline"),
+      letIR("h", effectIR("caller", "readHandle"), seqIR(joinByHandleIR("h"), joinByHandleIR("h"))),
+    );
+
+    const { result } = yield* execute({ ir: callerIr as never });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.message).toContain("already been joined");
+    }
+  });
+
+  it("IL-RD-like: inline-spawned child replay is byte-identical", function* () {
+    // Inline body spawns a child that yields one effect and returns; inline
+    // body then joins the handle. Live run; replay with same stream.
+    const childBody = seqIR(effectIR("inline-spawn", "work"), Q(99));
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      letIR("t", spawnIR(childBody as unknown as Val), joinByHandleIR("t")) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let liveFireCount = 0;
+
+    const installAgents = function* () {
+      yield* Effects.around({
+        *dispatch([effectId, _data]: [string, Val], next) {
+          if (effectId === "caller.go") {
+            yield* invokeInline<Val>(asFn(inlineBody), []);
+            return null as Val;
+          }
+          return yield* next(effectId, _data);
+        },
+      });
+      yield* Effects.around(
+        {
+          *dispatch([effectId, _d]: [string, Val]) {
+            if (effectId === "inline-spawn.work") {
+              liveFireCount++;
+            }
+            return null as Val;
+          },
+        },
+        { at: "min" },
+      );
+    };
+
+    const stream = new InMemoryStream();
+    yield* installAgents();
+
+    const { result: liveResult, journal: liveJournal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+      stream,
+    });
+    expect(liveResult.status).toBe("ok");
+    expect(liveFireCount).toBe(1);
+
+    // Replay — child does not refire live.
+    liveFireCount = 0;
+    const { result: replayResult, journal: replayJournal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+      stream,
+    });
+    expect(replayResult.status).toBe("ok");
+    expect(liveFireCount).toBe(0);
+    expect(replayJournal).toEqual(liveJournal);
+
+    // Child YieldEvent is under root.0.0, not the inline lane.
+    const workYields = yields(liveJournal).filter(
+      (e) => e.description.type === "inline-spawn" && e.description.name === "work",
+    );
+    expect(workYields).toHaveLength(1);
+    expect(workYields[0]!.coroutineId).toBe("root.0.0");
+  });
+
+  it("regression: timebox inside inline body still rejects with clear error", function* () {
+    const timeboxInner = {
+      tisyn: "eval",
+      id: "timebox",
+      data: {
+        tisyn: "quote",
+        expr: { duration: 10, body: Q(0) },
+      },
+    };
+    const bodyWithTimebox: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      timeboxInner as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          yield* invokeInline<Val>(asFn(bodyWithTimebox), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result } = yield* execute({ ir: effectIR("caller", "go") as never });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.message).toContain("'timebox'");
+      expect(result.error.message).toContain("'scope', 'timebox', 'all', 'race'");
+      expect(result.error.message).not.toContain("'spawn'");
+      expect(result.error.message).not.toContain("'join'");
     }
   });
 });


### PR DESCRIPTION
## Summary

Step middleware can now start background child work from
inside an `invokeInline` body and have the returned task
handle be joinable from the inline body, sibling inline
lanes, or later caller code — all without creating an inline
scope boundary. The spawned child attaches to the hosting
caller's Effection scope and task registry, so its lifetime
and join semantics match ordinary caller-level spawns.

Implements `tisyn-inline-invocation-specification.md` §11.5.

## Design

- **`InlineTaskRegistry` — plain pair-of-maps on the internal
  dispatch seam.** A single interface exposing the hosting
  site's `spawnedTasks` and `joinedTasks`. No discriminated
  union: `spawn`/`join` are already allowed inside resource
  init and cleanup bodies via the ordinary yield path, so
  rejecting them through the inline path would narrow an
  existing capability. Every hosting dispatch site
  (`driveKernel`, resource init, resource cleanup) passes a
  caller-scope registry backed by its own local maps.
- **Spawned child id = `laneId.{m}`**, allocated from the
  inline lane's own `inlineChildSpawnCount` (same rule used
  for `invoke`-inside-inline and `resource`-inside-inline).
  Child runs via full `driveKernel` — produces its own
  `CloseEvent` under the child id. Inline lane itself still
  produces none.
- **Shared `joinedTasks` across the boundary.** Double-join
  fires whether the second join comes from the inline body,
  a sibling inline lane, or caller code — handles registered
  inside an inline body and joined outside compose with the
  hosting caller's spawn/join state as a single pool.
- **Join error path mirrors other inline errors** via the
  three-outcome `kernel.throw` (uncaught re-throw /
  caught-return / caught-yield).

## What's still deferred

- `scope`, `timebox`, `all`, `race` inside inline bodies —
  rejected uniformly with a narrowed error listing just
  those four. Each is a follow-up phase.
- Nested resources inside a resource body remain rejected
  (preserved from Phase 5D).

## Changes

- `@tisyn/runtime` — `InlineTaskRegistry` interface added;
  threaded through `dispatchStandardEffect` +
  `buildDispatchContext` + `driveInlineBody`; caller, resource
  init, and resource cleanup dispatch sites pass their own
  local maps; `driveInlineBody` branches on `spawn` and
  `join` before the catch-all; catch-all message narrowed.
  Patch changeset with impact-first wording.
- `@tisyn/effects` — JSDoc on `invokeInline` updated to
  mention `spawn`/`join` now supported with caller-scope
  semantics. Public signature unchanged.
- `packages/runtime/src/inline-invocation.test.ts` — 8 new
  tests: IL-CS-006, IL-CS-007, IL-CS-008, sibling-join
  continuity, caller-join continuity, double-join regression,
  inline-spawned replay byte-identical, and a new `timebox`
  still-rejected regression. The Phase 5D `scope`-rejection
  test's assertion is updated to the narrowed message.

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (root; matches CI): all suites green;
      runtime now 301 tests (up from 293).
- [x] `inline-invocation.test.ts` — 44 tests pass (36 post-5D
      + 8 new).
- [x] `spawn.test.ts`, `resource.test.ts`,
      `replay-dispatch.test.ts`, `nested-invocation.test.ts`
      unchanged green.
- [x] Grep sanity: narrowed catch-all exactly once; old 5D
      catch-all (with spawn/join) gone; every modified
      package has a changeset.

## Context

- Refs #122 (original tracking issue; closed with PR #130).
- Context: PR #131 (core inline lane runtime slice — Phase
  5B).
- Context: PR #132 (inline stream ownership — Phase 5C).
- Context: PR #133 (inline resource continuity — Phase 5D).