### PR TITLE
Implement inline-lane timebox, all, and race

### DIFF
--- a/.changeset/effects-inline-timebox-all-race.md
+++ b/.changeset/effects-inline-timebox-all-race.md
@@ -1,0 +1,13 @@
+---
+"@tisyn/effects": patch
+---
+
+Update the `invokeInline` public JSDoc to document the new
+runtime support: `timebox`, `all`, and `race` now work
+inside inline bodies with their own compound-external
+semantics per §11.6. `scope` is the only compound still
+rejected; a follow-up phase will review its
+transport-binding semantics before lifting it.
+
+Paired with the runtime-side implementation. Public
+signature unchanged.

--- a/.changeset/runtime-inline-timebox-all-race.md
+++ b/.changeset/runtime-inline-timebox-all-race.md
@@ -1,0 +1,46 @@
+---
+"@tisyn/runtime": patch
+---
+
+Lift the `timebox`, `all`, and `race` rejections inside
+`invokeInline` bodies per §11.6 of the inline-invocation
+specification. Step middleware can now use bounded and
+concurrent child work inside shared-lifetime inline
+execution without introducing a scope boundary.
+
+- **`timebox` inside an inline body.** Allocates two child
+  IDs from the inline lane's own counter —
+  `laneId.{N}` (body) and `laneId.{N+1}` (timeout) — and
+  delegates to the existing `orchestrateTimebox` helper.
+  The orchestrator resolves with the tagged value
+  `{ status: "completed", value }` on body-win and
+  `{ status: "timeout" }` on timeout-win (timeout is NOT
+  an error; it is a successful tagged value). Both the
+  body child and the timeout child emit their own
+  `CloseEvent`; the inline lane itself still emits none.
+- **`all` and `race` inside an inline body.** Allocate
+  `exprs.length` contiguous child IDs from the inline
+  lane's own counter and delegate to the existing
+  `orchestrateAll` / `orchestrateRace` helpers. Result
+  ordering, first-winner propagation, and empty-list
+  handling all match the runtime's pre-existing semantics.
+- **Error routing.** Orchestrator errors (e.g. fail-fast
+  propagation from `all`) are routed through
+  `kernel.throw(err)` with the three-outcome pattern, so
+  the inline body's own `try`/`catch` semantics work for
+  these compounds the same way they do for standard-effect
+  errors.
+- **`provide` misuse framing.** An inline body yielding a
+  bare `provide` outside a resource context throws
+  `RuntimeBugError("provide outside resource context")` —
+  framed as caller IR misuse (matching driveKernel), not
+  as a "deferred inline compound".
+
+`scope` inside an inline body remains rejected with a
+clear error naming only it; its transport-binding
+semantics (handler / bindings / scope boundary) need their
+own review before lifting. The catch-all rejection message
+is narrowed to the single-compound form.
+
+No kernel / compiler / IR / durable-event-algebra changes;
+no public API changes; `invokeInline` signature unchanged.

--- a/packages/effects/src/invoke-inline.ts
+++ b/packages/effects/src/invoke-inline.ts
@@ -43,11 +43,12 @@ import type { InvokeOpts } from "./dispatch.js";
  * post-return caller code, and the inline body itself can all
  * resolve task handles acquired inside an inline body; double-join
  * across the boundary fails with the existing "already been
- * joined" error. The
- * remaining four compound externals (`scope`, `timebox`, `all`,
- * `race`) inside an inline body are still rejected with a clear
- * error; follow-up runtime phases will lift those. `resource`
- * inside an inline body invoked from a resource-init or
+ * joined" error — and `timebox` / `all` / `race` with their own
+ * compound-external semantics (§11.6). `scope` inside an inline
+ * body remains rejected with a clear error; it is the only
+ * compound still deferred, and a follow-up runtime phase will
+ * review its transport-binding semantics before lifting it.
+ * `resource` inside an inline body invoked from a resource-init or
  * resource-cleanup dispatch context also remains rejected — nested
  * resources inside a resource body are unsupported.
  */

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -401,10 +401,22 @@ function buildDispatchContext(args: {
  *   the inline body itself can `join` them; the caller's
  *   `joinedTasks` set is shared so a double-join across the
  *   boundary fails with the existing "already been joined" error.
- * - The remaining four compound externals (`scope`, `timebox`,
- *   `all`, `race`) inside an inline body are still rejected with a
- *   clear error: this runtime phase does NOT run them under
- *   inline-lane semantics yet.
+ * - `timebox` / `all` / `race` keep their own compound-external
+ *   semantics (§11.6). Child IDs are allocated from the lane's
+ *   own `inlineChildSpawnCount` — `timebox` takes two
+ *   (`laneId.{N}` body + `laneId.{N+1}` timeout); `all` / `race`
+ *   take a contiguous range of length `exprs.length`. The lane
+ *   itself still produces no `CloseEvent`; each child produces
+ *   its own `CloseEvent` per the orchestrator's existing rules.
+ *   Errors are routed through `kernel.throw(...)` with the
+ *   three-outcome pattern, so the inline body's `try`/`catch`
+ *   sees them as ordinary `EffectError` raises.
+ * - `scope` inside an inline body remains rejected with a clear
+ *   error — its transport-binding semantics need their own
+ *   review and will be a follow-up phase. A bare `provide` yield
+ *   (outside a resource init body) is caller IR misuse and
+ *   throws `RuntimeBugError("provide outside resource context")`,
+ *   matching driveKernel's behavior.
  */
 function* driveInlineBody<T = Val>(
   kernel: Generator<EffectDescriptor, Val, Val>,
@@ -614,15 +626,101 @@ function* driveInlineBody<T = Val>(
         continue;
       }
 
-      // `scope`, `timebox`, `all`, `race` — still deferred. Reject
-      // uniformly with a clear error naming the id. (`provide` is
-      // only legal inside a resource init body; a bare `provide`
-      // yield here is caller IR misuse rather than an unsupported
-      // inline compound, so it also hits this branch.)
+      if (descriptor.id === "timebox") {
+        // §11.6: `timebox` keeps its own compound-external semantics.
+        // Allocate 2 child IDs from the lane's own
+        // `inlineChildSpawnCount`: body = N, timeout = N+1
+        // (TB-R2). Delegate to the existing orchestrator and route
+        // any error through `kernel.throw` with the three outcomes.
+        const compoundData = descriptor.data as {
+          __tisyn_inner: { duration: number; body: Expr };
+          __tisyn_env: Env;
+        };
+        const bodyChildId = `${laneId}.${inlineChildSpawnCount++}`;
+        const timeoutChildId = `${laneId}.${inlineChildSpawnCount++}`;
+        const childEnv = compoundData.__tisyn_env;
+
+        let timeboxValue: Val = null;
+        let timeboxErr: Error | null = null;
+        try {
+          timeboxValue = yield* orchestrateTimebox(
+            compoundData.__tisyn_inner.duration,
+            compoundData.__tisyn_inner.body,
+            bodyChildId,
+            timeoutChildId,
+            childEnv,
+            ctx,
+          );
+        } catch (e) {
+          timeboxErr = e instanceof Error ? e : new Error(String(e));
+        }
+
+        if (timeboxErr === null) {
+          nextValue = timeboxValue;
+          continue;
+        }
+        const throwResult = kernel.throw(timeboxErr);
+        if (throwResult.done) {
+          return (throwResult.value ?? null) as T;
+        }
+        pendingStep = throwResult;
+        nextValue = null;
+        continue;
+      }
+
+      if (descriptor.id === "all" || descriptor.id === "race") {
+        // §11.6: `all` / `race` keep their own compound-external
+        // semantics. Allocate `exprs.length` contiguous child IDs
+        // from the lane's own `inlineChildSpawnCount`; delegate to
+        // the existing orchestrator; route any error through
+        // `kernel.throw` with the three outcomes.
+        const compoundData = descriptor.data as {
+          __tisyn_inner: { exprs: Expr[] };
+          __tisyn_env: Env;
+        };
+        const exprs = compoundData.__tisyn_inner.exprs;
+        const childEnv = compoundData.__tisyn_env;
+        const startIndex = inlineChildSpawnCount;
+        inlineChildSpawnCount += exprs.length;
+
+        let compoundValue: Val = null;
+        let compoundErr: Error | null = null;
+        try {
+          compoundValue =
+            descriptor.id === "all"
+              ? yield* orchestrateAll(exprs, laneId, startIndex, childEnv, ctx)
+              : yield* orchestrateRace(exprs, laneId, startIndex, childEnv, ctx);
+        } catch (e) {
+          compoundErr = e instanceof Error ? e : new Error(String(e));
+        }
+
+        if (compoundErr === null) {
+          nextValue = compoundValue;
+          continue;
+        }
+        const throwResult = kernel.throw(compoundErr);
+        if (throwResult.done) {
+          return (throwResult.value ?? null) as T;
+        }
+        pendingStep = throwResult;
+        nextValue = null;
+        continue;
+      }
+
+      if (descriptor.id === "provide") {
+        // Caller IR misuse — same rule as driveKernel: `provide` is
+        // only legal inside a resource init body. An inline body
+        // dispatching a bare `provide` is a runtime bug, not a
+        // deferred inline compound.
+        throw new RuntimeBugError("provide outside resource context");
+      }
+
+      // `scope` — still deferred. `scope` involves transport-binding
+      // semantics that need their own review before landing inside
+      // inline bodies; see §11.6 plan and the follow-up phase.
       throw new Error(
         `invokeInline body dispatched compound external '${descriptor.id}'; ` +
-          `compound primitives 'scope', 'timebox', 'all', 'race' ` +
-          `inside inline bodies are deferred ` +
+          `compound primitive 'scope' inside inline bodies is deferred ` +
           `(see tisyn-inline-invocation-specification.md §11)`,
       );
     }

--- a/packages/runtime/src/inline-invocation.test.ts
+++ b/packages/runtime/src/inline-invocation.test.ts
@@ -18,16 +18,20 @@
  *    attach to the hosting caller's Effection scope and task
  *    registry. IL-CS-006/007/008 + sibling/caller join continuity +
  *    double-join + replay.
+ *  - Lifetime (§11.6) — `timebox` / `all` / `race` inside an
+ *    inline body keep their own compound-external semantics,
+ *    with child IDs allocated from the lane's own
+ *    `inlineChildSpawnCount`.
  *
  * Out of scope — not tested here:
- *   - Non-resource/spawn/join compound externals (scope/timebox/all/
- *     race) inside inline bodies (still rejected loudly by
- *     driveInlineBody).
+ *   - `scope` inside inline bodies (still rejected loudly by
+ *     driveInlineBody; lifting is a follow-up phase).
  *   - IL-INT-*, IL-EX-*, and the full 31-test minimum subset.
  */
 
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
+import { suspend } from "effection";
 import type { Operation } from "effection";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import type { DurableEvent, YieldEvent, CloseEvent } from "@tisyn/kernel";
@@ -1779,12 +1783,18 @@ describe("invokeInline — core runtime slice", () => {
     expect(result.status).toBe("error");
     if (result.status === "error") {
       expect(result.error.message).toContain("'scope'");
-      // The narrowed Phase 5E message names the four still-rejected compounds.
-      expect(result.error.message).toContain("'scope', 'timebox', 'all', 'race'");
-      // Does NOT list 'resource', 'spawn', or 'join' in that set.
+      // Phase 5F narrowed the message to single-compound — only
+      // `scope` is still rejected.
+      expect(result.error.message).toContain(
+        "compound primitive 'scope' inside inline bodies is deferred",
+      );
+      // No other compound appears in the rejection list.
       expect(result.error.message).not.toContain("'resource'");
       expect(result.error.message).not.toContain("'spawn'");
       expect(result.error.message).not.toContain("'join'");
+      expect(result.error.message).not.toContain("'timebox'");
+      expect(result.error.message).not.toContain("'all'");
+      expect(result.error.message).not.toContain("'race'");
     }
   });
 
@@ -2291,24 +2301,323 @@ describe("invokeInline — core runtime slice", () => {
     expect(workYields[0]!.coroutineId).toBe("root.0.0");
   });
 
-  it("regression: timebox inside inline body still rejects with clear error", function* () {
-    const timeboxInner = {
+  // ── Phase 5F: inline-body `timebox` / `all` / `race` (§11.6) ──
+
+  const timeboxIR = (duration: number, body: unknown) =>
+    ({
       tisyn: "eval",
       id: "timebox",
-      data: {
-        tisyn: "quote",
-        expr: { duration: 10, body: Q(0) },
-      },
-    };
-    const bodyWithTimebox: TisynFn<[], Val> = Fn<[], Val>(
+      data: { tisyn: "quote", expr: { duration, body } },
+    }) as unknown as Val;
+
+  const allIR = (exprs: unknown[]) =>
+    ({
+      tisyn: "eval",
+      id: "all",
+      data: { tisyn: "quote", expr: { exprs } },
+    }) as unknown as Val;
+
+  const raceIR = (exprs: unknown[]) =>
+    ({
+      tisyn: "eval",
+      id: "race",
+      data: { tisyn: "quote", expr: { exprs } },
+    }) as unknown as Val;
+
+  const provideOutsideResourceIR = (value: unknown) =>
+    ({
+      tisyn: "eval",
+      id: "provide",
+      data: value,
+    }) as unknown as Val;
+
+  it("IL-CS-009 / timebox-completed: body wins → tagged { status: 'completed', value }", function* () {
+    // Inline body runs timebox with a fast-completing body (`Q(42)`);
+    // body-win produces the tagged value.
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
       [],
-      timeboxInner as unknown as Val,
+      timeboxIR(10_000, Q(42)) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let inlineReturn: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          inlineReturn = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({ ir: effectIR("caller", "go") as never });
+    expect(result.status).toBe("ok");
+    expect(inlineReturn).toEqual({ status: "completed", value: 42 });
+
+    // Body child (root.0.0) + timeout child (root.0.1) both produce CloseEvents.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0.0")).toBe(true);
+    expect(closes(journal).some((e) => e.coroutineId === "root.0.1")).toBe(true);
+    // Inline lane itself has no CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("timebox-timed-out: timeout wins → tagged { status: 'timeout' }; not an error", function* () {
+    // Inline body runs timebox with duration 0. Timeout wins; orchestrator
+    // resolves with `{ status: "timeout" }` — this is a tagged success
+    // value, NOT an error.
+    const slowBody = effectIR("timebox-body", "wait");
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      timeboxIR(0, slowBody) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let inlineReturn: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          inlineReturn = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([effectId, _d]: [string, Val]) {
+          if (effectId === "timebox-body.wait") {
+            // Never resolves on its own — the timeout will halt the body.
+            yield* suspend();
+          }
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({ ir: effectIR("caller", "go") as never });
+    // Execute result is OK — timeout is a successful tagged value.
+    expect(result.status).toBe("ok");
+    expect(inlineReturn).toEqual({ status: "timeout" });
+
+    // Body + timeout child CloseEvents both present.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0.0")).toBe(true);
+    expect(closes(journal).some((e) => e.coroutineId === "root.0.1")).toBe(true);
+    // Inline lane itself has no CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("all-success: children under contiguous lane IDs; result order preserved", function* () {
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      allIR([Q(1), Q(2), Q(3)]) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let inlineReturn: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          inlineReturn = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({ ir: effectIR("caller", "go") as never });
+    expect(result.status).toBe("ok");
+    expect(inlineReturn).toEqual([1, 2, 3]);
+
+    // Three contiguous child IDs, each with its own CloseEvent.
+    for (const childId of ["root.0.0", "root.0.1", "root.0.2"]) {
+      expect(closes(journal).some((e) => e.coroutineId === childId)).toBe(true);
+    }
+    // Inline lane has no CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("race-success: first ok child wins; children under contiguous lane IDs", function* () {
+    // Two children: first literal Q(99) should win trivially (both race
+    // orchestrator kicks them off concurrently; Q is synchronous).
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      raceIR([Q(99), Q("slow")]) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let inlineReturn: Val | undefined;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          inlineReturn = yield* invokeInline<Val>(asFn(inlineBody), []);
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([_e, _d]: [string, Val]) {
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result, journal } = yield* execute({ ir: effectIR("caller", "go") as never });
+    expect(result.status).toBe("ok");
+    // Race orchestrator's scheduling picks one of the two as the winner;
+    // pin the behavior to "value comes from one of the input exprs".
+    expect([99, "slow"]).toContain(inlineReturn);
+
+    // Both race child IDs appear (though loser is halted mid-way).
+    const childCloses = closes(journal).filter(
+      (e) => e.coroutineId === "root.0.0" || e.coroutineId === "root.0.1",
+    );
+    expect(childCloses.length).toBeGreaterThanOrEqual(1);
+    // Inline lane has no CloseEvent.
+    expect(closes(journal).some((e) => e.coroutineId === "root.0")).toBe(false);
+  });
+
+  it("error from `all` routes through inline body's try/catch via kernel.throw", function* () {
+    // Inline body: try { all([Throw("boom"), Q(2)]) } catch "e" Ref("e-msg-from-effect")
+    // Simpler variant: just let the error propagate, assert the inline
+    // call rejects and the outer execute result is error with the "boom"
+    // message (fail-fast from orchestrateAll).
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      Try(
+        allIR([effectIR("bomb", "go"), Q(2)]) as unknown as Val,
+        "e",
+        Ref<Val>("e"),
+      ) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let inlineReturn: Val | undefined;
+    let inlineThrown: unknown;
+
+    yield* Effects.around({
+      *dispatch([effectId, _data]: [string, Val], next) {
+        if (effectId === "caller.go") {
+          try {
+            inlineReturn = yield* invokeInline<Val>(asFn(inlineBody), []);
+          } catch (e) {
+            inlineThrown = e;
+          }
+          return null as Val;
+        }
+        return yield* next(effectId, _data);
+      },
+    });
+    yield* Effects.around(
+      {
+        *dispatch([effectId, _d]: [string, Val]) {
+          if (effectId === "bomb.go") {
+            throw new Error("boom");
+          }
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { result } = yield* execute({ ir: effectIR("caller", "go") as never });
+    expect(result.status).toBe("ok");
+    // The inline body's try/catch caught the EffectError raised by the
+    // orchestrator; the catch binding `e` becomes an Error value which
+    // the IR evaluator surfaces as the error object itself.
+    expect(inlineThrown).toBeUndefined();
+    expect(inlineReturn).toBeDefined();
+    // The caught value is the EffectError — its message is "boom".
+    const msg = (inlineReturn as unknown as { message?: string })?.message;
+    expect(msg).toContain("boom");
+  });
+
+  it("replay byte-identical: inline-body `all` reruns on replay without firing live", function* () {
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      allIR([effectIR("replay-all", "one"), effectIR("replay-all", "two")]) as unknown as Val,
+    ) as unknown as TisynFn<[], Val>;
+
+    let liveFireCount = 0;
+
+    const installAgents = function* () {
+      yield* Effects.around({
+        *dispatch([effectId, _data]: [string, Val], next) {
+          if (effectId === "caller.go") {
+            yield* invokeInline<Val>(asFn(inlineBody), []);
+            return null as Val;
+          }
+          return yield* next(effectId, _data);
+        },
+      });
+      yield* Effects.around(
+        {
+          *dispatch([effectId, _d]: [string, Val]) {
+            if (effectId === "replay-all.one" || effectId === "replay-all.two") {
+              liveFireCount++;
+              return "done" as Val;
+            }
+            return null as Val;
+          },
+        },
+        { at: "min" },
+      );
+    };
+
+    const stream = new InMemoryStream();
+    yield* installAgents();
+
+    const { result: liveResult, journal: liveJournal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+      stream,
+    });
+    expect(liveResult.status).toBe("ok");
+    expect(liveFireCount).toBe(2);
+
+    // Replay — nothing should refire live.
+    liveFireCount = 0;
+    const { result: replayResult, journal: replayJournal } = yield* execute({
+      ir: effectIR("caller", "go") as never,
+      stream,
+    });
+    expect(replayResult.status).toBe("ok");
+    expect(liveFireCount).toBe(0);
+    expect(replayJournal).toEqual(liveJournal);
+  });
+
+  it("regression: bare `provide` inside inline body is runtime misuse, not 'deferred'", function* () {
+    // Inline body yields provide(42) outside any resource context. Same
+    // rule as driveKernel: RuntimeBugError("provide outside resource
+    // context"). NOT a "deferred inline compound" — provide is never
+    // legal outside a resource body.
+    const inlineBody: TisynFn<[], Val> = Fn<[], Val>(
+      [],
+      provideOutsideResourceIR(42) as unknown as Val,
     ) as unknown as TisynFn<[], Val>;
 
     yield* Effects.around({
       *dispatch([effectId, _data]: [string, Val], next) {
         if (effectId === "caller.go") {
-          yield* invokeInline<Val>(asFn(bodyWithTimebox), []);
+          yield* invokeInline<Val>(asFn(inlineBody), []);
           return null as Val;
         }
         return yield* next(effectId, _data);
@@ -2326,10 +2635,9 @@ describe("invokeInline — core runtime slice", () => {
     const { result } = yield* execute({ ir: effectIR("caller", "go") as never });
     expect(result.status).toBe("error");
     if (result.status === "error") {
-      expect(result.error.message).toContain("'timebox'");
-      expect(result.error.message).toContain("'scope', 'timebox', 'all', 'race'");
-      expect(result.error.message).not.toContain("'spawn'");
-      expect(result.error.message).not.toContain("'join'");
+      expect(result.error.message).toContain("provide outside resource context");
+      // Not framed as a deferred compound.
+      expect(result.error.message).not.toContain("deferred");
     }
   });
 });


### PR DESCRIPTION
## Summary

Inline step middleware can now use bounded and concurrent
child work inside `invokeInline` bodies — `timebox`, `all`,
and `race` — without introducing a scope boundary. Each
primitive keeps its own existing compound-external
semantics; children are allocated under the inline lane's
own ID space and emit their normal `CloseEvent`s; the
inline lane itself still emits none.

Implements `tisyn-inline-invocation-specification.md`
§11.6.

## Design

- **`timebox` inside an inline body.** Allocates two child
  IDs from the lane's own `inlineChildSpawnCount`
  (`laneId.{N}` body + `laneId.{N+1}` timeout) and
  delegates to the existing `orchestrateTimebox` helper.
  The orchestrator's tagged result propagates unchanged:
  `{ status: "completed", value }` on body-win and
  `{ status: "timeout" }` on timeout-win. Timeout is a
  successful tagged value, not an error.
- **`all` / `race` inside an inline body.** Allocate
  `exprs.length` contiguous child IDs from the lane's
  counter and delegate to `orchestrateAll` /
  `orchestrateRace`. Result ordering, first-winner
  propagation, and empty-list handling all match the
  runtime's pre-existing semantics.
- **Error routing.** Orchestrator errors (e.g. fail-fast
  propagation from `all`) route through the inline body's
  `kernel.throw(err)` with the three-outcome pattern used
  by the existing resource/spawn/join branches, so the
  inline body's own `try`/`catch` semantics work the same
  way for these compounds as for standard-effect errors.
- **`provide` misuse framing.** A bare `provide` yield
  inside an inline body outside any resource context
  throws `RuntimeBugError("provide outside resource
  context")` — caller IR misuse, same rule as driveKernel.
  Not framed as a "deferred inline compound" because there
  is no future phase where this becomes legal; it's a
  runtime bug.

## What's still deferred

`scope` inside inline bodies remains rejected with a clear
error naming only it. Its semantics interact with
transport-bindings, handler dispatch scoping, and scope
variable resolution in ways that need their own review
separately from the concurrency-primitive story. A
follow-up phase will address it.

## Changes

- `@tisyn/runtime` — `driveInlineBody` gains explicit
  `timebox`, `all`/`race`, and `provide` branches before
  the catch-all; catch-all message narrowed to the
  single-compound form naming only `scope`. Patch
  changeset with impact-first wording.
- `@tisyn/effects` — JSDoc on `invokeInline` updated to
  mention the new compound supports. Public signature
  unchanged.
- `packages/runtime/src/inline-invocation.test.ts` — 6
  positive IL-* cases (timebox-completed, timebox-timed-
  out, all-success, race-success, error-routed, replay
  byte-identical), 1 updated scope regression on the
  narrowed message, 1 new provide-misuse regression; the
  Phase 5E timebox rejection regression is removed.

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (root; matches CI): all suites
      green; runtime now 307 tests (up from 301).
- [x] `inline-invocation.test.ts` — 50 tests pass
      (44 post-5E − 1 deleted timebox regression + 7 new).
- [x] `timebox.test.ts`, `all.test.ts`, `race.test.ts`,
      `spawn.test.ts`, `resource.test.ts`,
      `replay-dispatch.test.ts`,
      `nested-invocation.test.ts` unchanged green.
- [x] Grep sanity: narrowed catch-all exactly once; old
      four-compound catch-all gone; every modified package
      has a changeset.

## Context

- Refs #122 (original tracking issue; closed with PR #130).
- Context: PR #131 (core inline lane runtime slice — Phase
  5B).
- Context: PR #132 (inline stream ownership — Phase 5C).
- Context: PR #133 (inline resource continuity — Phase 5D).
- Context: PR #135 (inline spawn / join — Phase 5E).