### PR TITLE
Reclassify __config as non-canonicalizable runtime-direct (spec-only)

### DIFF
--- a/specs/tisyn-kernel-specification.md
+++ b/specs/tisyn-kernel-specification.md
@@ -913,9 +913,15 @@ payload-sensitive effect that lacks either field is
 `__config`)*:
 
 ```
-{ type: "stream", name: "subscribe" }
-{ type: "tisyn",  name: "__config"  }
+{ type: "stream",   name: "subscribe" }
+{ type: "__config", name: "__config"  }
 ```
+
+The `type`/`name` fields for each effect are derived from
+`parseEffectId(effectId)` (§4.6). The `__config` shape above
+follows the undotted-ID rule: `parseEffectId("__config")`
+returns `{ type: "__config", name: "__config" }` because the ID
+contains no dot.
 
 `input` and `sha` MUST NOT be present on either. Replay
 comparison for these effects compares only `type` and `name`;

--- a/specs/tisyn-kernel-specification.md
+++ b/specs/tisyn-kernel-specification.md
@@ -883,17 +883,18 @@ Two event types. Nothing else.
 ```
 
 `description` carries `input` and `sha` for all payload-sensitive
-effects (see "Effect Description Shape" below). `stream.subscribe`
-is the only effect whose description omits both fields — its
-payload contains a live Effection `Operation` with no stable
-durable identity. The durable event algebra is unchanged:
-`DurableEvent = YieldEvent | CloseEvent`.
+effects (see "Effect Description Shape" below). Two effects —
+`stream.subscribe` and `__config` — omit both fields because
+neither has a canonicalizable input distinct from runtime-owned
+state. See §3.1.1 of `tisyn-scoped-effects-specification.md` for
+the classification rationale. The durable event algebra is
+unchanged: `DurableEvent = YieldEvent | CloseEvent`.
 
 **Effect Description Shape.** `YieldEvent.description` has two
 valid shapes.
 
 *Payload-sensitive effects* — all effects except
-`stream.subscribe`:
+`stream.subscribe` and `__config`:
 
 ```
 {
@@ -908,16 +909,21 @@ Both `input` and `sha` are REQUIRED. A `YieldEvent` for a
 payload-sensitive effect that lacks either field is
 **nonconforming**.
 
-*`stream.subscribe`* — non-canonicalizable runtime-direct:
+*Non-canonicalizable runtime-direct effects (`stream.subscribe`,
+`__config`)*:
 
 ```
 { type: "stream", name: "subscribe" }
+{ type: "tisyn",  name: "__config"  }
 ```
 
-`input` and `sha` MUST NOT be present.
+`input` and `sha` MUST NOT be present on either. Replay
+comparison for these effects compares only `type` and `name`;
+missing `sha` on a stored entry is expected and correct.
 
 A TypeScript representation marks both fields optional at the
-type level so the same type fits `stream.subscribe`:
+type level so the same type fits both non-canonicalizable
+shapes:
 
 ```typescript
 interface EffectDescription {
@@ -929,8 +935,9 @@ interface EffectDescription {
 ```
 
 The TS optionality is purely so the type also fits
-`stream.subscribe`. The normative requirement remains: `input`
-and `sha` MUST be present for every payload-sensitive effect.
+`stream.subscribe` and `__config`. The normative requirement
+remains: `input` and `sha` MUST be present for every
+payload-sensitive effect.
 
 **`payloadSha`.** Payload identity is computed by:
 
@@ -1079,7 +1086,8 @@ compare(stored, current):
   if stored.type ≠ current.type: → DIVERGENCE (type/name mismatch)
   if stored.name ≠ current.name: → DIVERGENCE (type/name mismatch)
   if effect is payload-sensitive
-        (i.e., stored.type/name is not stream.subscribe):
+        (i.e., stored.type/name is not in the
+         non-canonicalizable set { stream.subscribe, __config }):
     if stored.sha is absent:
       → DIVERGENCE (nonconforming journal — missing required sha)
     if stored.sha ≠ current.sha:
@@ -1122,15 +1130,17 @@ specifies only how two descriptions compare.
 ### 10.3 Description Matching
 
 Three fields participate in the matching algorithm for
-payload-sensitive effects: `type`, `name`, and `sha`. For
-`stream.subscribe` (non-canonicalizable; see §9.1 "Effect
-Description Shape"), only `type` and `name` participate;
-`sha` is neither expected nor compared.
+payload-sensitive effects: `type`, `name`, and `sha`. For the
+non-canonicalizable runtime-direct effects (`stream.subscribe`,
+`__config`; see §9.1 "Effect Description Shape"), only `type`
+and `name` participate; `sha` is neither expected nor compared.
 
 `sha` is part of durable identity for payload-sensitive
 effects. A stored entry that omits `sha` for a payload-
 sensitive effect is nonconforming and MUST raise
-`DivergenceError` (§10.4); it MUST NOT replay successfully.
+`DivergenceError` (§10.4); it MUST NOT replay successfully. A
+stored entry that omits `sha` for a non-canonicalizable
+runtime-direct effect is expected and MUST replay successfully.
 
 ### 10.4 Divergence
 

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -220,7 +220,7 @@ The following classification applies:
 
 | Effect | Classification | Rationale |
 |---|---|---|
-| `__config` | Runtime-direct | Reads execution-scoped configuration from runtime context. Not a user or agent effect. |
+| `__config` | Runtime-direct, non-canonicalizable | Reads execution-scoped configuration from runtime context. Not a user or agent effect. The compiled IR for `Config.useConfig(Token)` carries no payload (the token is erased to `null`); the resolved value is read from runtime context at dispatch time. There is no canonicalizable input distinct from runtime context. |
 | `stream.subscribe` | Runtime-direct, non-canonicalizable | Creates a runtime-owned live subscription capability. Payload includes a live Effection `Operation`. |
 | `stream.next` | Runtime-direct | Consumes a runtime-owned subscription capability via an opaque handle token. |
 | `sleep` | Chain-dispatched | Handled by the Effects chain's core handler. Interceptable by `Effects.around`. |
@@ -927,7 +927,8 @@ primitive. Guard implementations are host-provided.
 > **Status note.** Payload-sensitive cursor matching is now
 > specified by this section. `YieldEvent.description` carries
 > `input` and `sha` for all payload-sensitive effects;
-> `stream.subscribe` is the only carve-out. See §9.5.3, §9.5.5,
+> `stream.subscribe` and `__config` are the non-canonicalizable
+> carve-outs (see §3.1.1 and §9.5.8). See §9.5.3, §9.5.5,
 > §9.5.8, §9.5.9, and `tisyn-kernel-specification.md` §9.5,
 > §10.2–§10.4.
 
@@ -950,7 +951,9 @@ primitive. Guard implementations are host-provided.
   substitution boundary — the request as max middleware
   forwards it.
 - **Payload-sensitive effect.** Any effect whose payload is
-  canonicalizable. All effects except `stream.subscribe`.
+  canonicalizable. All effects except `stream.subscribe` and
+  `__config` (the two non-canonicalizable runtime-direct effects;
+  see §3.1.1 and §9.5.8).
 
 #### 9.5.1 The Structural Replay Boundary
 
@@ -1165,8 +1168,8 @@ effects uses the **source descriptor** because no max
 middleware can transform the request — there is no boundary
 distinct from the source.
 
-**Payload-sensitive runtime-direct effects (`__config`,
-`stream.next`).** Before dispatching, the runtime MUST:
+**Payload-sensitive runtime-direct effects (`stream.next`).**
+Before dispatching, the runtime MUST:
 
 1. Compare source `type` and `name` against the stored
    `description.type` and `description.name`. Mismatch MUST
@@ -1189,16 +1192,28 @@ the canonicalizable handle-token payload passed to
 `stream.next`. It MUST NOT contain the live subscription
 object, the stream source, or any Effection `Operation`.
 
-**Non-canonicalizable runtime-direct (`stream.subscribe`).**
-`stream.subscribe`'s payload includes a live Effection
-`Operation` whose canonical encoding would be a degenerate
-constant. The runtime MUST omit `input` and `sha` from
-`stream.subscribe` `YieldEvent.description` entries; the
-description shape is `{ type: "stream", name: "subscribe" }`
-exactly. Replay comparison for `stream.subscribe` MUST compare
-only `type` and `name`. A missing `sha` on a stored
-`stream.subscribe` entry is expected and correct, not a
-nonconforming-journal error.
+**Non-canonicalizable runtime-direct effects (`stream.subscribe`,
+`__config`).** Both effects lack a canonicalizable input
+distinct from runtime-owned state:
+
+- `stream.subscribe`'s payload includes a live Effection
+  `Operation` whose canonical encoding would be a degenerate
+  constant.
+- `__config`'s compiled IR carries no payload — the lowering of
+  `Config.useConfig(Token)` erases the token and emits a
+  null-payload effect; the resolved value is read from runtime
+  context at dispatch time. There is no canonicalizable input
+  distinct from that context, and hashing the erased payload
+  would yield a degenerate constant.
+
+For both effects, the runtime MUST omit `input` and `sha` from
+the `YieldEvent.description`; the description shape is
+`{ type: "stream", name: "subscribe" }` and `{ type: "tisyn",
+name: "__config" }` (or whatever `parseEffectId(...)` returns
+for `__config`) exactly. Replay comparison for these effects
+MUST compare only `type` and `name`. A missing `sha` on a
+stored `stream.subscribe` or `__config` entry is expected and
+correct, not a nonconforming-journal error.
 
 #### 9.5.9 Transition Detection
 
@@ -1235,9 +1250,14 @@ identity:
   `YieldEvent.description` for all payload-sensitive effects.
   A stored entry missing `sha` for a payload-sensitive effect
   MUST raise `DivergenceError` (nonconforming journal).
-- **Only exception.** `stream.subscribe`, which MUST omit
-  `input` and `sha` because its payload contains a live
-  Effection `Operation` with no stable durable identity.
+- **Exceptions.** `stream.subscribe` and `__config` MUST omit
+  `input` and `sha`. Both are non-canonicalizable runtime-direct
+  effects: `stream.subscribe`'s payload contains a live Effection
+  `Operation` with no stable durable identity, and `__config`'s
+  compiled IR carries no payload (the token is erased at
+  lowering; the resolved value is read from runtime context at
+  dispatch time, so there is no canonicalizable input distinct
+  from that context).
 
 No legacy-compatibility path replays missing-`sha` payload-
 sensitive entries. Implementations MUST NOT silently accept

--- a/specs/tisyn-scoped-effects-specification.md
+++ b/specs/tisyn-scoped-effects-specification.md
@@ -1207,13 +1207,15 @@ distinct from runtime-owned state:
   would yield a degenerate constant.
 
 For both effects, the runtime MUST omit `input` and `sha` from
-the `YieldEvent.description`; the description shape is
-`{ type: "stream", name: "subscribe" }` and `{ type: "tisyn",
-name: "__config" }` (or whatever `parseEffectId(...)` returns
-for `__config`) exactly. Replay comparison for these effects
-MUST compare only `type` and `name`. A missing `sha` on a
-stored `stream.subscribe` or `__config` entry is expected and
-correct, not a nonconforming-journal error.
+the `YieldEvent.description`. The description shape is
+`{ type: "stream", name: "subscribe" }` for `stream.subscribe`
+and `{ type: "__config", name: "__config" }` for `__config`
+(per `parseEffectId` per `tisyn-kernel-specification.md` §4.6 —
+undotted IDs map to `{ type: id, name: id }`). Replay
+comparison for these effects MUST compare only `type` and
+`name`. A missing `sha` on a stored `stream.subscribe` or
+`__config` entry is expected and correct, not a
+nonconforming-journal error.
 
 #### 9.5.9 Transition Detection
 

--- a/specs/tisyn-scoped-effects-test-plan.md
+++ b/specs/tisyn-scoped-effects-test-plan.md
@@ -549,13 +549,13 @@ and does NOT subsume this matrix.
 | RD-PD-DC-005 | Core | Workflow-visible + Journal-visible | `stream.subscribe` is NOT intercepted and writes no `input`/`sha` | Same setup as DC-004. Inspect the user-installed middleware log AND the journal for the subscribe event. | Subscribe YieldEvent: no `input`, no `sha`. `"stream.subscribe"` does not appear in the user-installed middleware log. |
 | RD-PD-DC-006 | Core | Journal-visible | Chain-dispatched and runtime-direct built-ins have different replay identity rules | Two effects: `sleep(100)` (chain-dispatched) and `stream.next(handle)` (runtime-direct). Max middleware transforms `sleep` data. | `sleep` YieldEvent has boundary identity (transformed data). `stream.next` YieldEvent has source identity (kernel-yielded data). |
 
-#### 13.12.4 Runtime-Direct Payload-Sensitive Effects
+#### 13.12.4 Runtime-Direct Effects (write paths)
 
 | ID | Tier | Obs. class | Description | Setup | Expected |
 |---|---|---|---|---|---|
 | RD-PD-015 | Core | Journal-visible | `stream.subscribe` writes neither `input` nor `sha` | Loop IR, live dispatch. | Subscribe YieldEvent: neither field present. |
 | RD-PD-016 | Core | Journal-visible | `stream.next` writes source `input` and `sha` | Live dispatch. | `sha` present, computed from handle data. |
-| RD-PD-017 | Core | Journal-visible | `__config` writes source `input` and `sha` | Config read. | Both present. |
+| RD-PD-017 | Core | Journal-visible | `__config` writes neither `input` nor `sha` (non-canonicalizable runtime-direct) | Config read. | `__config` YieldEvent: neither `input` nor `sha` present. (Per §3.1.1 / §9.5.8: `__config` is non-canonicalizable; the compiled IR for `Config.useConfig(Token)` carries no payload.) |
 | RD-PD-018 | Core | Journal-visible | `sleep` writes boundary `input` and `sha` (chain-dispatched) | `sleep(100)` with no max transform. | `type="sleep"`, `name="sleep"`, `input=[100]`, `sha=payloadSha([100])` |
 | RD-PD-019 | Core | Journal-visible | `sleep` boundary identity when max transforms | Max transforms `sleep` data `[100]` → `[0]`, calls `next`. | `input=[0]`, `sha=payloadSha([0])` |
 
@@ -602,8 +602,18 @@ and does NOT subsume this matrix.
 | RD-PD-056 | Core | Workflow-visible | Stored `stream.next` missing `sha` → DivergenceError | Stored `stream.next` with no `sha`. | `DivergenceError`. |
 | RD-PD-057 | Core | Journal-visible | Stored `stream.subscribe` without `sha` → NOT an error | Stored `stream.subscribe` no `sha`. | Replay succeeds. (Expected: non-canonicalizable.) |
 | RD-PD-058 | Core | Workflow-visible | Stored `sleep` missing `sha` → DivergenceError | Stored `sleep` with no `sha`. | `DivergenceError`. |
+| RD-PD-059 | Core | Journal-visible | Stored `__config` without `sha` → NOT an error | Stored `__config` no `sha`. | Replay succeeds. (Expected: non-canonicalizable, mirrors RD-PD-057 for `stream.subscribe`.) |
 
-#### 13.12.10 `stream.subscribe` / `stream.next`
+Missing-SHA divergence applies only to genuinely payload-sensitive
+effects (`stream.next`, `sleep`, agent effects). The two
+non-canonicalizable runtime-direct effects (`stream.subscribe`,
+`__config`) replay successfully without `sha` per §9.5.8.
+
+#### 13.12.10 Non-canonicalizable runtime-direct (`stream.subscribe`, `__config`) and `stream.next`
+
+`stream.subscribe` and `__config` are the two non-canonicalizable
+runtime-direct effects (no `input`, no `sha`); `stream.next` is the
+only payload-sensitive runtime-direct effect.
 
 | ID | Tier | Obs. class | Description | Setup | Expected |
 |---|---|---|---|---|---|
@@ -613,6 +623,8 @@ and does NOT subsume this matrix.
 | RD-PD-073 | Core | Journal-visible | `stream.next` `description.input` contains only the serializable handle-token payload | Same as RD-PD-072. Inspect `description.input`. | `input` is the handle-token payload (e.g., `[{ __tisyn_subscription: "sub:root:0" }]`). It does NOT contain a live subscription object, stream source, or Effection `Operation`. |
 | RD-PD-074 | Core | Journal-visible | `stream.next` `description.input` does not contain non-serializable values | Same as RD-PD-072. Verify `canonical(description.input)` produces a meaningful (non-degenerate) canonical form. | `canonical(input)` is NOT `[{}]` or `{}`. It contains the handle token string. |
 | RD-PD-075 | Core | Workflow-visible | `stream.next` replay with changed handle token raises `DivergenceError` | Stored `stream.next` with SHA from handle token `sub:root:0`. Replay produces handle token `sub:root:1`. | `DivergenceError` with payload mismatch. |
+| RD-PD-076 | Core | Journal-visible | `__config` no `input`/`sha` | Live dispatch with `Config.useConfig(Token)` IR. | `__config` YieldEvent: neither `input` nor `sha` present. (Mirrors RD-PD-070 for `stream.subscribe`.) |
+| RD-PD-077 | Core | Journal-visible | `__config` replays with type/name only | Stored `__config` entry. | Replay succeeds; no `sha` comparison. (Mirrors RD-PD-071 for `stream.subscribe`.) |
 
 #### 13.12.11 Resource-Body Parity
 
@@ -721,10 +733,10 @@ Feature is implementation-ready when all 12 pass:
 | §9.5.3 Boundary identity (delegated) | RD-PD-001..006, RD-PD-020..024, RD-PD-030..035, RD-PD-090..092 |
 | §9.5.5 Source identity (short-circuit) | RD-PD-010..012, RD-PD-040..041 |
 | §9.5.7 Resource-body payload-sensitive | RD-PD-080..082 |
-| §9.5.8 Runtime-direct payload-sensitive | RD-PD-015..019, RD-PD-070..075 |
+| §9.5.8 Runtime-direct replay comparison (payload-sensitive + non-canonicalizable) | RD-PD-015..019, RD-PD-070..077 |
 | §9.5.9 Transition detection | RD-PD-050..051 |
 | Kernel §9.1 / §9.5 EffectDescription shape | RD-PD-095, RD-PD-096..097 |
-| Kernel §10.2 / §10.3 / §10.4 matching + divergence | RD-PD-055..058, RD-PD-100..105 |
+| Kernel §10.2 / §10.3 / §10.4 matching + divergence | RD-PD-055..059, RD-PD-100..105 |
 
 **Tier counts (RD-* baseline)**
 
@@ -755,14 +767,14 @@ Feature is implementation-ready when all 12 pass:
 | Boundary divergence | 6 | 0 | 0 | 6 |
 | Short-circuit divergence | 2 | 0 | 0 | 2 |
 | Transition detection | 2 | 0 | 0 | 2 |
-| Nonconforming journal | 4 | 0 | 0 | 4 |
-| stream.subscribe / next | 6 | 0 | 0 | 6 |
+| Nonconforming journal | 5 | 0 | 0 | 5 |
+| Non-canonicalizable runtime-direct + stream.next | 8 | 0 | 0 | 8 |
 | Resource-body parity | 3 | 0 | 0 | 3 |
 | Boundary placement | 3 | 0 | 0 | 3 |
 | Input determinism | 1 | 0 | 0 | 1 |
 | Fixture conformance | 2 | 0 | 0 | 2 |
 | Regression protection | 6 | 0 | 0 | 6 |
-| **Total** | **60** | **0** | **0** | **60** |
+| **Total** | **63** | **0** | **0** | **63** |
 
 ---
 
@@ -903,11 +915,11 @@ correctly implemented when:
 | §9.5.6 No delegation helper | Replay-aware dispatch | RD-RG-004, RD-RG-005 | Covered |
 | §9.5.7 Resource-body interaction | Replay-aware dispatch | RD-RS-001–003 | Covered |
 | §9.5.7 Resource-body payload-sensitive | Payload-sensitive | RD-PD-080..082 | Covered |
-| §9.5.8 Runtime-direct replay comparison | Payload-sensitive | RD-PD-015..019, RD-PD-070..075 | Covered |
+| §9.5.8 Runtime-direct replay comparison | Payload-sensitive | RD-PD-015..019, RD-PD-070..077 | Covered |
 | §9.5.9 Transition detection | Payload-sensitive | RD-PD-050..051 | Covered |
 | §3.1.1 Runtime-direct classification | Payload-sensitive | RD-PD-DC-001..006 | Covered |
 | Kernel §9.1 / §9.5 EffectDescription shape | Payload-sensitive | RD-PD-095..097 | Covered |
-| Kernel §10.2 / §10.3 / §10.4 matching + divergence | Payload-sensitive | RD-PD-055..058, RD-PD-100..105 | Covered |
+| Kernel §10.2 / §10.3 / §10.4 matching + divergence | Payload-sensitive | RD-PD-055..059, RD-PD-100..105 | Covered |
 
 ### 17.2 Test Count Summary
 
@@ -946,13 +958,13 @@ correctly implemented when:
 | RD-PD boundary divergence | 6 | 0 | 6 |
 | RD-PD short-circuit divergence | 2 | 0 | 2 |
 | RD-PD transition detection | 2 | 0 | 2 |
-| RD-PD nonconforming journal | 4 | 0 | 4 |
-| RD-PD stream.subscribe / next | 6 | 0 | 6 |
+| RD-PD nonconforming journal | 5 | 0 | 5 |
+| RD-PD non-canonicalizable runtime-direct + stream.next | 8 | 0 | 8 |
 | RD-PD resource-body parity | 3 | 0 | 3 |
 | RD-PD boundary placement | 3 | 0 | 3 |
 | RD-PD input determinism | 1 | 0 | 1 |
 | RD-PD fixture conformance | 2 | 0 | 2 |
 | RD-PD regression protection | 6 | 0 | 6 |
-| **Total** | **153** | **14** | **167** |
+| **Total** | **156** | **14** | **170** |
 
 > **Note.** §13.10 also includes one Diagnostic test (`RD-RG-005`) which is non-normative and not counted in the Core/Extended totals above. See §13.14 for the full Core/Extended/Diagnostic breakdown.


### PR DESCRIPTION
## Summary

Spec-only amendment to PR #143. Resolves an internal contradiction between the merged spec's `__config` classification and the current compiler/runtime behavior.

**The problem.** PR #143 §9.5.8 says payload-sensitive runtime-direct effects (`__config`, `stream.next`) MUST journal `input: descriptor.data` and compare `payloadSha(descriptor.data)` on replay. But the compiler at `packages/compiler/src/emit.ts:3362` erases the token:

```
yield* Config.useConfig(Token) → ExternalEval(\"__config\", Q(null))
```

So `descriptor.data` for `__config` is always `null`. Hashing `null` yields a degenerate constant on every dispatch, meaning **config changes would never trigger payload divergence on replay** — defeating the purpose of payload-sensitive replay for `__config`. The runtime resolves the actual config via `ConfigContext.expect()` at `packages/runtime/src/execute.ts:2300`; `descriptor.data` plays no role.

**The fix.** Move `__config` into the non-canonicalizable runtime-direct group alongside `stream.subscribe`. The shape and rule already exist for `stream.subscribe`; this amendment broadens both to enumerate `{ stream.subscribe, __config }` consistently across all three spec files.

### Why now

This is a prerequisite for the runtime/kernel implementation PR (PR 2 of 2 for payload-sensitive replay). Without this amendment, an honest implementation of `__config` payload-sensitive replay is impossible on current main — the implementation would either ship a degenerate constant SHA (silent failure) or silently diverge from the spec it claims to implement.

### Alternatives considered

The implementation plan considered two other resolutions:

2. Define `__config`'s `input` as the resolved-config-context payload (`ConfigContext.expect()` at dispatch time, not `descriptor.data`). Requires runtime change but keeps `__config` payload-sensitive.
3. Amend the compiler so `Config.useConfig(Token)` emits a meaningful payload into `descriptor.data`. Compiler change is its own PR; spec stays as-is.

This PR adopts **resolution 1 (reclassify)** as the simplest path. It mirrors the existing `stream.subscribe` carve-out shape, requires no runtime/compiler change, and is conceptually correct: `__config`'s authoritative state is the runtime config context, not a per-call descriptor payload.

## Sections changed

**`tisyn-scoped-effects-specification.md`**
- §3.1.1 classification table — `__config` row updated with rationale.
- §9.5 prelude — \"Payload-sensitive effect\" definition narrowed to enumerate both carve-outs.
- §9.5.8 — `__config` moved from payload-sensitive group to non-canonicalizable group; shape-and-rule paragraph for `stream.subscribe` broadened to cover both.
- §9.5.10 breaking-change callout — \"Only exception\" → \"Exceptions\" with both effects named.

**`tisyn-kernel-specification.md`**
- §9.1 Effect Description Shape — header pluralized; both shapes shown; TS optionality narrative updated.
- §10.2 `compare(stored, current)` predicate — payload-sensitive test widened to \"not in the non-canonicalizable set { stream.subscribe, __config }\".
- §10.3 — names both effects; explicit rule that missing sha on a non-canonicalizable entry MUST replay successfully.

**`tisyn-scoped-effects-test-plan.md`**
- §13.12.4 RD-PD-017 — rewritten to \"__config writes neither input nor sha\" (mirrors RD-PD-070).
- §13.12.9 — added RD-PD-059 (`__config` no-sha replays); explicit narrowing of missing-SHA divergence to genuinely payload-sensitive effects.
- §13.12.10 — added RD-PD-076 / RD-PD-077 mirroring RD-PD-070 / RD-PD-071 for `__config`.
- §13.14 / §17 — coverage tables and grand totals re-derived (60 → 63 RD-PD Core; §17.2 grand total 167 → 170).

## Non-goals

- No code changes
- No changesets
- No package READMEs
- No fixture updates
- No runtime tests
- No conformance harness changes
- No compiler changes

## Test plan

- [x] `git diff --name-only origin/main` shows only the three target spec files
- [x] No package, example, or `.changeset` files modified
- [x] Contradiction sweep: no remaining \"`stream.subscribe` is the only...\" / \"only effect whose description omits...\" / \"sole carve-out\" universality claims
- [x] `__config` mentioned alongside `stream.subscribe` 14× across the three files (5+4+5)
- [x] Internal numbering consistent: §13.14 RD-PD total 60 → 63; §17.2 grand total 167 → 170
- [x] §10.2 compare predicate parses correctly with the new non-canonicalizable set
- [ ] Spec review for normative-vs-rationale labeling