### PR TITLE
Add browser-safe subpaths for execute() and durable-streams

### DIFF
--- a/.changeset/durable-streams-browser-subpath.md
+++ b/.changeset/durable-streams-browser-subpath.md
@@ -1,0 +1,5 @@
+---
+"@tisyn/durable-streams": minor
+---
+
+Add `@tisyn/durable-streams/browser` subpath exporting `DurableStream`, `InMemoryStream`, `ReplayIndex`, and `YieldEntry`. Browser bundles can import from this subpath to avoid pulling `FileStream`'s `node:fs` / `node:path` dependencies transitively.

--- a/.changeset/runtime-browser-execute-subpath.md
+++ b/.changeset/runtime-browser-execute-subpath.md
@@ -1,0 +1,5 @@
+---
+"@tisyn/runtime": minor
+---
+
+Add `@tisyn/runtime/execute` subpath so consumers bundling `execute()` for the browser can import it without pulling the Node-only loader/config code re-exported from the root entrypoint. Closes #106.

--- a/.changeset/transport-browser-executor-imports.md
+++ b/.changeset/transport-browser-executor-imports.md
@@ -1,0 +1,5 @@
+---
+"@tisyn/transport": patch
+---
+
+Switch `@tisyn/transport/browser-executor` internals to import `execute` and `InMemoryStream` from the new `@tisyn/runtime/execute` and `@tisyn/durable-streams/browser` subpaths, so Vite/browser bundles of `createBrowserExecutor` and `createInProcessRunner` no longer drag Node built-ins through transitive root re-exports. No public API change.

--- a/examples/multi-agent-chat/test/browser/helpers/in-page-executor.ts
+++ b/examples/multi-agent-chat/test/browser/helpers/in-page-executor.ts
@@ -1,7 +1,7 @@
 import { run } from "effection";
 import { Agents } from "@tisyn/agent";
-import { execute } from "@tisyn/runtime";
-import { InMemoryStream } from "@tisyn/durable-streams";
+import { execute } from "@tisyn/runtime/execute";
+import { InMemoryStream } from "@tisyn/durable-streams/browser";
 import { Call } from "@tisyn/ir";
 import type { IrInput } from "@tisyn/ir";
 import { Dom } from "../dom-workflows.generated.js";

--- a/packages/durable-streams/package.json
+++ b/packages/durable-streams/package.json
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js"
     }
   },
   "publishConfig": {

--- a/packages/durable-streams/src/browser.ts
+++ b/packages/durable-streams/src/browser.ts
@@ -1,0 +1,2 @@
+export { type DurableStream, InMemoryStream } from "./stream.js";
+export { ReplayIndex, type YieldEntry } from "./replay-index.js";

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./execute": {
+      "types": "./dist/execute.d.ts",
+      "import": "./dist/execute.js"
     }
   },
   "publishConfig": {

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -29,7 +29,7 @@ import {
 } from "./errors.js";
 import { assertValidIr } from "@tisyn/validate";
 import { evaluate, type Env, envFromRecord, extendMulti } from "@tisyn/kernel";
-import { type DurableStream, InMemoryStream, ReplayIndex } from "@tisyn/durable-streams";
+import { type DurableStream, InMemoryStream, ReplayIndex } from "@tisyn/durable-streams/browser";
 import {
   dispatch,
   Effects,

--- a/packages/transport/src/transports/browser-executor.ts
+++ b/packages/transport/src/transports/browser-executor.ts
@@ -20,8 +20,8 @@
 
 import type { Operation } from "effection";
 import { run } from "effection";
-import { execute } from "@tisyn/runtime";
-import { InMemoryStream } from "@tisyn/durable-streams";
+import { execute } from "@tisyn/runtime/execute";
+import { InMemoryStream } from "@tisyn/durable-streams/browser";
 import { Call } from "@tisyn/ir";
 import type { IrInput, Json } from "@tisyn/ir";
 import type { InProcessRunner, LocalCapability } from "./browser.js";

--- a/packages/transport/vitest.config.ts
+++ b/packages/transport/vitest.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
       { find: /^@tisyn\/agent$/, replacement: resolve(__dirname, "../agent/src/index.ts") },
       { find: /^@tisyn\/protocol$/, replacement: resolve(__dirname, "../protocol/src/index.ts") },
       { find: /^@tisyn\/runtime$/, replacement: resolve(__dirname, "../runtime/src/index.ts") },
-      { find: /^@tisyn\/runtime\/execute$/, replacement: resolve(__dirname, "../runtime/src/execute.ts") },
+      {
+        find: /^@tisyn\/runtime\/execute$/,
+        replacement: resolve(__dirname, "../runtime/src/execute.ts"),
+      },
       { find: /^@tisyn\/validate$/, replacement: resolve(__dirname, "../validate/src/index.ts") },
     ],
   },

--- a/packages/transport/vitest.config.ts
+++ b/packages/transport/vitest.config.ts
@@ -3,14 +3,15 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    alias: {
-      "@tisyn/ir": resolve(__dirname, "../ir/src/index.ts"),
-      "@tisyn/kernel": resolve(__dirname, "../kernel/src/index.ts"),
-      "@tisyn/agent": resolve(__dirname, "../agent/src/index.ts"),
-      "@tisyn/protocol": resolve(__dirname, "../protocol/src/index.ts"),
-      "@tisyn/runtime": resolve(__dirname, "../runtime/src/index.ts"),
-      "@tisyn/validate": resolve(__dirname, "../validate/src/index.ts"),
-    },
+    alias: [
+      { find: /^@tisyn\/ir$/, replacement: resolve(__dirname, "../ir/src/index.ts") },
+      { find: /^@tisyn\/kernel$/, replacement: resolve(__dirname, "../kernel/src/index.ts") },
+      { find: /^@tisyn\/agent$/, replacement: resolve(__dirname, "../agent/src/index.ts") },
+      { find: /^@tisyn\/protocol$/, replacement: resolve(__dirname, "../protocol/src/index.ts") },
+      { find: /^@tisyn\/runtime$/, replacement: resolve(__dirname, "../runtime/src/index.ts") },
+      { find: /^@tisyn\/runtime\/execute$/, replacement: resolve(__dirname, "../runtime/src/execute.ts") },
+      { find: /^@tisyn\/validate$/, replacement: resolve(__dirname, "../validate/src/index.ts") },
+    ],
   },
   test: {
     exclude: ["node_modules/**", "dist/**"],


### PR DESCRIPTION
Closes #106.

## Summary

- Add public `@tisyn/runtime/execute` subpath exporting `execute`, `ExecuteOptions`, `ExecuteResult`. Consumers bundling workflow execution for the browser can import from this subpath to avoid pulling the Node-only `loadModule`/config/`Runtime` host APIs re-exported from the root.
- Add public `@tisyn/durable-streams/browser` subpath exporting `DurableStream`, `InMemoryStream`, `ReplayIndex`, and `YieldEntry`. `FileStream` (`node:fs`/`node:path`) stays on the root.
- Tighten `runtime/src/execute.ts` to import durable-streams from `/browser`, so the root entrypoint's transitive reach never includes `FileStream` either.
- Update the two browser-bundled consumers (`@tisyn/transport/browser-executor`, `examples/multi-agent-chat` in-page executor) to use the new subpaths.

Root entrypoints (`@tisyn/runtime`, `@tisyn/durable-streams`) are unchanged; Node/CLI/runtime-host callers keep working untouched. No `FileStream` removal, no root split.

## Notable detail

Transport's `vitest.config.ts` used object-form aliases with greedy prefix matching, which rewrote `@tisyn/runtime/execute` to `…/runtime/src/index.ts/execute`. Fix: convert to array form with anchored `^…$` regex, plus an explicit alias mapping `@tisyn/runtime/execute` to `runtime/src/execute.ts` so tests exercise source directly.

## Test plan

- [x] `pnpm --filter @tisyn/durable-streams build` / `test` — 16/16
- [x] `pnpm --filter @tisyn/runtime build` / `test` — 307/307
- [x] `pnpm --filter @tisyn/transport build` / `test` — 109/109
- [x] Root `pnpm run test` — all 22 workspaces pass
- [x] Node ESM resolution: `import('@tisyn/runtime/execute')` and `import('@tisyn/durable-streams/browser')` both resolve to the expected dist files with correct public exports.
- [x] Static verification on build outputs:
  - `packages/runtime/dist/execute.js` imports only from `@tisyn/durable-streams/browser`.
  - `packages/durable-streams/dist/browser.js` contains no `node:fs`/`node:path`.
  - Both browser-bundled consumer files import only from `/execute` and `/browser` subpaths.

## Known pre-existing issue (not part of this PR)

`pnpm --dir examples/multi-agent-chat run build:test-executor` fails on an earlier `build:test-workflows` step (deprecated `input` vs `roots` field in `tisyn.config.ts`), unrelated to #106. The browser-bundle acceptance case from the plan was therefore verified via Node's ESM resolver and vitest's Vite-based resolver (transport tests), which both exercise the same subpath resolution path.

## Changesets

- `@tisyn/runtime`: minor (new `./execute` subpath)
- `@tisyn/durable-streams`: minor (new `./browser` subpath)
- `@tisyn/transport`: patch (internal import fix to new subpaths)