### PR TITLE
Specify payload-sensitive replay (spec-only, PR 1 of 2)

### DIFF
--- a/specs/tisyn-kernel-specification.md
+++ b/specs/tisyn-kernel-specification.md
@@ -872,10 +872,83 @@ Two event types. Nothing else.
 {
   "type": "yield",
   "coroutineId": "root.0",
-  "description": { "type": "fraud-detector", "name": "fraudCheck" },
+  "description": {
+    "type": "fraud-detector",
+    "name": "fraudCheck",
+    "input": { "userId": "u-123", "amount": 4200 },
+    "sha": "9f3a…e8b1"
+  },
   "result": { "status": "ok", "value": true }
 }
 ```
+
+`description` carries `input` and `sha` for all payload-sensitive
+effects (see "Effect Description Shape" below). `stream.subscribe`
+is the only effect whose description omits both fields — its
+payload contains a live Effection `Operation` with no stable
+durable identity. The durable event algebra is unchanged:
+`DurableEvent = YieldEvent | CloseEvent`.
+
+**Effect Description Shape.** `YieldEvent.description` has two
+valid shapes.
+
+*Payload-sensitive effects* — all effects except
+`stream.subscribe`:
+
+```
+{
+  type: string,
+  name: string,
+  input: <durable canonicalizable JSON value>,
+  sha: string
+}
+```
+
+Both `input` and `sha` are REQUIRED. A `YieldEvent` for a
+payload-sensitive effect that lacks either field is
+**nonconforming**.
+
+*`stream.subscribe`* — non-canonicalizable runtime-direct:
+
+```
+{ type: "stream", name: "subscribe" }
+```
+
+`input` and `sha` MUST NOT be present.
+
+A TypeScript representation marks both fields optional at the
+type level so the same type fits `stream.subscribe`:
+
+```typescript
+interface EffectDescription {
+  type: string;
+  name: string;
+  input?: Val;
+  sha?: string;
+}
+```
+
+The TS optionality is purely so the type also fits
+`stream.subscribe`. The normative requirement remains: `input`
+and `sha` MUST be present for every payload-sensitive effect.
+
+**`payloadSha`.** Payload identity is computed by:
+
+```
+payloadSha(v) = bytesToHex(sha256(utf8(canonical(v))))
+```
+
+`canonical` is the canonical JSON encoding defined in §11.5.
+The hash function is SHA-256 from `@noble/hashes` (isomorphic
+across Node and browser builds). `payloadSha` is exported from
+`@tisyn/kernel`.
+
+**`input` semantics.** `input` is the durable canonicalizable
+JSON value from which `sha` is computed. The runtime MUST
+canonicalize `input` before hashing. Implementations MAY emit
+`input` with canonical key ordering. **Replay comparison uses
+`sha` only**; `input` is recorded for journal introspection
+and post-hoc auditability.
 
 **Close** — records a task's terminal state:
 
@@ -994,19 +1067,34 @@ buildIndex(events):
 
 ### 10.2 The Matching Algorithm
 
-When the kernel suspends with descriptor `D` for `coroutineId`:
+The kernel specifies the **comparison primitive**: given a
+stored description and a current description, what counts as a
+match. The kernel does NOT specify which description plays the
+`current` role; that ownership lives in
+`tisyn-scoped-effects-specification.md` and varies by dispatch
+path.
 
 ```
-match(coroutineId, D):
+compare(stored, current):
+  if stored.type ≠ current.type: → DIVERGENCE (type/name mismatch)
+  if stored.name ≠ current.name: → DIVERGENCE (type/name mismatch)
+  if effect is payload-sensitive
+        (i.e., stored.type/name is not stream.subscribe):
+    if stored.sha is absent:
+      → DIVERGENCE (nonconforming journal — missing required sha)
+    if stored.sha ≠ current.sha:
+      → DIVERGENCE (payload mismatch)
+  → MATCH
+```
+
+When the kernel suspends, the matching procedure is:
+
+```
+match(coroutineId, current):
   entry = peekYield(coroutineId)
 
   CASE 1: entry exists
-    expectedType = entry.description.type
-    expectedName = entry.description.name
-    actualType = parseEffectId(D.id).type
-    actualName = parseEffectId(D.id).name
-    if actualType ≠ expectedType: → DIVERGENCE
-    if actualName ≠ expectedName: → DIVERGENCE
+    compare(entry.description, current)
     consumeYield(coroutineId)    // cursor++
     return entry.result          // REPLAY path
 
@@ -1017,22 +1105,76 @@ match(coroutineId, D):
     → LIVE path (dispatch to agent)
 ```
 
+The construction of `current` is dispatch-path-specific and is
+specified by `tisyn-scoped-effects-specification.md`:
+
+- **Runtime-direct effects** (`__config`, `stream.subscribe`,
+  `stream.next`): source descriptor, per scoped-effects §9.5.8.
+- **Chain-dispatched delegated effects** (max calls `next`):
+  boundary descriptor, per scoped-effects §9.5.3.
+- **Chain-dispatched short-circuit effects** (max returns
+  without `next`): source descriptor, per scoped-effects
+  §9.5.5.
+
+The kernel does not restate the boundary-vs-source rule; it
+specifies only how two descriptions compare.
+
 ### 10.3 Description Matching
 
-Only two fields are compared: `type` and `name`. All other fields
-are ignored. This allows arguments to change between versions
-without breaking replay.
+Three fields participate in the matching algorithm for
+payload-sensitive effects: `type`, `name`, and `sha`. For
+`stream.subscribe` (non-canonicalizable; see §9.1 "Effect
+Description Shape"), only `type` and `name` participate;
+`sha` is neither expected nor compared.
+
+`sha` is part of durable identity for payload-sensitive
+effects. A stored entry that omits `sha` for a payload-
+sensitive effect is nonconforming and MUST raise
+`DivergenceError` (§10.4); it MUST NOT replay successfully.
 
 ### 10.4 Divergence
 
-A divergence is fatal. The kernel MUST halt and surface:
+A divergence is fatal. The kernel MUST halt and surface
+`DivergenceError`. The error MUST carry enough information to
+diagnose the cause; the following message templates are
+normative for the three cases:
+
+**Type/name mismatch:**
+
+```
+Divergence at {coroutineId}[{cursor}]: expected
+{storedType}.{storedName}, got {currentType}.{currentName}
+```
+
+**Payload mismatch (SHA differs):**
+
+```
+Divergence at {coroutineId}[{cursor}]: payload mismatch for
+{type}.{name}:
+  stored sha: {storedSha}
+  current sha: {currentSha}
+```
+
+**Missing required SHA (nonconforming journal):**
+
+```
+Divergence at {coroutineId}[{cursor}]: stored entry for
+{type}.{name} missing required sha — nonconforming journal
+```
+
+`DivergenceError` is the single error type for all three
+cases. No specialized payload-divergence error class is
+introduced. Implementations SHOULD include both the stored
+and current SHA hex strings in the payload-mismatch message
+to aid diagnosis.
 
 ```
 DivergenceError {
   coroutineId: string,
   position: number,
-  expected: { type, name },
-  actual: { type, name }
+  message: string,            // formatted per templates above
+  expected?: { type, name, sha? },
+  actual?:   { type, name, sha? }
 }
 ```
 

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -42,7 +42,9 @@ underlying scoped-effects semantics that surface builds on.
 
 The specification also defines:
 
-- a dispatch boundary through which all effects flow,
+- a dispatch boundary through which all chain-dispatched
+  effects flow (runtime-direct effects classified by §3.1.1
+  follow a separate runtime-owned path),
 - a cross-boundary middleware protocol using IR `Fn` nodes,
 - scope-local dispatch semantics for IR middleware logic, and
 - durability requirements for cross-boundary middleware as
@@ -250,11 +252,15 @@ const Effects = createApi("tisyn.effects", {
 ````
 
 The dispatch boundary is the semantic primitive of the Effects
-API. All effects — built-in and user-defined — MUST flow
-through it. The built-in typed methods (`sleep`, `fetch`,
-`readFile`, `glob`, `exec`) are convenience surface only; they
-lower to `dispatch` calls with reserved `tisyn.*` effect IDs
-and carry no independent semantics beyond that lowering.
+API. All **chain-dispatched** effects — built-in and
+user-defined — MUST flow through it. Runtime-direct effects
+(§3.1.1) bypass the user-facing Effects chain and are handled
+by the runtime's own standard-effect dispatch path. The
+built-in typed methods (`sleep`, `fetch`, `readFile`, `glob`,
+`exec`) are convenience surface for chain-dispatched
+built-ins; they lower to `dispatch` calls with reserved
+`tisyn.*` effect IDs and carry no independent semantics beyond
+that lowering.
 
 For v1 of scoped effects, only the generic `Effects` boundary
 is required. Implementations do **not** need to provide the
@@ -262,16 +268,21 @@ typed convenience methods (`Effects.sleep`, `Effects.fetch`,
 `Effects.readFile`, `Effects.glob`, `Effects.exec`) yet. Those
 remain deferred to a later tooling-oriented pass. Middleware
 and interception semantics in this specification apply to plain
-effect IDs regardless of whether convenience methods exist.
+chain-dispatched effect IDs regardless of whether convenience
+methods exist.
 
 > **Note:** The exact convenience method surface is provisional
 > and MAY evolve. The normative commitments of this section are:
-> (a) the runtime MUST expose a dispatch boundary, (b) the
-> `tisyn.*` namespace is reserved for built-in effects, and
-> (c) built-in effects MUST be interceptable by middleware the
-> same way as user-defined effects. The specific set of
-> convenience methods and their signatures are not yet the
-> primary normative commitment. See Appendix A for the current
+> (a) the runtime MUST expose a dispatch boundary; (b) the
+> `tisyn.*` namespace is reserved for built-in effects; (c)
+> chain-dispatched built-in effects (e.g., `sleep`, `fetch`,
+> `readFile`, `glob`, `exec`) MUST be interceptable by
+> middleware the same way as user-defined effects, while
+> runtime-direct effects classified by §3.1.1 (`__config`,
+> `stream.subscribe`, `stream.next`) MUST NOT be intercepted by
+> `Effects.around`. The specific set of convenience methods and
+> their signatures are not yet the primary normative
+> commitment. See Appendix A for the current chain-dispatched
 > built-in effect catalog.
 
 ---
@@ -1339,8 +1350,13 @@ involved in this routing decision.
 The runtime MUST:
 
 1. **Provide a dispatch boundary.** Expose a scoped dispatch
-   boundary through which all effects flow. Built-in effects
-   and user-defined effects MUST enter the same boundary.
+   boundary through which all chain-dispatched effects flow.
+   Chain-dispatched built-in effects and user-defined effects
+   MUST enter the same boundary. Runtime-direct effects
+   classified by §3.1.1 (`__config`, `stream.subscribe`,
+   `stream.next`) MUST NOT enter the user-facing Effects
+   chain; the runtime handles them via its own standard-effect
+   dispatch path.
 2. **Process transport binding.** Bind agent identities to
    transport implementations within the current scope. Manage
    transport lifetime — shut down on scope exit.
@@ -1360,12 +1376,17 @@ The runtime MUST:
    Store cross-boundary IR middleware logic alongside other
    execution inputs. Validate consistency on replay (§9).
 7. **Provide the generic effect boundary.** The runtime MUST
-   route plain effect IDs, including reserved `tisyn.*` IDs,
-   through the same scoped `Effects` boundary.
-8. **Handle built-in effects when implemented.** If the runtime
-   implements any provisional built-in `tisyn.*` effects, it
-   MUST route them through the same boundary and journal them
-   per Appendix A.
+   route plain chain-dispatched effect IDs, including reserved
+   `tisyn.*` IDs that are chain-dispatched, through the same
+   scoped `Effects` boundary. Runtime-direct effects (§3.1.1)
+   are routed through the runtime's standard-effect dispatch
+   path instead.
+8. **Handle chain-dispatched built-in effects when implemented.**
+   If the runtime implements any provisional chain-dispatched
+   built-in `tisyn.*` effects, it MUST route them through the
+   same boundary and journal them per Appendix A.
+   Runtime-direct built-ins follow the runtime-direct dispatch
+   path defined in §9.5.8.
 9. **Route user-defined effects.** Route non-`tisyn.*` effect
    IDs to agent-registered handlers via transport bindings.
 
@@ -1468,7 +1489,14 @@ effect IDs under the reserved `tisyn.*` namespace:
 | `tisyn.readFile` | File read |
 | `tisyn.glob` | Directory scan |
 
-All built-in effects are subject to middleware per §3.1.
+The chain-dispatched built-in effects listed above
+(`tisyn.sleep`, `tisyn.fetch`, `tisyn.exec`, `tisyn.readFile`,
+`tisyn.glob`) are subject to middleware per §3.1. The
+runtime-direct effects classified by §3.1.1 (`__config`,
+`stream.subscribe`, `stream.next`) are NOT subject to
+`Effects.around` middleware; they are handled by the runtime's
+standard-effect dispatch path per §9.5.8 and are not part of
+this Appendix A catalog.
 
 ### A.2 Journaling Contracts
 

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -114,10 +114,15 @@ through a per-agent Context API into the scope's `Effects`
 middleware chain.
 
 **Dispatch boundary.** The interception point through which all
-effects flow. Middleware composes around this boundary.
-Workflow-level effect execution enters from the outside. The
-runtime MUST expose this boundary; the exact API surface is
-part of the reference API.
+**chain-dispatched** effects flow (see §3.1, §3.1.1).
+Middleware installed via `Effects.around` composes around this
+boundary. Workflow-level chain-dispatched effect execution
+enters from the outside. The runtime MUST expose this
+boundary; the exact API surface is part of the reference API.
+Runtime-direct effects classified by §3.1.1 (`__config`,
+`stream.subscribe`, `stream.next`) do NOT flow through this
+boundary; the runtime handles them via its own standard-effect
+dispatch path.
 
 **Global dispatch.** The outermost dispatch operation. When
 workflow code performs an effect, it enters the full middleware
@@ -1500,37 +1505,57 @@ this Appendix A catalog.
 
 ### A.2 Journaling Contracts
 
-Each built-in effect SHOULD produce journal entries with the
-following description/result shapes. These shapes are designed
-to support replay, security redaction, and guard integration.
+Each built-in effect produces a `YieldEvent` whose
+`description` follows the uniform envelope defined by
+`tisyn-kernel-specification.md` §9.1: `{ type, name, input,
+sha }`. The `type` and `name` are derived from the effect ID
+via `parseEffectId(...)`; `sha = payloadSha(input)`. This
+appendix specifies the recommended shape of `description.input`
+(the canonicalizable durable payload) and the recommended
+result shape for each effect. Redaction, hashing, and
+sort/normalization expectations apply to `description.input`
+under that envelope; they MUST NOT be expressed by replacing
+the envelope with an alternative top-level description schema.
 
 **`tisyn.sleep`**
-- Description: `{ kind: "tisyn.sleep", duration: number }`
-- Result: `{ completedAt: string }`
-- On replay: return immediately, no wait.
+- `description.type` = `"tisyn"`, `description.name` = `"sleep"`.
+- `description.input`: `{ duration: number }`.
+- Result: `{ completedAt: string }`.
+- On replay: return the stored result immediately, no wait.
 
 **`tisyn.fetch`**
-- Description: `{ kind: "tisyn.fetch", url, method, safeHeaders, bodyHash }`
-- Result: `{ status, filteredHeaders, body, bodyHash }`
+- `description.type` = `"tisyn"`, `description.name` = `"fetch"`.
+- `description.input`: `{ url, method, safeHeaders, bodyHash }`.
+- Result: `{ status, filteredHeaders, body, bodyHash }`.
 - Security: sensitive request headers SHOULD be redacted from
-  the description. Request body SHOULD be hashed, not stored.
+  `description.input.safeHeaders`. The request body SHOULD be
+  hashed into `description.input.bodyHash` and SHOULD NOT be
+  stored in `description.input` in raw form.
 
 **`tisyn.exec`**
-- Description: `{ kind: "tisyn.exec", command, cwd, envKeys, timeout }`
-- Result: `{ exitCode, stdout, stderr }`
+- `description.type` = `"tisyn"`, `description.name` = `"exec"`.
+- `description.input`: `{ command, cwd, envKeys, timeout }`.
+- Result: `{ exitCode, stdout, stderr }`.
 - Security: environment variable values SHOULD NOT appear in
-  the description. Only key names are recorded.
+  `description.input`. Only key names (`envKeys`) are recorded.
 
 **`tisyn.readFile`**
-- Description: `{ kind: "tisyn.readFile", path, encoding }`
-- Result: `{ content, contentHash }`
+- `description.type` = `"tisyn"`, `description.name` = `"readFile"`.
+- `description.input`: `{ path, encoding }`.
+- Result: `{ content, contentHash }`.
 - The `contentHash` field enables replay guard integration.
 
 **`tisyn.glob`**
-- Description: `{ kind: "tisyn.glob", baseDir, include, exclude }`
-- Result: `{ matches: [{path, contentHash}], scanHash }`
+- `description.type` = `"tisyn"`, `description.name` = `"glob"`.
+- `description.input`: `{ baseDir, include, exclude }`.
+- Result: `{ matches: [{path, contentHash}], scanHash }`.
 - Matches SHOULD be sorted by path. Duplicates SHOULD be
   removed.
+
+`description.sha` is `payloadSha(description.input)` for every
+entry above (kernel §9.1). Implementations MAY emit
+`description.input` with canonical key ordering; `sha` is
+deterministic either way.
 
 ### A.3 Design Rationale
 

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -153,28 +153,73 @@ effects flow — both built-in and user-defined. Middleware
 composes around this boundary. The dispatch boundary is the
 single interception point for all effect traffic within a scope.
 
-All effects MUST enter the dispatch boundary uniformly. There
-MUST NOT be a separate path for built-in effects that bypasses
-middleware. Middleware installed via the middleware installation
-primitive MUST intercept built-in effect calls the same way it
-intercepts user-defined effect calls.
+All effects MUST enter the dispatch boundary uniformly, **except
+effects classified as runtime-direct by this or a companion
+specification** (see §3.1.1). Runtime-direct effects are handled
+by the runtime's standard-effect dispatch path before entering
+the Effects middleware chain. Middleware installed via the
+middleware installation primitive (`Effects.around`) MUST
+intercept all chain-dispatched effects — both built-in and
+user-defined — uniformly. Middleware installed via
+`Effects.around` MUST NOT intercept runtime-direct effects; the
+runtime MUST route runtime-direct effects through its own
+dispatch path, not through the user-facing Effects chain.
 
-> **Non-normative.** Two valid paths reach the dispatch boundary
-> defined above:
+> **Non-normative.** Three dispatch paths reach effect
+> resolution under this specification:
 >
-> 1. **Compiled path.** Authored `yield* handle.method(args)` is
->    lowered by the compiler to `Eval("agent.method", ...)`. The
->    kernel suspends. The runtime routes the resulting effect
->    descriptor through the Effects middleware chain.
+> 1. **Compiled chain-dispatched path.** Authored
+>    `yield* handle.method(args)` is lowered by the compiler to
+>    `Eval("agent.method", ...)`. The kernel suspends. The
+>    runtime routes the resulting effect descriptor through the
+>    Effects middleware chain. `Effects.around` applies.
 >
-> 2. **Runtime facade path.** `useAgent()` returns a facade
->    (§6.2). Facade direct methods delegate through a backing
->    per-agent Context API. The call enters the same Effects
->    dispatch boundary without compiler-generated IR for the
->    call site.
+> 2. **Runtime facade chain-dispatched path.** `useAgent()`
+>    returns a facade (§6.2). Facade direct methods delegate
+>    through a backing per-agent Context API. The call enters
+>    the same Effects dispatch boundary as path 1, without
+>    compiler-generated IR for the call site. `Effects.around`
+>    applies.
 >
+> 3. **Runtime-direct path.** Effects classified as
+>    runtime-direct by §3.1.1 (currently `__config`,
+>    `stream.subscribe`, `stream.next`) are handled by the
+>    runtime's standard-effect dispatch path before reaching
+>    the user-facing Effects chain. `Effects.around` does NOT
+>    apply. Replay identity uses the source descriptor.
+>
+> Paths 1 and 2 share the chain-dispatched dispatch model:
 > `Effects.around()` middleware applies at the shared dispatch
-> boundary regardless of which path an effect takes to reach it.
+> boundary regardless of which compiled or facade path an
+> effect takes to reach it. Path 3 is the runtime-direct
+> exception.
+
+#### 3.1.1 Runtime-Direct Effects
+
+Runtime-direct effects are runtime-owned effects whose
+semantics depend on runtime-local state or capability
+reconstruction that cannot be meaningfully intercepted,
+transformed, or replaced by user middleware. Runtime-direct
+effects execute outside the user middleware dispatch chain.
+They still produce `YieldEvent` entries and participate in
+replay matching, but they are not interceptable by
+`Effects.around`.
+
+The following classification applies:
+
+| Effect | Classification | Rationale |
+|---|---|---|
+| `__config` | Runtime-direct | Reads execution-scoped configuration from runtime context. Not a user or agent effect. |
+| `stream.subscribe` | Runtime-direct, non-canonicalizable | Creates a runtime-owned live subscription capability. Payload includes a live Effection `Operation`. |
+| `stream.next` | Runtime-direct | Consumes a runtime-owned subscription capability via an opaque handle token. |
+| `sleep` | Chain-dispatched | Handled by the Effects chain's core handler. Interceptable by `Effects.around`. |
+| Agent effects | Chain-dispatched | Enter the Effects chain. Max middleware can intercept and transform. |
+
+**Extensibility.** Future effects that depend on runtime-local
+state or capability reconstruction MAY be classified as
+runtime-direct by companion specifications. The default
+classification for any new effect is chain-dispatched unless
+explicitly stated otherwise.
 
 > The runtime MAY expose `invokeInline(fn, args, opts?)` from `Effects.around({ dispatch })` middleware. Effects journal under a distinct inline lane coroutineId (journal identity); capability ownership and counter allocation use the original caller's coroutineId (owner identity). Owner coroutineId is runtime context, not durable data. The lane does not produce a `CloseEvent`. Child-bearing primitives retain own semantics. Participates in §9.5 replay. Nested inline permitted. Semantics: `tisyn-inline-invocation-specification.md`.
 
@@ -859,6 +904,34 @@ primitive. Guard implementations are host-provided.
 
 ### 9.5 Replay Substitution at the Dispatch Boundary
 
+> **Status note.** Payload-sensitive cursor matching is now
+> specified by this section. `YieldEvent.description` carries
+> `input` and `sha` for all payload-sensitive effects;
+> `stream.subscribe` is the only carve-out. See §9.5.3, §9.5.5,
+> §9.5.8, §9.5.9, and `tisyn-kernel-specification.md` §9.5,
+> §10.2–§10.4.
+
+**Definitions used in this section:**
+
+- **Chain-dispatched effect.** An effect that enters the
+  Effects middleware chain. Max middleware can intercept and
+  transform. The replay boundary performs boundary-identity
+  comparison and substitution.
+- **Runtime-direct effect.** An effect handled inline by the
+  runtime before entering the Effects chain (see §3.1.1). Not
+  interceptable by `Effects.around`. The source descriptor is
+  the durable identity (no middleware transformation is
+  possible).
+- **Source descriptor.** `{ type, name }` from
+  `parseEffectId(descriptor.id)`, paired with `descriptor.data`
+  — the kernel-yielded identity at the moment of suspension.
+- **Boundary descriptor.** `{ type, name }` and data taken
+  from the post-max `[effectId, data]` reaching the replay
+  substitution boundary — the request as max middleware
+  forwards it.
+- **Payload-sensitive effect.** Any effect whose payload is
+  canonicalizable. All effects except `stream.subscribe`.
+
 #### 9.5.1 The Structural Replay Boundary
 
 The runtime MUST install a replay-substitution boundary between
@@ -907,17 +980,34 @@ The result is journaled.
 #### 9.5.3 Replay Substitution Semantics
 
 The runtime's replay boundary MUST implement the following
-behavior for every standard-effect dispatch:
+behavior for every chain-dispatched standard-effect dispatch.
+Replay-identity comparison is **authoritative at the post-max
+boundary** — comparison uses the boundary descriptor, not the
+kernel-yielded source descriptor.
 
-1. **Check the replay cursor.** Using the dispatch's effect
-   description (type + name), check whether a stored
+1. **Construct the boundary description.** From the post-max
+   `[effectId, data]` reaching the replay boundary, derive
+   `{ type, name }` via `parseEffectId(effectId)` and form the
+   boundary description `{ type, name, input: data, sha:
+   payloadSha(data) }`. (`payloadSha` is defined in
+   `tisyn-kernel-specification.md` §9.5.)
+
+2. **Check the replay cursor.** Look up whether a stored
    `YieldEvent` entry exists in the journal for this dispatch
    point.
 
-2. **If a stored entry exists (replay path):**
-   - MUST return the stored result as the dispatch result.
+3. **If a stored entry exists (replay path):**
+   - MUST compare boundary `type` and `name` against the stored
+     entry's `description.type` and `description.name`. Mismatch
+     MUST raise `DivergenceError`.
+   - If the stored `description.sha` is absent, MUST raise
+     `DivergenceError` (nonconforming journal). `sha` is a
+     required field on stored entries for payload-sensitive
+     effects; chain-dispatched effects are payload-sensitive.
+   - MUST compare the boundary `sha` against the stored
+     `description.sha`. Mismatch MUST raise `DivergenceError`.
    - MUST consume the replay cursor entry.
-   - MUST push a replayed `YieldEvent` to the in-memory
+   - MUST push the stored `YieldEvent` to the in-memory
      execution journal returned by `execute`.
    - MUST NOT append a duplicate replayed `YieldEvent` to the
      backing durable stream. The durable stream is an
@@ -927,11 +1017,27 @@ behavior for every standard-effect dispatch:
    - MUST NOT delegate into the min region or core handler.
      Min-priority middleware and the core handler MUST NOT
      execute.
+   - MUST return the stored result as the dispatch result.
 
-3. **If no stored entry exists (live path):**
+4. **If no stored entry exists (live path):**
    - MUST delegate into the min region and core handler.
    - The result of delegation is the dispatch result.
-   - The runtime journals the result as a live `YieldEvent`.
+   - The runtime MUST journal the result as a live
+     `YieldEvent` whose `description` is the **boundary
+     description** (not the kernel-yielded source description).
+
+> **Rationale (non-normative).** Replay-identity comparison
+> happens at the post-max boundary because max-priority
+> middleware MAY transform `effectId` and/or `data` before
+> dispatching to the next layer (e.g., a max middleware that
+> rewrites `a.fetch({id: "A"})` into `http.get({url:
+> "/orders/A"})`). The durable identity of a chain-dispatched
+> effect MUST be the request that reaches the replay
+> substitution boundary; otherwise a transform whose output
+> changes between runs would replay the stale stored result
+> against a now-divergent live request. Comparing the
+> kernel-yielded source descriptor would mask exactly this
+> failure mode.
 
 #### 9.5.4 Max-Priority Middleware Re-Executes on Replay
 
@@ -957,20 +1063,43 @@ This is required because:
 
 If a max-priority frame returns a value without calling `next`
 (short-circuit), the chain terminates in the max region. The
-replay boundary is not reached.
+replay boundary is not reached, so no boundary descriptor is
+constructed.
 
-On replay, the runtime MUST check: if a stored cursor entry
-exists for this dispatch, the stored result MUST be used as
-the authoritative dispatch result. The short-circuiting
-frame's return value is discarded.
+Short-circuit identity uses the **source descriptor** — the
+kernel-yielded `{ type, name }` from
+`parseEffectId(descriptor.id)` and `descriptor.data` — because
+the request never reaches the post-max boundary.
+
+On replay, the runtime MUST check whether a stored cursor
+entry exists for this dispatch. If one does:
+
+1. MUST compare source `type` and `name` against the stored
+   entry's `description.type` and `description.name`. Mismatch
+   MUST raise `DivergenceError`.
+2. If the stored `description.sha` is absent, MUST raise
+   `DivergenceError` (nonconforming journal).
+3. MUST compare `payloadSha(descriptor.data)` against the
+   stored `description.sha`. Mismatch MUST raise
+   `DivergenceError`.
+4. MUST consume the cursor, push the stored `YieldEvent` to
+   the in-memory journal (subject to the same
+   no-duplicate-durable-append rule as §9.5.3), and return the
+   stored result. The short-circuiting frame's return value is
+   discarded.
 
 On live dispatch, the short-circuiting frame's return value is
-the dispatch result, journaled normally.
+the dispatch result. The runtime MUST journal a live
+`YieldEvent` whose `description` is the source description
+`{ type, name, input: descriptor.data, sha:
+payloadSha(descriptor.data) }`.
 
 This is the same cursor-authoritative rule as §9.5.3, applied
 to the other chain termination mode. One semantic rule — **the
 stored cursor is authoritative for dispatch results on
-replay** — two application sites.
+replay** — two application sites with two different identity
+conventions: boundary identity for delegated dispatch, source
+identity for short-circuit dispatch.
 
 #### 9.5.6 No Explicit Delegation Helper
 
@@ -990,12 +1119,12 @@ middleware-body authors:
 - No runtime-provided context is required to be read or
   invoked by middleware bodies.
 
-Helper-based terminal-delegation patterns — such as the
-`runAsTerminal` / `RuntimeTerminal` / `RuntimeTerminalBoundary`
-shape explored during earlier design work — are explicitly a
-non-goal. They MUST NOT be introduced as normative surface of
-`@tisyn/effects`, `@tisyn/effects/internal`, or
-`@tisyn/runtime`.
+Helper-based terminal-delegation patterns — any wrapper that
+asks middleware authors to restate effect parameters at a
+runtime-provided boundary in order to be replay-safe — are
+explicitly a non-goal. They MUST NOT be introduced as
+normative surface of `@tisyn/effects`,
+`@tisyn/effects/internal`, or `@tisyn/runtime`.
 
 #### 9.5.7 Resource-Body Dispatch
 
@@ -1007,16 +1136,101 @@ applies identically to resource-body dispatches.
 Implementations MUST NOT route resource-body dispatches
 through a separate path that bypasses the replay boundary.
 
+#### 9.5.8 Runtime-Direct Replay Comparison
+
+Runtime-direct effects (§3.1.1) are handled by the runtime's
+standard-effect dispatch path before reaching the user-facing
+Effects chain. Replay-identity comparison for runtime-direct
+effects uses the **source descriptor** because no max
+middleware can transform the request — there is no boundary
+distinct from the source.
+
+**Payload-sensitive runtime-direct effects (`__config`,
+`stream.next`).** Before dispatching, the runtime MUST:
+
+1. Compare source `type` and `name` against the stored
+   `description.type` and `description.name`. Mismatch MUST
+   raise `DivergenceError`.
+2. If the stored `description.sha` is absent, MUST raise
+   `DivergenceError` (nonconforming journal).
+3. Compare `payloadSha(descriptor.data)` against stored
+   `description.sha`. Mismatch MUST raise `DivergenceError`.
+
+On the live path, the runtime MUST journal a `YieldEvent` whose
+`description` is `{ type, name, input: descriptor.data, sha:
+payloadSha(descriptor.data) }`.
+
+**`stream.next` input rule.** `stream.next` is payload-sensitive
+because its runtime input is the serializable subscription
+handle-token payload, not the live Effection subscription, the
+stream source, or the source `Operation`. A conforming
+`stream.next` `YieldEvent.description.input` MUST contain only
+the canonicalizable handle-token payload passed to
+`stream.next`. It MUST NOT contain the live subscription
+object, the stream source, or any Effection `Operation`.
+
+**Non-canonicalizable runtime-direct (`stream.subscribe`).**
+`stream.subscribe`'s payload includes a live Effection
+`Operation` whose canonical encoding would be a degenerate
+constant. The runtime MUST omit `input` and `sha` from
+`stream.subscribe` `YieldEvent.description` entries; the
+description shape is `{ type: "stream", name: "subscribe" }`
+exactly. Replay comparison for `stream.subscribe` MUST compare
+only `type` and `name`. A missing `sha` on a stored
+`stream.subscribe` entry is expected and correct, not a
+nonconforming-journal error.
+
+#### 9.5.9 Transition Detection
+
+When a workflow's dispatch shape changes between runs in a way
+that crosses dispatch paths, replay MUST raise `DivergenceError`:
+
+- **Delegation → short-circuit.** A stored entry recorded
+  under boundary identity (chain-dispatched delegated) replays
+  against a current execution where max short-circuits.
+  Comparison is between stored boundary `{ type, name }` and
+  current source `{ type, name }`. Mismatch MUST raise
+  `DivergenceError`.
+- **Short-circuit → delegation.** A stored entry recorded
+  under source identity (short-circuit) replays against a
+  current execution where max delegates. Comparison is between
+  stored source `{ type, name }` and current boundary
+  `{ type, name }`. Mismatch MUST raise `DivergenceError`.
+
+These cases are detected by the same `type`/`name` mismatch
+checks specified in §9.5.3 and §9.5.5; they are called out
+separately because the failure mode (transformed identity
+moving between two stable shapes) is a frequent regression in
+practice.
+
+#### 9.5.10 Pre-1.0 Breaking Change
+
+This specification is a pre-1.0 breaking change to durable
+identity:
+
+- **Old behavior.** `YieldEvent.description` could omit
+  payload identity; replay matched on `type + name` only;
+  legacy entries without `sha` replayed successfully.
+- **New behavior.** `input` and `sha` are REQUIRED on
+  `YieldEvent.description` for all payload-sensitive effects.
+  A stored entry missing `sha` for a payload-sensitive effect
+  MUST raise `DivergenceError` (nonconforming journal).
+- **Only exception.** `stream.subscribe`, which MUST omit
+  `input` and `sha` because its payload contains a live
+  Effection `Operation` with no stable durable identity.
+
+No legacy-compatibility path replays missing-`sha` payload-
+sensitive entries. Implementations MUST NOT silently accept
+stored entries that violate the new shape.
+
 ---
 
 > **Note (future extensions and interactions).** This
 > specification defines replay substitution against the current
-> `YieldEvent | CloseEvent` durable algebra and
-> effect-description (type + name) cursor matching.
-> Payload-sensitive cursor matching is expected to compose with
-> this model without changing §9.5.1–§9.5.7, if and when a
-> payload-fingerprint specification is adopted. Inline
-> invocation is specified by
+> `YieldEvent | CloseEvent` durable algebra. Payload-sensitive
+> cursor matching is specified in §9.5.3, §9.5.5, §9.5.8, and
+> §9.5.9; §9.5.1, §9.5.2, §9.5.4, §9.5.6, and §9.5.7 are
+> unchanged. Inline invocation is specified by
 > `tisyn-inline-invocation-specification.md`; effects dispatched
 > during inline-body evaluation participate in §9.5 replay per
 > that specification's §9 (Replay Model).

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -156,21 +156,25 @@ the core execution spec for the complete set.
 ### 3.1 Requirements
 
 The runtime MUST expose a dispatch boundary through which all
-effects flow — both built-in and user-defined. Middleware
-composes around this boundary. The dispatch boundary is the
-single interception point for all effect traffic within a scope.
+**chain-dispatched** effects flow — both built-in and
+user-defined. Middleware installed via the middleware
+installation primitive (`Effects.around`) composes around this
+boundary. The dispatch boundary is the single interception
+point for chain-dispatched effect traffic within a scope.
+Runtime-direct effects classified by §3.1.1 (`__config`,
+`stream.subscribe`, `stream.next`) follow a separate
+runtime-owned dispatch path outside the user-facing Effects
+chain and do NOT pass through this boundary.
 
-All effects MUST enter the dispatch boundary uniformly, **except
-effects classified as runtime-direct by this or a companion
-specification** (see §3.1.1). Runtime-direct effects are handled
-by the runtime's standard-effect dispatch path before entering
-the Effects middleware chain. Middleware installed via the
-middleware installation primitive (`Effects.around`) MUST
-intercept all chain-dispatched effects — both built-in and
-user-defined — uniformly. Middleware installed via
-`Effects.around` MUST NOT intercept runtime-direct effects; the
-runtime MUST route runtime-direct effects through its own
-dispatch path, not through the user-facing Effects chain.
+All chain-dispatched effects MUST enter the dispatch boundary
+uniformly. The runtime MUST NOT introduce a separate path for
+chain-dispatched built-in effects that bypasses middleware.
+`Effects.around` MUST intercept all chain-dispatched effects —
+built-in and user-defined — uniformly. Runtime-direct effects
+are the only documented exception: `Effects.around` MUST NOT
+intercept them, and the runtime MUST route them through its own
+standard-effect dispatch path rather than through the
+user-facing Effects chain.
 
 > **Non-normative.** Three dispatch paths reach effect
 > resolution under this specification:

--- a/specs/tisyn-scoped-effects-test-plan.md
+++ b/specs/tisyn-scoped-effects-test-plan.md
@@ -544,9 +544,9 @@ and does NOT subsume this matrix.
 |---|---|---|---|---|---|
 | RD-PD-DC-001 | Core | Workflow-visible | `sleep` is intercepted by max middleware | Max `Effects.around` intercepts `sleep` effectId, returns `42`. Execute `sleep(100)`. | Result is `42`. `sleep` entered the Effects chain. |
 | RD-PD-DC-002 | Core | Journal-visible | `sleep` uses boundary identity when max transforms | Max transforms `sleep` data `[100]` → `[0]` before `next`. | Journal: `input=[0]`, `sha=payloadSha([0])`. Boundary identity, not source. |
-| RD-PD-DC-003 | Core | Diagnostic | `__config` is NOT intercepted by `Effects.around` | Install max `Effects.around` dispatch middleware that logs all effectIds it sees. Execute an IR that reads config. | `"__config"` does NOT appear in the middleware log. Config read succeeds. |
-| RD-PD-DC-004 | Core | Diagnostic | `stream.next` is NOT intercepted by `Effects.around` | Install max `Effects.around` dispatch middleware that logs. Execute IR with `stream.subscribe` + `stream.next`. | `"stream.next"` and `"stream.subscribe"` do NOT appear in middleware log. Stream operations succeed. |
-| RD-PD-DC-005 | Core | Journal-visible + Diagnostic | `stream.subscribe` is NOT intercepted and writes no `input`/`sha` | Same setup as DC-004. Inspect journal for subscribe event. | Subscribe YieldEvent: no `input`, no `sha`. Not in middleware log. |
+| RD-PD-DC-003 | Core | Workflow-visible | `__config` is NOT intercepted by `Effects.around` | Install max `Effects.around` dispatch middleware that appends each observed effectId to a workflow-visible log array. Execute an IR that reads config. | `"__config"` does NOT appear in the log. Config read succeeds. (Log is workflow-visible because the middleware is user-installed and its accumulator is observable from authored code.) |
+| RD-PD-DC-004 | Core | Workflow-visible | `stream.next` is NOT intercepted by `Effects.around` | Install max `Effects.around` dispatch middleware that appends each observed effectId to a workflow-visible log array. Execute IR with `stream.subscribe` + `stream.next`. | `"stream.next"` and `"stream.subscribe"` do NOT appear in the log. Stream operations succeed. |
+| RD-PD-DC-005 | Core | Workflow-visible + Journal-visible | `stream.subscribe` is NOT intercepted and writes no `input`/`sha` | Same setup as DC-004. Inspect the user-installed middleware log AND the journal for the subscribe event. | Subscribe YieldEvent: no `input`, no `sha`. `"stream.subscribe"` does not appear in the user-installed middleware log. |
 | RD-PD-DC-006 | Core | Journal-visible | Chain-dispatched and runtime-direct built-ins have different replay identity rules | Two effects: `sleep(100)` (chain-dispatched) and `stream.next(handle)` (runtime-direct). Max middleware transforms `sleep` data. | `sleep` YieldEvent has boundary identity (transformed data). `stream.next` YieldEvent has source identity (kernel-yielded data). |
 
 #### 13.12.4 Runtime-Direct Payload-Sensitive Effects
@@ -640,8 +640,8 @@ and does NOT subsume this matrix.
 
 | ID | Tier | Obs. class | Description | Setup | Expected |
 |---|---|---|---|---|---|
-| RD-PD-096 | Core | Diagnostic | Updated conformance fixtures pass | Run all conformance replay fixtures (with `input`/`sha`). | All pass. |
-| RD-PD-097 | Core | Diagnostic | Fixture omitting `sha` for payload-sensitive effect fails | Stale fixture without `sha` for `a.op`. | Fails. |
+| RD-PD-096 | Core | Journal-visible | Updated conformance fixtures pass | Run all conformance replay fixtures (with `input`/`sha`); the harness compares actual `YieldEvent` journals against the fixture's expected journal. | All fixtures pass: actual journals match expected journals. |
+| RD-PD-097 | Core | Journal-visible | Fixture omitting `sha` for payload-sensitive effect fails | Stale fixture without `sha` for `a.op`; harness compares actual journal against expected journal. | Harness reports a journal mismatch and the fixture fails. |
 
 #### 13.12.15 Regression Protection
 

--- a/specs/tisyn-scoped-effects-test-plan.md
+++ b/specs/tisyn-scoped-effects-test-plan.md
@@ -471,18 +471,14 @@ implementation helper names.
 | RD-TR-002 | Core | Journal-visible | Transport reinstallation on replay (scope setup rerun) | Scope setup calls `installAgentTransport`. Run live; replay | Transport is reinstalled during scope-setup rerun; dispatches substitute at replay boundary |
 | RD-TR-003 | Extended | Journal-visible | Multiple transport bindings in the same scope | Two agents bound to different transports. Dispatch to each. Run live; replay | Both substitute correctly; neither refires |
 
-### 13.10 Exclusion Regression — Prototype Helper Shape (§9.5.6)
+### 13.10 Structural-Replay Regression (§9.5.6)
 
-Tests in this section verify that the excluded prototype
-symbols are not exported by the implementation, and that
-replay works without any such helper. Phrased as exclusion
-regression, not removal regression.
+Tests in this section verify that replay works without any
+helper-based delegation wrapper, in line with §9.5.6's
+structural-property requirement.
 
 | ID | Tier | Obs. class | Description | Setup | Expected |
 |---|---|---|---|---|---|
-| RD-RG-001 | Extended | API-surface-visible | `runAsTerminal` is not exported from `@tisyn/effects` | Attempt to import `runAsTerminal` from `@tisyn/effects` | Import fails; symbol does not exist |
-| RD-RG-002 | Extended | API-surface-visible | `RuntimeTerminal` is not exported from `@tisyn/effects/internal` | Attempt to import `RuntimeTerminal` from `@tisyn/effects/internal` | Import fails; symbol does not exist |
-| RD-RG-003 | Extended | API-surface-visible | `RuntimeTerminalBoundary` is not exported from `@tisyn/effects/internal` | Attempt to import `RuntimeTerminalBoundary` from `@tisyn/effects/internal` | Import fails; symbol does not exist |
 | RD-RG-004 | Core | Journal-visible | Replay correctness without any helper | Agent handler at min, no terminal-delegation wrapping anywhere. Run live; replay | Identical journals; no refire; replay substitution is structural |
 | RD-RG-005 | Diagnostic | Harness-introspective | No `effectId`/`data` restatement at any framework handler site | Inspect `Agents.use`, `implementAgent(...).install`, `installAgentTransport`, `installRemoteAgent` handler bodies at the source level | No restated parameters to a boundary helper. **Non-normative; implementation-quality check only** |
 
@@ -496,16 +492,195 @@ regression, not removal regression.
 | RD-EX-005 | Core | Journal-visible | Full existing nested-invocation test plan passes | Identical journals |
 | RD-EX-006 | Core | Journal-visible | Full existing payload-sensitive divergence tests pass | Identical journals |
 
-> **Note.** Test IDs `RD-PD-*` are reserved for a future
-> payload-fingerprint specification and are intentionally not
-> defined in this test plan (payload-sensitive divergence
-> regression is already covered by `RD-EX-006`). Test IDs
-> `RD-IL-*`, `RD-MX-003`, and `RD-EX-004` are deliberately not
-> defined here either; inline-invocation coverage lives in
-> `tisyn-inline-invocation-test-plan.md`, which is the
-> authoritative test plan for `invokeInline` semantics.
+> **Note.** Test IDs `RD-IL-*`, `RD-MX-003`, and `RD-EX-004`
+> are deliberately not defined here; inline-invocation coverage
+> lives in `tisyn-inline-invocation-test-plan.md`, which is the
+> authoritative test plan for `invokeInline` semantics. The
+> `RD-PD-*` matrix (payload-sensitive divergence) is now
+> defined in §13.12 below, covering boundary-identity, source-
+> identity, and runtime-direct dispatch paths against the
+> payload-sensitive replay rules in scoped-effects §9.5.3,
+> §9.5.5, §9.5.8, §9.5.9.
 
-### 13.12 Minimum Acceptance Subset
+### 13.12 Payload-Sensitive Divergence (RD-PD-*)
+
+These tests cover payload-sensitive replay against scoped-
+effects §9.5.3 (boundary identity for delegated chain
+dispatch), §9.5.5 (source identity for short-circuit), §9.5.8
+(runtime-direct), §9.5.9 (transition detection), §3.1.1
+(runtime-direct classification), and kernel §9.1, §10.2,
+§10.3, §10.4. They are normative additions for payload-
+sensitive replay; `RD-EX-006` is a baseline-regression entry
+and does NOT subsume this matrix.
+
+> **Editorial.** This matrix uses the `Setup → Expected`
+> column shape from earlier §13 subsections. The Obs. class
+> column is included in the same convention as the rest of
+> §13 (Workflow-visible / Journal-visible / Diagnostic /
+> API-surface-visible).
+
+#### 13.12.1 Delegated Dispatch — Boundary Identity Write Path
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-001 | Core | Journal-visible | Live delegated dispatch writes boundary `input` and `sha` | `a.op` data `[1,2]`. Max passes through. Min returns `42`. | `description`: `type="a"`, `name="op"`, `input=[1,2]`, `sha=payloadSha([1,2])` |
+| RD-PD-002 | Core | Journal-visible | Max transforms payload; journal records boundary input | Max intercepts `a.op` data `[1]`, calls `next("a.op", [999])`. | `input=[999]`, `sha=payloadSha([999])`. NOT `[1]`. |
+| RD-PD-003 | Core | Journal-visible | Max transforms effectId; journal records boundary type/name | Max intercepts `a.original`, calls `next("b.transformed", data)`. | `type="b"`, `name="transformed"`. NOT `type="a"`. |
+| RD-PD-004 | Core | Journal-visible | Max transforms both effectId and data | Max intercepts `a.fetch({id:"A"})`, calls `next("http.get", {url:"/orders/A"})`. | `type="http"`, `name="get"`, `input={url:"/orders/A"}` |
+| RD-PD-005 | Core | Journal-visible | Exactly one YieldEvent on live delegated dispatch | `a.op` with max pass-through. | Exactly one yield. No duplicate. |
+| RD-PD-006 | Core | Journal-visible | SHA is deterministic across executions | Same effect in two separate executions. | Identical `sha` |
+
+#### 13.12.2 Short-Circuit — Source Identity Write Path
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-010 | Core | Journal-visible | Short-circuit writes source `input` and `sha` | Max returns `"mock"` without `next`. Kernel yields `a.op` data `[1]`. | `type="a"`, `name="op"`, `input=[1]`, `sha=payloadSha([1])`, `result.value="mock"` |
+| RD-PD-011 | Core | Journal-visible | Short-circuit uses kernel-yielded type/name | Kernel yields `a.op`. Max short-circuits. | `type="a"`, `name="op"` |
+| RD-PD-012 | Core | Journal-visible | Exactly one YieldEvent on live short-circuit | Max short-circuits. | Exactly one yield. |
+
+#### 13.12.3 Dispatch Path Classification (§3.1.1)
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-DC-001 | Core | Workflow-visible | `sleep` is intercepted by max middleware | Max `Effects.around` intercepts `sleep` effectId, returns `42`. Execute `sleep(100)`. | Result is `42`. `sleep` entered the Effects chain. |
+| RD-PD-DC-002 | Core | Journal-visible | `sleep` uses boundary identity when max transforms | Max transforms `sleep` data `[100]` → `[0]` before `next`. | Journal: `input=[0]`, `sha=payloadSha([0])`. Boundary identity, not source. |
+| RD-PD-DC-003 | Core | Diagnostic | `__config` is NOT intercepted by `Effects.around` | Install max `Effects.around` dispatch middleware that logs all effectIds it sees. Execute an IR that reads config. | `"__config"` does NOT appear in the middleware log. Config read succeeds. |
+| RD-PD-DC-004 | Core | Diagnostic | `stream.next` is NOT intercepted by `Effects.around` | Install max `Effects.around` dispatch middleware that logs. Execute IR with `stream.subscribe` + `stream.next`. | `"stream.next"` and `"stream.subscribe"` do NOT appear in middleware log. Stream operations succeed. |
+| RD-PD-DC-005 | Core | Journal-visible + Diagnostic | `stream.subscribe` is NOT intercepted and writes no `input`/`sha` | Same setup as DC-004. Inspect journal for subscribe event. | Subscribe YieldEvent: no `input`, no `sha`. Not in middleware log. |
+| RD-PD-DC-006 | Core | Journal-visible | Chain-dispatched and runtime-direct built-ins have different replay identity rules | Two effects: `sleep(100)` (chain-dispatched) and `stream.next(handle)` (runtime-direct). Max middleware transforms `sleep` data. | `sleep` YieldEvent has boundary identity (transformed data). `stream.next` YieldEvent has source identity (kernel-yielded data). |
+
+#### 13.12.4 Runtime-Direct Payload-Sensitive Effects
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-015 | Core | Journal-visible | `stream.subscribe` writes neither `input` nor `sha` | Loop IR, live dispatch. | Subscribe YieldEvent: neither field present. |
+| RD-PD-016 | Core | Journal-visible | `stream.next` writes source `input` and `sha` | Live dispatch. | `sha` present, computed from handle data. |
+| RD-PD-017 | Core | Journal-visible | `__config` writes source `input` and `sha` | Config read. | Both present. |
+| RD-PD-018 | Core | Journal-visible | `sleep` writes boundary `input` and `sha` (chain-dispatched) | `sleep(100)` with no max transform. | `type="sleep"`, `name="sleep"`, `input=[100]`, `sha=payloadSha([100])` |
+| RD-PD-019 | Core | Journal-visible | `sleep` boundary identity when max transforms | Max transforms `sleep` data `[100]` → `[0]`, calls `next`. | `input=[0]`, `sha=payloadSha([0])` |
+
+#### 13.12.5 Replay — Boundary Matching (Happy Path)
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-020 | Core | Journal-visible | Matching boundary SHA substitutes stored result | Stored with boundary `sha`. Max passes through. | Stored result substituted; min does not fire. |
+| RD-PD-021 | Core | Journal-visible | Max transforms; replay compares boundary SHA | Stored boundary SHA from `[999]`. Max transforms `[1]` → `[999]`. | SHA matches. Substituted. |
+| RD-PD-022 | Core | Journal-visible | Max transforms effectId; replay compares boundary type/name | Stored boundary `type="b"`. Max transforms `a.original` → `b.transformed`. | Matches. Substituted. |
+| RD-PD-023 | Core | Journal-visible | Replay consumes exactly one cursor entry | Two sequential effects replayed. | Each consumes one. No journal duplicates. |
+| RD-PD-024 | Core | Journal-visible | Replay does not write to durable stream | Replay from stored journal. | Durable stream `appendCount` unchanged. |
+
+#### 13.12.6 Replay — Boundary Divergence
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-030 | Core | Workflow-visible | Mismatched boundary SHA → DivergenceError | Stored boundary SHA from `[999]`. Max now → `[888]`. | `DivergenceError`: payload mismatch. |
+| RD-PD-031 | Core | Workflow-visible | **Motivating failure**: same source, different boundary → divergence | Kernel yields same `a.fetch`. Max previously → `http.get /orders/A`. Now → `http.get /customers/A`. | `DivergenceError`. |
+| RD-PD-032 | Core | Workflow-visible | Same source, different boundary effectId → divergence | Same kernel `a.op`. Max previously → `b.op`. Now → `c.op`. | `DivergenceError`: expected `b.op`, got `c.op`. |
+| RD-PD-033 | Core | Workflow-visible | Error message includes stored and current SHA | Same as RD-PD-030. | Both hex strings in message. |
+| RD-PD-034 | Core | Workflow-visible | Boundary divergence is fatal | Two effects. Mismatch on first. | Second never reached. |
+| RD-PD-035 | Core | Journal-visible | Object key order does not cause false divergence | Stored SHA from `{a:1,b:2}`. Current boundary `{b:2,a:1}`. | SHA matches (canonical). |
+
+#### 13.12.7 Replay — Short-Circuit Divergence
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-040 | Core | Journal-visible | Short-circuit replay with matching source SHA | Stored source SHA. Max short-circuits. Same data. | Stored result used. |
+| RD-PD-041 | Core | Workflow-visible | Short-circuit with changed source input → divergence | Stored source SHA from `[1]`. Current data `[2]`. | `DivergenceError`. |
+
+#### 13.12.8 Transition Detection (§9.5.9)
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-050 | Core | Workflow-visible | Delegation → short-circuit → divergence | Stored: boundary `http.get`. Max now short-circuits. Source = `a.fetch`. | `DivergenceError`. |
+| RD-PD-051 | Core | Workflow-visible | Short-circuit → delegation → divergence | Stored: source `a.op`. Max now delegates `next("b.op",...)`. | `DivergenceError`. |
+
+#### 13.12.9 Nonconforming Journal — Missing Required SHA
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-055 | Core | Workflow-visible | Stored agent effect missing `sha` → DivergenceError | Stored `a.op` with no `sha`. | `DivergenceError`: nonconforming journal. |
+| RD-PD-056 | Core | Workflow-visible | Stored `stream.next` missing `sha` → DivergenceError | Stored `stream.next` with no `sha`. | `DivergenceError`. |
+| RD-PD-057 | Core | Journal-visible | Stored `stream.subscribe` without `sha` → NOT an error | Stored `stream.subscribe` no `sha`. | Replay succeeds. (Expected: non-canonicalizable.) |
+| RD-PD-058 | Core | Workflow-visible | Stored `sleep` missing `sha` → DivergenceError | Stored `sleep` with no `sha`. | `DivergenceError`. |
+
+#### 13.12.10 `stream.subscribe` / `stream.next`
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-070 | Core | Journal-visible | `stream.subscribe` no `input`/`sha` | Live dispatch. | Neither field present. |
+| RD-PD-071 | Core | Journal-visible | `stream.subscribe` replays with type/name only | Stored subscribe. | Succeeds. |
+| RD-PD-072 | Core | Journal-visible | `stream.next` journal entry includes `input` and `sha` | Live `stream.next` dispatch via loop IR with mock stream. Inspect journal. | `stream.next` YieldEvent has `description.input` and `description.sha` both present. |
+| RD-PD-073 | Core | Journal-visible | `stream.next` `description.input` contains only the serializable handle-token payload | Same as RD-PD-072. Inspect `description.input`. | `input` is the handle-token payload (e.g., `[{ __tisyn_subscription: "sub:root:0" }]`). It does NOT contain a live subscription object, stream source, or Effection `Operation`. |
+| RD-PD-074 | Core | Journal-visible | `stream.next` `description.input` does not contain non-serializable values | Same as RD-PD-072. Verify `canonical(description.input)` produces a meaningful (non-degenerate) canonical form. | `canonical(input)` is NOT `[{}]` or `{}`. It contains the handle token string. |
+| RD-PD-075 | Core | Workflow-visible | `stream.next` replay with changed handle token raises `DivergenceError` | Stored `stream.next` with SHA from handle token `sub:root:0`. Replay produces handle token `sub:root:1`. | `DivergenceError` with payload mismatch. |
+
+#### 13.12.11 Resource-Body Parity
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-080 | Core | Journal-visible | Resource init dispatch writes boundary `input`/`sha` | Resource init dispatches `a.op`. Max passes through. | Boundary `input`/`sha` in YieldEvent. |
+| RD-PD-081 | Core | Journal-visible | Resource init replay checks boundary SHA | Same data. | Replay succeeds. |
+| RD-PD-082 | Core | Workflow-visible | Resource init replay detects SHA mismatch | Different data. | `DivergenceError`. |
+
+#### 13.12.12 Boundary Placement Verification
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-090 | Core | Journal-visible | Lane compares boundary identity; no pre-check false divergence | Max transforms `a.original` → `b.transformed`. Stored boundary `b.transformed`. | Lane matches. No pre-check error. Replay succeeds. |
+| RD-PD-091 | Core | Workflow-visible | **Regression**: kernel-yielded-only hashing fails | Max transforms `[1]` → `[999]`. Stored boundary SHA from `[999]`. Max now → `[888]`. Source `[1]` unchanged. | `DivergenceError`. Kernel-yielded-only hashing would incorrectly pass. |
+| RD-PD-092 | Core | Journal-visible | Pre-check removed for chain-dispatched effects | Stored boundary `type="b"`. Kernel-yielded `type="a"`. Max transforms. | No pre-check error. Lane matches boundary. |
+
+#### 13.12.13 `input` Determinism
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-095 | Core | Journal-visible | `sha` equals `payloadSha(input)` | Live dispatch with data `{b:2,a:1}`. | `sha == payloadSha(description.input)` |
+
+#### 13.12.14 Fixture Conformance
+
+| ID | Tier | Obs. class | Description | Setup | Expected |
+|---|---|---|---|---|---|
+| RD-PD-096 | Core | Diagnostic | Updated conformance fixtures pass | Run all conformance replay fixtures (with `input`/`sha`). | All pass. |
+| RD-PD-097 | Core | Diagnostic | Fixture omitting `sha` for payload-sensitive effect fails | Stale fixture without `sha` for `a.op`. | Fails. |
+
+#### 13.12.15 Regression Protection
+
+| ID | Tier | Obs. class | Description | Expected |
+|---|---|---|---|---|
+| RD-PD-100 | Core | Journal-visible | Existing replay tests pass (updated) | Pass |
+| RD-PD-101 | Core | Journal-visible | Existing replay-dispatch tests pass (updated) | Pass |
+| RD-PD-102 | Core | Journal-visible | Existing stream-iteration replay tests pass (updated) | Pass |
+| RD-PD-103 | Core | Journal-visible | Existing crash-replay e2e tests pass | Pass |
+| RD-PD-104 | Core | Journal-visible | Existing recovery tests pass | Pass |
+| RD-PD-105 | Core | Journal-visible | Existing inline-invocation replay tests pass | Pass |
+
+#### 13.12.16 Payload-Sensitive Minimum Acceptance Subset
+
+Payload-sensitive replay is implementation-ready when all 15
+pass:
+
+| # | ID | What it proves |
+|---|---|---|
+| 1 | RD-PD-001 | Live delegated writes boundary identity |
+| 2 | RD-PD-002 | Max transforms payload → boundary input in journal |
+| 3 | RD-PD-005 | No double journal write |
+| 4 | RD-PD-010 | Short-circuit writes source identity |
+| 5 | RD-PD-015 | `stream.subscribe` omits `input`/`sha` |
+| 6 | RD-PD-018 | `sleep` is chain-dispatched |
+| 7 | RD-PD-020 | Matching boundary SHA replays |
+| 8 | RD-PD-031 | Motivating failure caught |
+| 9 | RD-PD-041 | Short-circuit source divergence |
+| 10 | RD-PD-050 | Delegation→short-circuit transition |
+| 11 | RD-PD-055 | Missing required `sha` → error |
+| 12 | RD-PD-091 | Kernel-yielded-only regression |
+| 13 | RD-PD-097 | Stale fixture fails |
+| 14 | RD-PD-DC-003 | `__config` is runtime-direct (not in middleware log) |
+| 15 | RD-PD-100 | Existing tests updated and green |
+
+This subset is in addition to the §13.13 RD-* subset; both
+gates apply to feature-readiness.
+
+### 13.13 Minimum Acceptance Subset
 
 Feature is implementation-ready when all 12 pass:
 
@@ -524,9 +699,9 @@ Feature is implementation-ready when all 12 pass:
 | 11 | RD-RG-004 | Replay works without any helper |
 | 12 | RD-EX-001 | Existing crash-replay suite stays green |
 
-### 13.13 Coverage Summary for §13
+### 13.14 Coverage Summary for §13
 
-**Spec-section coverage**
+**Spec-section coverage (RD-* baseline)**
 
 | Spec subsection | Test IDs |
 |---|---|
@@ -535,10 +710,23 @@ Feature is implementation-ready when all 12 pass:
 | §9.5.3 Replay substitution semantics | RD-RP-001..006, RD-MN-001..006 |
 | §9.5.4 Max re-executes on replay | RD-MX-001, 002, 004, 005 |
 | §9.5.5 Short-circuit stored-cursor-wins | RD-SC-001..004 |
-| §9.5.6 No delegation helper | RD-RG-001..005 |
+| §9.5.6 No delegation helper | RD-RG-004, RD-RG-005 |
 | §9.5.7 Resource-body interaction | RD-RS-001..003 |
 
-**Tier counts**
+**Spec-section coverage (RD-PD-* payload-sensitive)**
+
+| Spec subsection | Test IDs |
+|---|---|
+| §3.1.1 Runtime-direct classification | RD-PD-DC-001..006 |
+| §9.5.3 Boundary identity (delegated) | RD-PD-001..006, RD-PD-020..024, RD-PD-030..035, RD-PD-090..092 |
+| §9.5.5 Source identity (short-circuit) | RD-PD-010..012, RD-PD-040..041 |
+| §9.5.7 Resource-body payload-sensitive | RD-PD-080..082 |
+| §9.5.8 Runtime-direct payload-sensitive | RD-PD-015..019, RD-PD-070..075 |
+| §9.5.9 Transition detection | RD-PD-050..051 |
+| Kernel §9.1 / §9.5 EffectDescription shape | RD-PD-095, RD-PD-096..097 |
+| Kernel §10.2 / §10.3 / §10.4 matching + divergence | RD-PD-055..058, RD-PD-100..105 |
+
+**Tier counts (RD-* baseline)**
 
 | Category | Core | Extended | Diagnostic | Total |
 |---|---|---|---|---|
@@ -551,9 +739,30 @@ Feature is implementation-ready when all 12 pass:
 | Short-circuit | 3 | 1 | 0 | 4 |
 | Resource interaction | 3 | 0 | 0 | 3 |
 | Transport interaction | 2 | 1 | 0 | 3 |
-| Exclusion regression | 1 | 3 | 1 | 5 |
+| Exclusion regression | 1 | 0 | 1 | 2 |
 | Existing regression | 5 | 0 | 0 | 5 |
-| **Total** | **37** | **11** | **1** | **49** |
+| **Total** | **37** | **8** | **1** | **46** |
+
+**Tier counts (RD-PD-* payload-sensitive)**
+
+| Category | Core | Extended | Diagnostic | Total |
+|---|---|---|---|---|
+| Delegated write path | 6 | 0 | 0 | 6 |
+| Short-circuit write path | 3 | 0 | 0 | 3 |
+| Dispatch path classification | 6 | 0 | 0 | 6 |
+| Runtime-direct payload effects | 5 | 0 | 0 | 5 |
+| Replay matching | 5 | 0 | 0 | 5 |
+| Boundary divergence | 6 | 0 | 0 | 6 |
+| Short-circuit divergence | 2 | 0 | 0 | 2 |
+| Transition detection | 2 | 0 | 0 | 2 |
+| Nonconforming journal | 4 | 0 | 0 | 4 |
+| stream.subscribe / next | 6 | 0 | 0 | 6 |
+| Resource-body parity | 3 | 0 | 0 | 3 |
+| Boundary placement | 3 | 0 | 0 | 3 |
+| Input determinism | 1 | 0 | 0 | 1 |
+| Fixture conformance | 2 | 0 | 0 | 2 |
+| Regression protection | 6 | 0 | 0 | 6 |
+| **Total** | **60** | **0** | **0** | **60** |
 
 ---
 
@@ -644,14 +853,20 @@ correctly implemented when:
 12. All Core tier replay-aware dispatch tests (RD-*) defined
     in §13 pass.
 
-13. The Minimum Acceptance Subset in §13.12 MUST pass before
+13. The Minimum Acceptance Subset in §13.13 MUST pass before
     the replay-aware dispatch implementation (Refs #125) is
     considered complete.
 
-14. No Core tier test produces an unexpected error, hang,
+14. All Core tier payload-sensitive replay tests (RD-PD-*)
+    defined in §13.12 pass. The Payload-Sensitive Minimum
+    Acceptance Subset in §13.12.16 MUST pass before the
+    payload-sensitive replay implementation is considered
+    complete.
+
+15. No Core tier test produces an unexpected error, hang,
     or crash.
 
-15. Generic host Effects middleware does not cross the
+16. Generic host Effects middleware does not cross the
     agent boundary by scope inheritance. Explicit
     cross-boundary middleware crosses via
     `installCrossBoundaryMiddleware(fn)` and the protocol
@@ -681,10 +896,18 @@ correctly implemented when:
 | §9.5.1 Structural replay boundary | Replay-aware dispatch | RD-CO-001–004, RD-PL-001–003 | Covered |
 | §9.5.2 Framework handlers at min | Replay-aware dispatch | RD-FW-001–006 | Covered |
 | §9.5.3 Replay substitution semantics | Replay-aware dispatch | RD-RP-001–006, RD-MN-001–006 | Covered |
+| §9.5.3 Boundary-identity payload-sensitive matching | Payload-sensitive | RD-PD-001..006, RD-PD-020..024, RD-PD-030..035, RD-PD-090..092 | Covered |
 | §9.5.4 Max re-executes on replay | Replay-aware dispatch | RD-MX-001, 002, 004, 005 | Covered |
 | §9.5.5 Short-circuit stored-cursor-wins | Replay-aware dispatch | RD-SC-001–004 | Covered |
-| §9.5.6 No delegation helper | Replay-aware dispatch | RD-RG-001–005 | Covered |
+| §9.5.5 Source-identity payload-sensitive matching | Payload-sensitive | RD-PD-010..012, RD-PD-040..041 | Covered |
+| §9.5.6 No delegation helper | Replay-aware dispatch | RD-RG-004, RD-RG-005 | Covered |
 | §9.5.7 Resource-body interaction | Replay-aware dispatch | RD-RS-001–003 | Covered |
+| §9.5.7 Resource-body payload-sensitive | Payload-sensitive | RD-PD-080..082 | Covered |
+| §9.5.8 Runtime-direct replay comparison | Payload-sensitive | RD-PD-015..019, RD-PD-070..075 | Covered |
+| §9.5.9 Transition detection | Payload-sensitive | RD-PD-050..051 | Covered |
+| §3.1.1 Runtime-direct classification | Payload-sensitive | RD-PD-DC-001..006 | Covered |
+| Kernel §9.1 / §9.5 EffectDescription shape | Payload-sensitive | RD-PD-095..097 | Covered |
+| Kernel §10.2 / §10.3 / §10.4 matching + divergence | Payload-sensitive | RD-PD-055..058, RD-PD-100..105 | Covered |
 
 ### 17.2 Test Count Summary
 
@@ -713,8 +936,23 @@ correctly implemented when:
 | RD short-circuit | 3 | 1 | 4 |
 | RD resource interaction | 3 | 0 | 3 |
 | RD transport interaction | 2 | 1 | 3 |
-| RD exclusion regression | 1 | 3 | 4 |
+| RD exclusion regression | 1 | 0 | 1 |
 | RD existing regression | 5 | 0 | 5 |
-| **Total** | **93** | **17** | **110** |
+| RD-PD delegated write path | 6 | 0 | 6 |
+| RD-PD short-circuit write path | 3 | 0 | 3 |
+| RD-PD dispatch path classification | 6 | 0 | 6 |
+| RD-PD runtime-direct payload effects | 5 | 0 | 5 |
+| RD-PD replay matching | 5 | 0 | 5 |
+| RD-PD boundary divergence | 6 | 0 | 6 |
+| RD-PD short-circuit divergence | 2 | 0 | 2 |
+| RD-PD transition detection | 2 | 0 | 2 |
+| RD-PD nonconforming journal | 4 | 0 | 4 |
+| RD-PD stream.subscribe / next | 6 | 0 | 6 |
+| RD-PD resource-body parity | 3 | 0 | 3 |
+| RD-PD boundary placement | 3 | 0 | 3 |
+| RD-PD input determinism | 1 | 0 | 1 |
+| RD-PD fixture conformance | 2 | 0 | 2 |
+| RD-PD regression protection | 6 | 0 | 6 |
+| **Total** | **153** | **14** | **167** |
 
-> **Note.** §13.10 also includes one Diagnostic test (`RD-RG-005`) which is non-normative and not counted in the Core/Extended totals above. See §13.13 for the full Core/Extended/Diagnostic breakdown.
+> **Note.** §13.10 also includes one Diagnostic test (`RD-RG-005`) which is non-normative and not counted in the Core/Extended totals above. See §13.14 for the full Core/Extended/Diagnostic breakdown.


### PR DESCRIPTION
## Summary

This PR updates the specs so replay can distinguish effects not just by effect name, but by the durable payload identity that actually mattered at execution time.

From a user perspective, this closes a real correctness gap: if replay reaches the same effect with different effective input, Tisyn should fail with divergence instead of silently reusing an old result.

This is a **spec-only** PR. Runtime and fixture changes follow separately.

## What This Changes

The specs now define:

- payload-sensitive replay identity on `YieldEvent.description`
- when replay matches on the **boundary** request vs the **source** request
- which effects are **chain-dispatched** vs **runtime-direct**
- that missing required `sha` on a payload-sensitive stored entry is a `DivergenceError`
- conformance coverage for the new replay rules

## User-Facing Behavior

### Replay now respects payload identity

If middleware or runtime behavior changes the effective request, replay compares the durable identity of that request, not just `type + name`.

### Delegated and short-circuited dispatches are treated differently

- **Delegated chain-dispatched effects** replay against the request that actually crossed the boundary.
- **Short-circuited chain-dispatched effects** replay against the original source request.
- **Runtime-direct effects** replay against runtime-owned source identity.

### Runtime-direct effects are explicit

The specs now make clear that:

- `__config`
- `stream.subscribe`
- `stream.next`

are runtime-direct and do not pass through `Effects.around`.

### Missing payload identity is now an error

For payload-sensitive effects, a stored entry without required `sha` is no longer treated as replay-compatible legacy data. It is nonconforming and must raise `DivergenceError`.

## Important Exception

`stream.subscribe` remains the one carve-out.

It creates a live runtime capability whose payload does not have stable durable identity, so its journal description remains type/name only.

## Files Updated

- `specs/tisyn-scoped-effects-specification.md`
- `specs/tisyn-kernel-specification.md`
- `specs/tisyn-scoped-effects-test-plan.md`

## Non-Goals

This PR does not include:

- runtime implementation changes
- fixture updates
- code tests
- conformance harness changes
- new durable event kinds

## Follow-Up

A separate implementation PR will carry:

- kernel payload identity support
- runtime replay-boundary behavior
- fixture updates
- runtime and conformance test changes

## Review Focus

Please review for:

1. whether the replay model is correct from a user-facing durability perspective
2. whether boundary-vs-source matching rules are stated clearly
3. whether the runtime-direct exception is coherent
4. whether the pre-1.0 breaking change is explicit enough
5. whether the added test-plan coverage matches the real failure modes
