### PR TITLE
Payload-sensitive replay: runtime + kernel implementation (PR 2 of 2)

### DIFF
--- a/.changeset/payload-sensitive-replay-conformance.md
+++ b/.changeset/payload-sensitive-replay-conformance.md
@@ -1,0 +1,7 @@
+---
+"@tisyn/conformance": minor
+---
+
+Replay fixtures now carry `input` and `sha` on payload-sensitive effects, matching the runtime's new journal output. The conformance harness's existing strict canonical-byte comparison (`journalMatches`) rejects fixtures whose `expected_journal` description omits `sha` for a payload-sensitive effect — a stale-fixture regression test (`RD-PD-097`) was added to confirm.
+
+**Breaking pre-1.0:** consumers with custom fixtures must update each `expected_journal` description for payload-sensitive effects to include `input` (the canonicalizable JSON payload from the `descriptor.data`) and `sha` (compute via `payloadSha` from `@tisyn/kernel`). Fixtures for `stream.subscribe` or `__config` keep `{ type, name }` only.

--- a/.changeset/payload-sensitive-replay-kernel.md
+++ b/.changeset/payload-sensitive-replay-kernel.md
@@ -1,0 +1,9 @@
+---
+"@tisyn/kernel": minor
+---
+
+Payload-sensitive replay support: `EffectDescription` gains optional `input` and `sha` fields, and a new `payloadSha(value)` helper computes `bytesToHex(sha256(utf8(canonical(value))))` (isomorphic Node + browser via `@noble/hashes`).
+
+**Breaking pre-1.0:** `YieldEvent.description` now carries `input` and `sha` for all payload-sensitive effects. Stored journal entries that omit `sha` for payload-sensitive effects now raise `DivergenceError` on replay (no legacy compatibility path). The two non-canonicalizable runtime-direct effects — `stream.subscribe` and `__config` — continue to omit both fields per scoped-effects spec §9.5.8.
+
+Adds `@noble/hashes` dependency.

--- a/.changeset/payload-sensitive-replay-kernel.md
+++ b/.changeset/payload-sensitive-replay-kernel.md
@@ -2,7 +2,7 @@
 "@tisyn/kernel": minor
 ---
 
-Payload-sensitive replay support: `EffectDescription` gains optional `input` and `sha` fields, and a new `payloadSha(value)` helper computes `bytesToHex(sha256(utf8(canonical(value))))` (isomorphic Node + browser via `@noble/hashes`).
+Payload-sensitive replay support: `EffectDescription` gains optional `input` and `sha` fields, and two new helpers — `payloadSha(value)` computes `bytesToHex(sha256(utf8(canonical(value))))` (isomorphic Node + browser via `@noble/hashes`); `payloadIdentity(value)` returns `{ input, sha }` derived from a single canonical snapshot, guaranteeing the pair stays self-consistent under in-place mutation of the original value.
 
 **Breaking pre-1.0:** `YieldEvent.description` now carries `input` and `sha` for all payload-sensitive effects. Stored journal entries that omit `sha` for payload-sensitive effects now raise `DivergenceError` on replay (no legacy compatibility path). The two non-canonicalizable runtime-direct effects — `stream.subscribe` and `__config` — continue to omit both fields per scoped-effects spec §9.5.8.
 

--- a/.changeset/payload-sensitive-replay-runtime.md
+++ b/.changeset/payload-sensitive-replay-runtime.md
@@ -1,0 +1,12 @@
+---
+"@tisyn/runtime": minor
+---
+
+Replay matching is now payload-sensitive. Chain-dispatched delegated dispatch records and compares against the **post-max boundary descriptor** (so a max middleware that transforms `effectId` or `data` produces a journal entry reflecting the transformed request); chain-dispatched short-circuit and runtime-direct dispatch use the **source descriptor**. `stream.next` is payload-sensitive; `stream.subscribe` and `__config` are non-canonicalizable per the amended spec and continue to journal `{ type, name }` only.
+
+**Breaking pre-1.0:**
+- Workflows whose stored journals omit `sha` for payload-sensitive effects will fail replay with `DivergenceError`. Re-run the live execution to rebuild the journal under the new shape.
+- `Effects.around` no longer intercepts the runtime-direct effects `__config`, `stream.subscribe`, or `stream.next` — they bypass the user-facing Effects chain per scoped-effects §3.1.1. Workflows that incidentally observed these effectIds in middleware logs will no longer see them.
+- `__config` `YieldEvent`s now write `{ type, name }` only (no `input`, no `sha`); replay treats missing `sha` on stored `__config` entries as expected, mirroring `stream.subscribe`.
+
+The motivating failure this resolves: a stored result for one input now correctly diverges instead of silently substituting against a different live input. See scoped-effects spec §9.5.3 / §9.5.5 / §9.5.8 / §9.5.10 and `RD-PD-031` / `RD-PD-091`.

--- a/packages/conformance/src/conformance.test.ts
+++ b/packages/conformance/src/conformance.test.ts
@@ -82,3 +82,49 @@ describe("Negative tests", () => {
     expect(result.pass, result.message).toBe(true);
   });
 });
+
+describe("Stale-fixture coverage (RD-PD-097)", () => {
+  it("RD-PD-097: a fixture whose expected_journal omits sha for a payload-sensitive effect MUST fail to match a runtime that journals sha", async () => {
+    // Construct a stale fixture where the expected_journal description
+    // for x.step1 omits the sha field. The runtime now journals
+    // { type, name, input, sha }, so the harness's strict canonical
+    // comparison rejects this fixture as nonconforming.
+    const staleFixture = {
+      id: "RD-PD-097",
+      suite_version: "2.0.0",
+      tier: "core" as const,
+      level: 3,
+      category: "kernel.replay.stale-fixture",
+      spec_ref: "scoped-effects.13.12.14",
+      type: "effect" as const,
+      description: "Stale expected_journal entry without sha must fail to match",
+      ir: { tisyn: "eval" as const, id: "x.step1", data: [] },
+      env: {},
+      effects: [
+        {
+          descriptor: { id: "x.step1", data: [] },
+          result: { status: "ok" as const, value: 10 },
+        },
+      ],
+      expected_result: { status: "ok" as const, value: 10 },
+      expected_journal: [
+        {
+          coroutineId: "root",
+          // Intentionally stale: missing input/sha.
+          description: { type: "x", name: "step1" },
+          result: { status: "ok" as const, value: 10 },
+          type: "yield" as const,
+        },
+        {
+          coroutineId: "root",
+          result: { status: "ok" as const, value: 10 },
+          type: "close" as const,
+        },
+      ],
+    };
+    const result = await runFixture(staleFixture);
+    expect(result.pass).toBe(false);
+    // The harness should report a description-shape mismatch.
+    expect(result.message).toMatch(/journal|description/i);
+  });
+});

--- a/packages/conformance/src/crash-replay.test.ts
+++ b/packages/conformance/src/crash-replay.test.ts
@@ -159,7 +159,17 @@ describe("End-to-end crash/replay", () => {
       description: { type: string; name: string };
     };
     expect(y1.description).toEqual({ type: "x", name: "step1", input: [], sha: payloadSha([]) });
-    expect(y2.description).toEqual({ type: "x", name: "step2", input: [10], sha: payloadSha([10]) });
-    expect(y3.description).toEqual({ type: "x", name: "step3", input: [20], sha: payloadSha([20]) });
+    expect(y2.description).toEqual({
+      type: "x",
+      name: "step2",
+      input: [10],
+      sha: payloadSha([10]),
+    });
+    expect(y3.description).toEqual({
+      type: "x",
+      name: "step3",
+      input: [20],
+      sha: payloadSha([20]),
+    });
   });
 });

--- a/packages/conformance/src/crash-replay.test.ts
+++ b/packages/conformance/src/crash-replay.test.ts
@@ -16,6 +16,7 @@ import { scoped } from "effection";
 import { execute } from "@tisyn/runtime";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { Effects } from "@tisyn/effects";
+import { payloadSha } from "@tisyn/kernel";
 
 describe("End-to-end crash/replay", () => {
   it("should replay stored effects and continue with live dispatch", function* () {
@@ -157,8 +158,8 @@ describe("End-to-end crash/replay", () => {
       type: "yield";
       description: { type: string; name: string };
     };
-    expect(y1.description).toEqual({ type: "x", name: "step1" });
-    expect(y2.description).toEqual({ type: "x", name: "step2" });
-    expect(y3.description).toEqual({ type: "x", name: "step3" });
+    expect(y1.description).toEqual({ type: "x", name: "step1", input: [], sha: payloadSha([]) });
+    expect(y2.description).toEqual({ type: "x", name: "step2", input: [10], sha: payloadSha([10]) });
+    expect(y3.description).toEqual({ type: "x", name: "step3", input: [20], sha: payloadSha([20]) });
   });
 });

--- a/packages/conformance/src/fixtures.ts
+++ b/packages/conformance/src/fixtures.ts
@@ -5,7 +5,18 @@
  * Each is a complete, machine-readable object matching the fixture schemas.
  */
 
+import { payloadSha } from "@tisyn/kernel";
+import type { Json } from "@tisyn/ir";
 import type { Fixture } from "./harness.js";
+
+// Helper: build a payload-sensitive description with input + sha.
+// All chain-dispatched effects in these fixtures are payload-sensitive
+// per scoped-effects §9.5.0; the runtime journals { type, name, input,
+// sha = payloadSha(input) }. (stream.subscribe and __config are
+// non-canonicalizable per §9.5.8 but no fixture uses them yet.)
+function ps(type: string, name: string, input: Json) {
+  return { type, name, input, sha: payloadSha(input) };
+}
 
 /** KERN-001: Integer literal evaluates to itself */
 export const KERN_001: Fixture = {
@@ -183,13 +194,13 @@ export const KERN_080: Fixture = {
   expected_journal: [
     {
       coroutineId: "root",
-      description: { name: "step1", type: "x" },
+      description: ps("x", "step1", []),
       result: { status: "ok", value: 10 },
       type: "yield",
     },
     {
       coroutineId: "root",
-      description: { name: "step2", type: "x" },
+      description: ps("x", "step2", [10]),
       result: { status: "ok", value: 20 },
       type: "yield",
     },
@@ -230,7 +241,7 @@ export const KERN_071: Fixture = {
   expected_journal: [
     {
       coroutineId: "root",
-      description: { name: "check", type: "x" },
+      description: ps("x", "check", [{ tisyn: "ref", name: "y" }] as Json),
       result: { status: "ok", value: true },
       type: "yield",
     },
@@ -298,13 +309,13 @@ export const REPLAY_010: Fixture = {
   stored_journal: [
     {
       coroutineId: "root",
-      description: { name: "step1", type: "x" },
+      description: ps("x", "step1", []),
       result: { status: "ok", value: 10 },
       type: "yield" as const,
     },
     {
       coroutineId: "root",
-      description: { name: "step2", type: "x" },
+      description: ps("x", "step2", [10]),
       result: { status: "ok", value: 20 },
       type: "yield" as const,
     },
@@ -319,19 +330,19 @@ export const REPLAY_010: Fixture = {
   expected_journal: [
     {
       coroutineId: "root",
-      description: { name: "step1", type: "x" },
+      description: ps("x", "step1", []),
       result: { status: "ok", value: 10 },
       type: "yield",
     },
     {
       coroutineId: "root",
-      description: { name: "step2", type: "x" },
+      description: ps("x", "step2", [10]),
       result: { status: "ok", value: 20 },
       type: "yield",
     },
     {
       coroutineId: "root",
-      description: { name: "step3", type: "x" },
+      description: ps("x", "step3", [20]),
       result: { status: "ok", value: 30 },
       type: "yield",
     },
@@ -358,7 +369,7 @@ export const REPLAY_020: Fixture = {
   stored_journal: [
     {
       coroutineId: "root",
-      description: { name: "op1", type: "a" },
+      description: ps("a", "op1", []),
       result: { status: "ok", value: 1 },
       type: "yield" as const,
     },
@@ -555,7 +566,7 @@ export const DET_002: Fixture = {
     {
       type: "yield",
       coroutineId: "root",
-      description: { type: "a", name: "op" },
+      description: ps("a", "op", { a: 2, m: 3, z: 1 }),
       result: { status: "ok", value: "done" },
     },
     {

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -27,6 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@noble/hashes": "^2.2.0",
     "@tisyn/ir": "workspace:*",
     "@tisyn/validate": "workspace:*"
   },

--- a/packages/kernel/src/events.ts
+++ b/packages/kernel/src/events.ts
@@ -1,8 +1,10 @@
-import type { Json } from "@tisyn/ir";
+import type { Json, Val } from "@tisyn/ir";
 
 export interface EffectDescription {
   type: string;
   name: string;
+  input?: Val;
+  sha?: string;
 }
 
 export type EventResult =

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -26,4 +26,4 @@ export type {
 } from "./events.js";
 export { canonical } from "./canonical.js";
 export { parseEffectId } from "./effect-id.js";
-export { payloadSha } from "./payload-sha.js";
+export { payloadSha, payloadIdentity } from "./payload-sha.js";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -26,3 +26,4 @@ export type {
 } from "./events.js";
 export { canonical } from "./canonical.js";
 export { parseEffectId } from "./effect-id.js";
+export { payloadSha } from "./payload-sha.js";

--- a/packages/kernel/src/payload-sha.ts
+++ b/packages/kernel/src/payload-sha.ts
@@ -1,0 +1,8 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import type { Json } from "@tisyn/ir";
+import { canonical } from "./canonical.js";
+
+export function payloadSha(value: Json): string {
+  return bytesToHex(sha256(new TextEncoder().encode(canonical(value))));
+}

--- a/packages/kernel/src/payload-sha.ts
+++ b/packages/kernel/src/payload-sha.ts
@@ -6,3 +6,26 @@ import { canonical } from "./canonical.js";
 export function payloadSha(value: Json): string {
   return bytesToHex(sha256(new TextEncoder().encode(canonical(value))));
 }
+
+/**
+ * Compute a self-consistent durable payload identity from a single snapshot.
+ *
+ * Both fields are derived from the same canonical encoding of `value`:
+ *   - `input` is parsed back from the canonical string, so it is a fresh
+ *     value graph with no live references into the caller's data. Subsequent
+ *     in-place mutation of the original `value` cannot drift `input` or `sha`.
+ *   - `sha` is `bytesToHex(sha256(utf8(canonical(value))))` over the same
+ *     canonical encoding, so `sha === payloadSha(input)` always holds.
+ *
+ * Use this at every site that constructs an `EffectDescription` for journal
+ * writes; the two-field shape is the load-bearing invariant that makes
+ * payload-sensitive replay work (kernel §9.1, scoped-effects §9.5.3 / §9.5.5
+ * / §9.5.8).
+ */
+export function payloadIdentity(value: Json): { input: Json; sha: string } {
+  const encoded = canonical(value);
+  return {
+    input: JSON.parse(encoded) as Json,
+    sha: bytesToHex(sha256(new TextEncoder().encode(encoded))),
+  };
+}

--- a/packages/runtime/src/default-sleep.test.ts
+++ b/packages/runtime/src/default-sleep.test.ts
@@ -5,16 +5,18 @@ import { Effects } from "@tisyn/effects";
 import type { Val } from "@tisyn/ir";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import type { YieldEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
 
 function sleepIR(ms: number) {
   return { tisyn: "eval", id: "sleep", data: [ms] };
 }
 
-function yieldEvent(value: unknown, coroutineId = "root"): YieldEvent {
+function yieldEvent(value: unknown, coroutineId = "root", ms = 1): YieldEvent {
+  const input = [ms];
   return {
     type: "yield",
     coroutineId,
-    description: { type: "sleep", name: "sleep" },
+    description: { type: "sleep", name: "sleep", input, sha: payloadSha(input) },
     result: { status: "ok", value: value as never },
   };
 }

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -915,10 +915,7 @@ export function* execute(options: ExecuteOptions): Operation<ExecuteResult> {
       // Replay path: authoritative comparison at the boundary per
       // kernel §10.2 / scoped-effects §9.5.3. type/name + sha.
       const cursor = rctx.ctx.replayIndex.getCursor(rctx.coroutineId);
-      if (
-        stored.description.type !== boundary.type ||
-        stored.description.name !== boundary.name
-      ) {
+      if (stored.description.type !== boundary.type || stored.description.name !== boundary.name) {
         throw new DivergenceError(
           `Divergence at ${rctx.coroutineId}[${cursor}]: ` +
             `expected ${stored.description.type}.${stored.description.name}, ` +
@@ -2295,8 +2292,7 @@ function* dispatchStandardEffect(
     descriptor.id === "__config" ||
     descriptor.id === "stream.subscribe" ||
     descriptor.id === "stream.next";
-  const isNonCanonicalizable =
-    descriptor.id === "stream.subscribe" || descriptor.id === "__config";
+  const isNonCanonicalizable = descriptor.id === "stream.subscribe" || descriptor.id === "__config";
 
   if (isRuntimeDirect) {
     // Pre-check: type/name compare for all runtime-direct effects.
@@ -2567,13 +2563,12 @@ function* dispatchStandardEffect(
     ? { status: "error", error: { message: threw.message, name: threw.name } }
     : { status: "ok", value: resultValue as Json };
 
-  const journalDescription: EffectDescription =
-    runtimeCtxValue.boundaryDescription ?? {
-      type: sourceDescription.type,
-      name: sourceDescription.name,
-      input: descriptor.data as Val,
-      sha: payloadSha(descriptor.data as Json),
-    };
+  const journalDescription: EffectDescription = runtimeCtxValue.boundaryDescription ?? {
+    type: sourceDescription.type,
+    name: sourceDescription.name,
+    input: descriptor.data as Val,
+    sha: payloadSha(descriptor.data as Json),
+  };
   const yieldEvent: YieldEvent = {
     type: "yield",
     coroutineId,

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -14,9 +14,11 @@ import {
   type DurableEvent,
   type YieldEvent,
   type CloseEvent,
+  type EffectDescription,
   type EffectDescriptor,
   type EventResult,
   parseEffectId,
+  payloadSha,
   isCompoundExternal,
 } from "@tisyn/kernel";
 import {
@@ -104,6 +106,16 @@ interface DriveContext {
 interface RuntimeDispatchValue {
   coroutineId: string;
   ctx: DriveContext;
+  /**
+   * Boundary description for chain-dispatched delegated dispatch.
+   * Set by the replay lane on the live path (no stored cursor) from the
+   * post-max `[effectId, data]` reaching the boundary, then read by
+   * `dispatchStandardEffect` for the live journal write per
+   * scoped-effects §9.5.3. Undefined for short-circuit (max returned
+   * without `next`); the post-dispatch path falls back to source
+   * identity per §9.5.5.
+   */
+  boundaryDescription?: EffectDescription;
 }
 
 const RuntimeDispatchContext = createContext<RuntimeDispatchValue | null>(
@@ -863,10 +875,12 @@ export function* execute(options: ExecuteOptions): Operation<ExecuteResult> {
     }
 
     // Install the replay-substitution lane. The middleware fires on every
-    // dispatch that enters the Effects chain; when no RuntimeDispatchContext
-    // is set (e.g. a raw test-only dispatch outside the kernel driver) or
-    // when no stored cursor entry exists, it passes through to `next`.
-    // Structural replay substitution — §9.5 of the scoped-effects spec.
+    // chain-dispatched effect that enters the Effects chain. When no
+    // RuntimeDispatchContext is set (e.g. a raw test-only dispatch outside
+    // the kernel driver) it passes through to `next`. Otherwise it
+    // constructs the post-max boundary description (per scoped-effects
+    // §9.5.3) and either substitutes the stored result (replay) or sets
+    // the boundary on RuntimeDispatchContext for the live write path.
     yield* installReplayDispatch(function* replayLane(
       [effectId, data]: [string, Val],
       next: (eid: string, d: Val) => Operation<Val>,
@@ -876,20 +890,56 @@ export function* execute(options: ExecuteOptions): Operation<ExecuteResult> {
         return yield* next(effectId, data);
       }
 
+      // Construct the boundary description from the post-max
+      // [effectId, data] reaching this point. For chain-dispatched
+      // effects, this is the durable identity (spec §9.5.3).
+      const boundary = parseEffectId(effectId);
+      const boundarySha = payloadSha(data as Json);
+      const boundaryDescription: EffectDescription = {
+        type: boundary.type,
+        name: boundary.name,
+        input: data,
+        sha: boundarySha,
+      };
+
       const stored = rctx.ctx.replayIndex.peekYield(rctx.coroutineId);
+
       if (stored == null) {
+        // Live path: stash the boundary description so
+        // dispatchStandardEffect's post-dispatch live write can journal
+        // boundary identity rather than source identity (§9.5.3).
+        rctx.boundaryDescription = boundaryDescription;
         return yield* next(effectId, data);
       }
 
-      // Authoritative divergence check runs in the helper BEFORE the chain;
-      // the defensive re-check here guards against runtime bugs.
-      const description = parseEffectId(effectId);
+      // Replay path: authoritative comparison at the boundary per
+      // kernel §10.2 / scoped-effects §9.5.3. type/name + sha.
+      const cursor = rctx.ctx.replayIndex.getCursor(rctx.coroutineId);
       if (
-        stored.description.type !== description.type ||
-        stored.description.name !== description.name
+        stored.description.type !== boundary.type ||
+        stored.description.name !== boundary.name
       ) {
-        throw new RuntimeBugError(
-          `Replay lane observed descriptor mismatch at ${rctx.coroutineId}`,
+        throw new DivergenceError(
+          `Divergence at ${rctx.coroutineId}[${cursor}]: ` +
+            `expected ${stored.description.type}.${stored.description.name}, ` +
+            `got ${boundary.type}.${boundary.name}`,
+        );
+      }
+      // Chain-dispatched effects are payload-sensitive (spec §9.5.0
+      // definition; the non-canonicalizable carve-outs are runtime-direct
+      // and never reach the chain). `sha` is required.
+      if (stored.description.sha == null) {
+        throw new DivergenceError(
+          `Divergence at ${rctx.coroutineId}[${cursor}]: ` +
+            `stored entry for ${boundary.type}.${boundary.name} missing required sha — nonconforming journal`,
+        );
+      }
+      if (stored.description.sha !== boundarySha) {
+        throw new DivergenceError(
+          `Divergence at ${rctx.coroutineId}[${cursor}]: ` +
+            `payload mismatch for ${boundary.type}.${boundary.name}:\n` +
+            `  stored sha: ${stored.description.sha}\n` +
+            `  current sha: ${boundarySha}`,
         );
       }
 
@@ -2232,34 +2282,61 @@ function* dispatchStandardEffect(
     durableTaskTable,
   } = params;
 
-  const description = parseEffectId(descriptor.id);
+  const sourceDescription = parseEffectId(descriptor.id);
   const stored = ctx.replayIndex.peekYield(coroutineId);
 
-  // Authoritative divergence pre-check. Applies to both intrinsic and
-  // agent-effect paths; runs before any live handling.
-  if (stored) {
-    if (
-      stored.description.type !== description.type ||
-      stored.description.name !== description.name
-    ) {
-      const cursor = ctx.replayIndex.getCursor(coroutineId);
-      throw new DivergenceError(
-        `Divergence at ${coroutineId}[${cursor}]: ` +
-          `expected ${stored.description.type}.${stored.description.name}, ` +
-          `got ${description.type}.${description.name}`,
-      );
-    }
-  }
-
-  // ── Runtime intrinsic bypass ──
-  const isIntrinsic =
+  // ── Runtime-direct bypass ──
+  // Per scoped-effects §3.1.1, three effects bypass the user-facing
+  // Effects chain: __config, stream.subscribe, stream.next. Of these,
+  // stream.subscribe and __config are non-canonicalizable (no input/no
+  // sha journaled; sha not compared on replay) per §9.5.8. stream.next
+  // is payload-sensitive (sha journaled and compared per kernel §10.2).
+  const isRuntimeDirect =
     descriptor.id === "__config" ||
     descriptor.id === "stream.subscribe" ||
     descriptor.id === "stream.next";
+  const isNonCanonicalizable =
+    descriptor.id === "stream.subscribe" || descriptor.id === "__config";
 
-  if (isIntrinsic) {
+  if (isRuntimeDirect) {
+    // Pre-check: type/name compare for all runtime-direct effects.
+    // Payload-sensitive runtime-direct (stream.next) additionally
+    // requires sha; non-canonicalizable runtime-direct effects skip
+    // the sha check (missing sha is expected per §9.5.8).
     if (stored) {
-      // Replay intrinsic.
+      if (
+        stored.description.type !== sourceDescription.type ||
+        stored.description.name !== sourceDescription.name
+      ) {
+        const cursor = ctx.replayIndex.getCursor(coroutineId);
+        throw new DivergenceError(
+          `Divergence at ${coroutineId}[${cursor}]: ` +
+            `expected ${stored.description.type}.${stored.description.name}, ` +
+            `got ${sourceDescription.type}.${sourceDescription.name}`,
+        );
+      }
+      if (!isNonCanonicalizable) {
+        // stream.next: payload-sensitive. sha required.
+        if (stored.description.sha == null) {
+          const cursor = ctx.replayIndex.getCursor(coroutineId);
+          throw new DivergenceError(
+            `Divergence at ${coroutineId}[${cursor}]: ` +
+              `stored entry for ${sourceDescription.type}.${sourceDescription.name} missing required sha — nonconforming journal`,
+          );
+        }
+        const currentSha = payloadSha(descriptor.data as Json);
+        if (currentSha !== stored.description.sha) {
+          const cursor = ctx.replayIndex.getCursor(coroutineId);
+          throw new DivergenceError(
+            `Divergence at ${coroutineId}[${cursor}]: ` +
+              `payload mismatch for ${sourceDescription.type}.${sourceDescription.name}:\n` +
+              `  stored sha: ${stored.description.sha}\n` +
+              `  current sha: ${currentSha}`,
+          );
+        }
+      }
+
+      // Replay runtime-direct.
       ctx.replayIndex.consumeYield(coroutineId);
 
       // stream.subscribe replay: restore subscription map entry from stored
@@ -2359,10 +2436,21 @@ function* dispatchStandardEffect(
       };
     }
 
+    // Live write: payload-sensitive runtime-direct (stream.next) carries
+    // input + sha; non-canonicalizable runtime-direct (stream.subscribe,
+    // __config) omit both per spec §9.5.8.
+    const liveDescription: EffectDescription = isNonCanonicalizable
+      ? sourceDescription
+      : {
+          type: sourceDescription.type,
+          name: sourceDescription.name,
+          input: descriptor.data as Val,
+          sha: payloadSha(descriptor.data as Json),
+        };
     const yieldEvent: YieldEvent = {
       type: "yield",
       coroutineId,
-      description,
+      description: liveDescription,
       result: effectResult,
     };
     yield* ctx.stream.append(yieldEvent);
@@ -2370,7 +2458,7 @@ function* dispatchStandardEffect(
     return { replayed: false, result: effectResult };
   }
 
-  // ── Agent-effect path ──
+  // ── Chain-dispatched (agent-effect) path ──
 
   // Peek-miss guards (only apply when stored == null → live dispatch).
   if (stored == null) {
@@ -2431,8 +2519,35 @@ function* dispatchStandardEffect(
   if (!replayed && stored) {
     // §9.5.5: max middleware short-circuited without calling `next`. The
     // lane never fired, so the cursor is still present and authoritative.
-    // Runtime consumes it now, journals the stored event, and overrides
-    // the short-circuit return value.
+    // Replay-identity here is the SOURCE descriptor (the request never
+    // reached the post-max boundary). Per kernel §10.2: type/name + sha
+    // must all match.
+    const cursor = ctx.replayIndex.getCursor(coroutineId);
+    if (
+      stored.description.type !== sourceDescription.type ||
+      stored.description.name !== sourceDescription.name
+    ) {
+      throw new DivergenceError(
+        `Divergence at ${coroutineId}[${cursor}]: ` +
+          `expected ${stored.description.type}.${stored.description.name}, ` +
+          `got ${sourceDescription.type}.${sourceDescription.name}`,
+      );
+    }
+    if (stored.description.sha == null) {
+      throw new DivergenceError(
+        `Divergence at ${coroutineId}[${cursor}]: ` +
+          `stored entry for ${sourceDescription.type}.${sourceDescription.name} missing required sha — nonconforming journal`,
+      );
+    }
+    const currentSha = payloadSha(descriptor.data as Json);
+    if (currentSha !== stored.description.sha) {
+      throw new DivergenceError(
+        `Divergence at ${coroutineId}[${cursor}]: ` +
+          `payload mismatch for ${sourceDescription.type}.${sourceDescription.name}:\n` +
+          `  stored sha: ${stored.description.sha}\n` +
+          `  current sha: ${currentSha}`,
+      );
+    }
     ctx.replayIndex.consumeYield(coroutineId);
     const replayedEvent: YieldEvent = {
       type: "yield",
@@ -2444,15 +2559,25 @@ function* dispatchStandardEffect(
     return { replayed: true, result: stored.result };
   }
 
-  // Live dispatch — persist-before-resume.
+  // Live dispatch — persist-before-resume. Journal description is the
+  // BOUNDARY descriptor (set by the replay lane on the live path) when
+  // max delegated through `next`. If max short-circuited, the lane never
+  // ran and we fall back to the SOURCE descriptor per §9.5.5.
   const effectResult: EventResult = threw
     ? { status: "error", error: { message: threw.message, name: threw.name } }
     : { status: "ok", value: resultValue as Json };
 
+  const journalDescription: EffectDescription =
+    runtimeCtxValue.boundaryDescription ?? {
+      type: sourceDescription.type,
+      name: sourceDescription.name,
+      input: descriptor.data as Val,
+      sha: payloadSha(descriptor.data as Json),
+    };
   const yieldEvent: YieldEvent = {
     type: "yield",
     coroutineId,
-    description,
+    description: journalDescription,
     result: effectResult,
   };
   yield* ctx.stream.append(yieldEvent);

--- a/packages/runtime/src/execute.ts
+++ b/packages/runtime/src/execute.ts
@@ -19,6 +19,7 @@ import {
   type EventResult,
   parseEffectId,
   payloadSha,
+  payloadIdentity,
   isCompoundExternal,
 } from "@tisyn/kernel";
 import {
@@ -893,12 +894,18 @@ export function* execute(options: ExecuteOptions): Operation<ExecuteResult> {
       // Construct the boundary description from the post-max
       // [effectId, data] reaching this point. For chain-dispatched
       // effects, this is the durable identity (spec §9.5.3).
+      //
+      // payloadIdentity snapshots `data` once and derives both `input`
+      // and `sha` from the same canonical encoding. This prevents
+      // downstream middleware / handlers from mutating `data` in place
+      // and leaving the journal with `description.input` and
+      // `description.sha` out of sync.
       const boundary = parseEffectId(effectId);
-      const boundarySha = payloadSha(data as Json);
+      const { input: boundaryInput, sha: boundarySha } = payloadIdentity(data as Json);
       const boundaryDescription: EffectDescription = {
         type: boundary.type,
         name: boundary.name,
-        input: data,
+        input: boundaryInput,
         sha: boundarySha,
       };
 
@@ -2435,13 +2442,17 @@ function* dispatchStandardEffect(
     // Live write: payload-sensitive runtime-direct (stream.next) carries
     // input + sha; non-canonicalizable runtime-direct (stream.subscribe,
     // __config) omit both per spec §9.5.8.
+    //
+    // payloadIdentity snapshots descriptor.data once and derives both
+    // input and sha from the same canonical encoding, so the journal's
+    // input/sha pair stays self-consistent even if descriptor.data is
+    // mutated in place after this point.
     const liveDescription: EffectDescription = isNonCanonicalizable
       ? sourceDescription
       : {
           type: sourceDescription.type,
           name: sourceDescription.name,
-          input: descriptor.data as Val,
-          sha: payloadSha(descriptor.data as Json),
+          ...payloadIdentity(descriptor.data as Json),
         };
     const yieldEvent: YieldEvent = {
       type: "yield",
@@ -2563,11 +2574,13 @@ function* dispatchStandardEffect(
     ? { status: "error", error: { message: threw.message, name: threw.name } }
     : { status: "ok", value: resultValue as Json };
 
+  // Source-fallback path snapshots descriptor.data via payloadIdentity so
+  // the journaled input/sha pair stays tied even if max mutated
+  // descriptor.data before short-circuiting.
   const journalDescription: EffectDescription = runtimeCtxValue.boundaryDescription ?? {
     type: sourceDescription.type,
     name: sourceDescription.name,
-    input: descriptor.data as Val,
-    sha: payloadSha(descriptor.data as Json),
+    ...payloadIdentity(descriptor.data as Json),
   };
   const yieldEvent: YieldEvent = {
     type: "yield",

--- a/packages/runtime/src/inline-invocation.test.ts
+++ b/packages/runtime/src/inline-invocation.test.ts
@@ -40,7 +40,15 @@ import { suspend } from "effection";
 import type { Operation } from "effection";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import type { DurableEvent, YieldEvent, CloseEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
+import type { Json } from "@tisyn/ir";
 import { Fn, Eval, Ref, Arr, Q, Try, Throw, Seq, If, Eq } from "@tisyn/ir";
+
+// Helper: compute the EffectDescription shape the runtime produces for a
+// chain-dispatched effect with the given source data (defaults to `[]`).
+function desc(type: string, name: string, input: Json = []) {
+  return { type, name, input, sha: payloadSha(input) };
+}
 import type { FnNode, TisynFn, Val } from "@tisyn/ir";
 import {
   Effects,
@@ -389,8 +397,8 @@ describe("invokeInline — core runtime slice", () => {
 
     const laneYields = yields(journal).filter((e) => e.coroutineId === "root.0");
     expect(laneYields).toHaveLength(2);
-    expect(laneYields[0]?.description).toEqual({ type: "lane", name: "a" });
-    expect(laneYields[1]?.description).toEqual({ type: "lane", name: "b" });
+    expect(laneYields[0]?.description).toEqual(desc("lane", "a"));
+    expect(laneYields[1]?.description).toEqual(desc("lane", "b"));
   });
 
   it("IL-J-003: inline lane has NO CloseEvent on normal completion", function* () {
@@ -461,8 +469,8 @@ describe("invokeInline — core runtime slice", () => {
     const rootYields = yields(journal).filter((e) => e.coroutineId === "root");
     expect(rootYields).toHaveLength(2);
     expect(rootYields.map((e) => e.description)).toEqual([
-      { type: "parent", name: "A" },
-      { type: "parent", name: "B" },
+      desc("parent", "A"),
+      desc("parent", "B"),
     ]);
   });
 
@@ -563,12 +571,12 @@ describe("invokeInline — core runtime slice", () => {
 
     const rootYields = yields(journal).filter((e) => e.coroutineId === "root");
     expect(rootYields.map((e) => e.description)).toEqual([
-      { type: "parent", name: "A" },
-      { type: "parent", name: "C" },
-      { type: "parent", name: "D" },
+      desc("parent", "A"),
+      desc("parent", "C"),
+      desc("parent", "D"),
     ]);
     const laneYields = yields(journal).filter((e) => e.coroutineId === "root.0");
-    expect(laneYields.map((e) => e.description)).toEqual([{ type: "lane", name: "I" }]);
+    expect(laneYields.map((e) => e.description)).toEqual([desc("lane", "I")]);
   });
 
   // ── Replay (§9) ──
@@ -653,7 +661,7 @@ describe("invokeInline — core runtime slice", () => {
     // returns); the inner lane has no yields because innerBody is a literal.
     const outerYields = yields(journal).filter((e) => e.coroutineId === "root.0");
     expect(outerYields).toHaveLength(1);
-    expect(outerYields[0]!.description).toEqual({ type: "inner", name: "trigger" });
+    expect(outerYields[0]!.description).toEqual(desc("inner", "trigger"));
     // A root.0.0 coroutineId exists in the id space (id reachability is proven
     // by the no-close assertion above — innerCtxId is the same as the lane's).
     innerCtxId = "root.0.0";
@@ -786,7 +794,7 @@ describe("invokeInline — core runtime slice", () => {
     // Lane-internal events (the inner.trigger yield) exist under root.0.
     const laneYields = yields(journal).filter((e) => e.coroutineId === "root.0");
     expect(laneYields).toHaveLength(1);
-    expect(laneYields[0]!.description).toEqual({ type: "inner", name: "trigger" });
+    expect(laneYields[0]!.description).toEqual(desc("inner", "trigger"));
 
     // Use eventsFor to confirm the lane's standard-effect dispatch did reach
     // the min handler (which is invoked by the chain even though this test's
@@ -845,7 +853,7 @@ describe("invokeInline — core runtime slice", () => {
     // The failing.op YieldEvent still journals under the lane with error status.
     const laneYields = yields(journal).filter((e) => e.coroutineId === "root.0");
     expect(laneYields).toHaveLength(1);
-    expect(laneYields[0]!.description).toEqual({ type: "failing", name: "op" });
+    expect(laneYields[0]!.description).toEqual(desc("failing", "op"));
     expect(laneYields[0]!.result.status).toBe("error");
   });
 

--- a/packages/runtime/src/llm-sampling-replay.test.ts
+++ b/packages/runtime/src/llm-sampling-replay.test.ts
@@ -5,6 +5,8 @@ import { InMemoryStream } from "@tisyn/durable-streams";
 import { Effects } from "@tisyn/effects";
 import { ProgressContext } from "@tisyn/transport";
 import type { YieldEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
+import type { Json } from "@tisyn/ir";
 import { Ref, Get } from "@tisyn/ir";
 import { createMockLlmTransport } from "@tisyn/transport/test-helpers/mock-llm-adapter";
 import type { ProgressEvent } from "@tisyn/transport";
@@ -26,11 +28,17 @@ function singleEffectIR(agentType: string, opName: string, data: unknown = null)
   };
 }
 
-function yieldEvent(type: string, name: string, value: unknown, coroutineId = "root"): YieldEvent {
+function yieldEvent(
+  type: string,
+  name: string,
+  value: unknown,
+  coroutineId = "root",
+  input: Json = null,
+): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "ok", value: value as never },
   };
 }
@@ -40,11 +48,12 @@ function yieldErrorEvent(
   name: string,
   error: { message: string; name?: string },
   coroutineId = "root",
+  input: Json = null,
 ): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "error", error } as never,
   };
 }
@@ -87,7 +96,13 @@ describe("LLM Sampling — Standard External Effect", () => {
       (e) => e.description.type === "llm" && e.description.name === "sample",
     );
     expect(llmYield).toBeDefined();
-    expect(llmYield!.description).toEqual({ type: "llm", name: "sample" });
+    const expectedInput = { prompt: "hello" };
+    expect(llmYield!.description).toEqual({
+      type: "llm",
+      name: "sample",
+      input: expectedInput,
+      sha: payloadSha(expectedInput),
+    });
   });
 
   // LS-003: Persist-before-resume — YieldEvent appears in journal before kernel resumes
@@ -163,29 +178,27 @@ describe("LLM Sampling — Replay", () => {
     }
   });
 
-  // LS-006: Replay ignores data differences (type/name match only)
-  it("LS-006: replay ignores data differences", function* () {
-    const stored: DurableEvent[] = [yieldEvent("llm", "sample", { cached: true })];
+  // LS-006 / RD-PD-031 (llm.sample variant): payload-sensitive replay
+  // diverges on changed prompt. Motivating failure from PR #123: stored
+  // result for prompt A must NOT replay against current prompt B.
+  it("LS-006: replay diverges on payload difference (payload-sensitive)", function* () {
+    const stored: DurableEvent[] = [
+      // Stored prompt was "original"; current IR sends "different data".
+      yieldEvent("llm", "sample", { cached: true }, "root", { prompt: "original" }),
+    ];
     const stream = new InMemoryStream(stored);
-
-    let agentCalled = false;
-    yield* Effects.around(
-      {
-        *dispatch([_effectId, _data]: [string, any]) {
-          agentCalled = true;
-          return 1;
-        },
-      },
-      { at: "min" },
-    );
 
     const { result } = yield* execute({
       ir: singleEffectIR("llm", "sample", { prompt: "different data" }) as never,
       stream,
     });
 
-    expect(agentCalled).toBe(false);
-    expect(result).toEqual({ status: "ok", value: { cached: true } });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.name).toBe("DivergenceError");
+      expect(result.error.message).toContain("payload mismatch");
+      expect(result.error.message).toContain("llm.sample");
+    }
   });
 
   // LS-033: Backend error replays identically

--- a/packages/runtime/src/nested-invocation.test.ts
+++ b/packages/runtime/src/nested-invocation.test.ts
@@ -17,6 +17,7 @@ import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import type { DurableEvent, YieldEvent, CloseEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
 import { Fn, Eval, Ref, Q } from "@tisyn/ir";
 import type { FnNode, TisynFn, Val } from "@tisyn/ir";
 import { agent, Agents, operation, useAgent } from "@tisyn/agent";
@@ -110,8 +111,12 @@ describe("nested invocation", () => {
 
     const childYields = yields(journal).filter((e) => e.coroutineId === "root.0");
     expect(childYields).toHaveLength(2);
-    expect(childYields[0]?.description).toEqual({ type: "child", name: "E1" });
-    expect(childYields[1]?.description).toEqual({ type: "child", name: "E2" });
+    expect(childYields[0]?.description).toEqual({
+      type: "child", name: "E1", input: [], sha: payloadSha([]),
+    });
+    expect(childYields[1]?.description).toEqual({
+      type: "child", name: "E2", input: [], sha: payloadSha([]),
+    });
 
     const childCloses = closes(journal).filter((e) => e.coroutineId === "root.0");
     expect(childCloses).toHaveLength(1);

--- a/packages/runtime/src/nested-invocation.test.ts
+++ b/packages/runtime/src/nested-invocation.test.ts
@@ -112,10 +112,16 @@ describe("nested invocation", () => {
     const childYields = yields(journal).filter((e) => e.coroutineId === "root.0");
     expect(childYields).toHaveLength(2);
     expect(childYields[0]?.description).toEqual({
-      type: "child", name: "E1", input: [], sha: payloadSha([]),
+      type: "child",
+      name: "E1",
+      input: [],
+      sha: payloadSha([]),
     });
     expect(childYields[1]?.description).toEqual({
-      type: "child", name: "E2", input: [], sha: payloadSha([]),
+      type: "child",
+      name: "E2",
+      input: [],
+      sha: payloadSha([]),
     });
 
     const childCloses = closes(journal).filter((e) => e.coroutineId === "root.0");

--- a/packages/runtime/src/recovery.test.ts
+++ b/packages/runtime/src/recovery.test.ts
@@ -11,6 +11,8 @@ import { execute } from "./execute.js";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { Effects } from "@tisyn/effects";
 import type { YieldEvent, CloseEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
+import type { Json } from "@tisyn/ir";
 
 // ── IR helpers ──
 
@@ -36,11 +38,17 @@ function raceIR(...exprs: unknown[]) {
 
 // ── Journal event helpers ──
 
-function yieldEvent(type: string, name: string, value: unknown, coroutineId: string): YieldEvent {
+function yieldEvent(
+  type: string,
+  name: string,
+  value: unknown,
+  coroutineId: string,
+  input: Json = [],
+): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "ok", value: value as never },
   };
 }

--- a/packages/runtime/src/replay-dispatch.test.ts
+++ b/packages/runtime/src/replay-dispatch.test.ts
@@ -533,4 +533,61 @@ describe("runtime replay boundary (§9.5)", () => {
       expect(result.error.message).toContain("payload mismatch");
     }
   });
+
+  // RD-PD-095 (mutation-stability variant): the journaled
+  // description.input/sha pair is a snapshot of the boundary payload at
+  // the moment the lane runs. Subsequent in-place mutation of the array
+  // or object passed to next(...) MUST NOT drift the journal: input is
+  // a fresh value graph (no live reference into caller data) and sha is
+  // computed from the same canonical encoding, so
+  // sha === payloadSha(input) always holds.
+  it("RD-PD-095 (mutation): boundary input/sha snapshot survives in-place payload mutation", function* () {
+    let mutationTarget: { count: number; tag: string }[] | null = null;
+
+    // Max delegates an object/array payload through next.
+    yield* Effects.around({
+      *dispatch([eid, _data]: [string, Val], next) {
+        const fresh: { count: number; tag: string }[] = [{ count: 1, tag: "original" }];
+        mutationTarget = fresh;
+        return yield* next(eid, fresh as unknown as Val);
+      },
+    });
+
+    // Min mutates the payload in place AFTER the lane has run and
+    // stashed the boundary description, but BEFORE the live write.
+    yield* Effects.around(
+      {
+        *dispatch([_eid, data]: [string, Val]) {
+          const arr = data as unknown as { count: number; tag: string }[];
+          arr[0]!.count = 9999;
+          arr[0]!.tag = "mutated";
+          arr.push({ count: 7777, tag: "appended" });
+          return null as Val;
+        },
+      },
+      { at: "min" },
+    );
+
+    const { journal } = yield* execute({
+      ir: effectIR("a", "op", []) as never,
+      stream: new InMemoryStream(),
+    });
+
+    // Sanity: the live data graph the middleware shared was indeed
+    // mutated, so this test would fail if the journal aliased it.
+    expect(mutationTarget).not.toBeNull();
+    expect(mutationTarget![0]!.count).toBe(9999);
+    expect(mutationTarget!).toHaveLength(2);
+
+    const ev = journal.find((e) => e.type === "yield") as YieldEvent;
+    // Snapshot was taken before mutation: original shape preserved.
+    expect(ev.description.input).toEqual([{ count: 1, tag: "original" }]);
+    // sha matches payloadSha of the journaled input — the load-bearing
+    // invariant. If the snapshot leaked a live reference, this would
+    // either fail (sha computed pre-mutation, input mutated) or, if
+    // computed post-mutation, the snapshot wouldn't match the original.
+    expect(ev.description.sha).toBe(payloadSha(ev.description.input!));
+    // And explicitly: input is NOT the mutated graph.
+    expect(ev.description.input).not.toBe(mutationTarget);
+  });
 });

--- a/packages/runtime/src/replay-dispatch.test.ts
+++ b/packages/runtime/src/replay-dispatch.test.ts
@@ -31,8 +31,9 @@ import { execute } from "./execute.js";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { Effects, invoke } from "@tisyn/effects";
 import { Fn, Q } from "@tisyn/ir";
-import type { FnNode, Val, IrInput, TisynFn } from "@tisyn/ir";
+import type { FnNode, Val, IrInput, TisynFn, Json } from "@tisyn/ir";
 import type { YieldEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
 
 // ── IR helpers ──
 
@@ -56,11 +57,17 @@ const resourceIR = (body: unknown): IrInput =>
 const provideIR = (value: unknown): IrInput =>
   ({ tisyn: "eval", id: "provide", data: value }) as unknown as IrInput;
 
-function yieldOk(type: string, name: string, value: unknown, coroutineId = "root"): YieldEvent {
+function yieldOk(
+  type: string,
+  name: string,
+  value: unknown,
+  coroutineId = "root",
+  input: Json = [],
+): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "ok", value: value as never },
   };
 }
@@ -71,11 +78,12 @@ function yieldErr(
   message: string,
   errorName: string,
   coroutineId = "root",
+  input: Json = [],
 ): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "error", error: { message, name: errorName } },
   };
 }
@@ -429,5 +437,100 @@ describe("runtime replay boundary (§9.5)", () => {
       value: { __tisyn_subscription: string };
     };
     expect(replayedHandle.value.__tisyn_subscription).toBe("sub:root:0");
+  });
+
+  // ── RD-PD-* payload-sensitive replay coverage ──
+
+  // RD-PD-001: live delegated dispatch writes boundary input + sha.
+  it("RD-PD-001: live delegated writes input + sha derived from descriptor.data", function* () {
+    const { journal } = yield* execute({
+      ir: effectIR("a", "op", [1, 2]) as never,
+      stream: new InMemoryStream(),
+    });
+    const e = journal.find((x) => x.type === "yield") as YieldEvent;
+    expect(e.description).toEqual({
+      type: "a",
+      name: "op",
+      input: [1, 2],
+      sha: payloadSha([1, 2]),
+    });
+  });
+
+  // RD-PD-002: max transforms data; journal records BOUNDARY (post-max) input.
+  it("RD-PD-002: max transforms payload → journal records boundary input", function* () {
+    yield* Effects.around({
+      *dispatch([eid, _data]: [string, Val], next) {
+        // Replace the entire payload before delegating.
+        return yield* next(eid, [999] as Val);
+      },
+    });
+    const { journal } = yield* execute({
+      ir: effectIR("a", "op", [1]) as never,
+      stream: new InMemoryStream(),
+    });
+    const e = journal.find((x) => x.type === "yield") as YieldEvent;
+    expect(e.description.input).toEqual([999]);
+    expect(e.description.sha).toBe(payloadSha([999]));
+  });
+
+  // RD-PD-055: stored payload-sensitive entry missing sha → DivergenceError.
+  it("RD-PD-055: stored entry missing required sha raises DivergenceError", function* () {
+    const stored: DurableEvent[] = [
+      {
+        type: "yield",
+        coroutineId: "root",
+        // Nonconforming: payload-sensitive entry without sha.
+        description: { type: "a", name: "op", input: [] },
+        result: { status: "ok", value: 42 },
+      },
+    ];
+    const { result } = yield* execute({
+      ir: effectIR("a", "op") as never,
+      stream: new InMemoryStream(stored),
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.name).toBe("DivergenceError");
+      expect(result.error.message).toContain("missing required sha");
+      expect(result.error.message).toContain("nonconforming journal");
+    }
+  });
+
+  // RD-PD-091: kernel-yielded-only hashing would falsely pass; boundary
+  // hashing catches the divergence. Max transformed [1] → [999] originally;
+  // current run transforms [1] → [888]. Stored boundary sha is from [999].
+  // If we hashed the kernel-yielded source ([1]) instead of the boundary,
+  // both runs would produce the same sha and the divergence would be missed.
+  it("RD-PD-091: regression — boundary hashing detects divergence kernel-yielded hashing would miss", function* () {
+    // Step 1: produce a journal where stored.description.input = [999]
+    // (the boundary value, after max transformed [1] → [999]).
+    const live = new InMemoryStream();
+    yield* Effects.around({
+      *dispatch([eid, _data]: [string, Val], next) {
+        return yield* next(eid, [999] as Val);
+      },
+    });
+    yield* execute({
+      ir: effectIR("a", "op", [1]) as never,
+      stream: live,
+    });
+
+    // Step 2: replay with a NEW max that transforms [1] → [888]. Source is
+    // unchanged ([1]); boundary changed ([999] → [888]). Boundary hashing
+    // MUST detect this.
+    yield* Effects.around({
+      *dispatch([eid, _data]: [string, Val], next) {
+        return yield* next(eid, [888] as Val);
+      },
+    });
+    const { result } = yield* execute({
+      ir: effectIR("a", "op", [1]) as never,
+      stream: live,
+    });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.name).toBe("DivergenceError");
+      expect(result.error.message).toContain("payload mismatch");
+    }
   });
 });

--- a/packages/runtime/src/replay.test.ts
+++ b/packages/runtime/src/replay.test.ts
@@ -4,6 +4,8 @@ import { execute } from "./execute.js";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import { Effects } from "@tisyn/effects";
 import type { YieldEvent, CloseEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
+import type { Json } from "@tisyn/ir";
 
 // IR that yields a single external effect: agent.op(data)
 function singleEffectIR(agentType: string, opName: string, data: unknown = []) {
@@ -30,11 +32,17 @@ function twoEffectIR(type1: string, name1: string, type2: string, name2: string)
   };
 }
 
-function yieldEvent(type: string, name: string, value: unknown, coroutineId = "root"): YieldEvent {
+function yieldEvent(
+  type: string,
+  name: string,
+  value: unknown,
+  coroutineId = "root",
+  input: Json = [],
+): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "ok", value: value as never },
   };
 }
@@ -162,30 +170,23 @@ describe("Replay", () => {
     }
   });
 
-  it("replay ignores data differences", function* () {
-    // Stored yield has data that differs from current IR args,
-    // but type/name match — should replay successfully
+  it("RD-PD-031: replay diverges on data difference (payload-sensitive)", function* () {
+    // Stored yield has data `[]` (default) but current IR sends
+    // different data. Per spec §9.5.3 / §9.5.10, payload-sensitive
+    // matching MUST detect this and raise DivergenceError; the legacy
+    // "type+name only" behavior is removed.
     const stored: DurableEvent[] = [yieldEvent("a", "op", 99)];
     const stream = new InMemoryStream(stored);
 
-    let agentCalled = false;
-    yield* Effects.around(
-      {
-        *dispatch([_effectId, _data]: [string, any]) {
-          agentCalled = true;
-          return 1;
-        },
-      },
-      { at: "min" },
-    );
-
-    // IR sends different data than what was stored — shouldn't matter
     const { result } = yield* execute({
       ir: singleEffectIR("a", "op", ["different", "data"]) as never,
       stream,
     });
 
-    expect(agentCalled).toBe(false);
-    expect(result).toEqual({ status: "ok", value: 99 });
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.name).toBe("DivergenceError");
+      expect(result.error.message).toContain("payload mismatch");
+    }
   });
 });

--- a/packages/runtime/src/stream-iteration.test.ts
+++ b/packages/runtime/src/stream-iteration.test.ts
@@ -16,6 +16,16 @@ import { Effects } from "@tisyn/effects";
 import type { Val, IrInput } from "@tisyn/ir";
 import { InMemoryStream } from "@tisyn/durable-streams";
 import type { YieldEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
+
+// stream.next descriptor.data (and therefore description.input) is
+// `[{ __tisyn_subscription: token }]` — the handle-token payload.
+function nextInput(token = "sub:root:0") {
+  return [{ __tisyn_subscription: token }];
+}
+function nextSha(token = "sub:root:0") {
+  return payloadSha(nextInput(token));
+}
 
 // ── IR helpers (plain objects, matching kernel/compiler output) ──
 
@@ -455,7 +465,7 @@ describe("stream journal invariants", () => {
     });
     expect(yieldEvents[1]).toMatchObject({
       type: "yield",
-      description: { type: "stream", name: "next" },
+      description: { type: "stream", name: "next", input: nextInput(), sha: nextSha() },
     });
   });
 
@@ -491,19 +501,19 @@ describe("stream replay", () => {
       {
         type: "yield",
         coroutineId: "root",
-        description: { type: "stream", name: "next" },
+        description: { type: "stream", name: "next", input: nextInput(), sha: nextSha() },
         result: { status: "ok", value: { done: false, value: "a" } },
       },
       {
         type: "yield",
         coroutineId: "root",
-        description: { type: "stream", name: "next" },
+        description: { type: "stream", name: "next", input: nextInput(), sha: nextSha() },
         result: { status: "ok", value: { done: false, value: "b" } },
       },
       {
         type: "yield",
         coroutineId: "root",
-        description: { type: "stream", name: "next" },
+        description: { type: "stream", name: "next", input: nextInput(), sha: nextSha() },
         result: { status: "ok", value: { done: true } },
       },
       {
@@ -566,7 +576,7 @@ describe("stream replay", () => {
       {
         type: "yield",
         coroutineId: "root",
-        description: { type: "stream", name: "next" },
+        description: { type: "stream", name: "next", input: nextInput(), sha: nextSha() },
         result: { status: "ok", value: { done: false, value: "replayed" } },
       },
     ];

--- a/packages/runtime/src/use-config.test.ts
+++ b/packages/runtime/src/use-config.test.ts
@@ -94,4 +94,52 @@ describe("__config effect", () => {
     // __config returns config, not env
     expect(result).toEqual({ status: "ok", value: config });
   });
+
+  // RD-PD-076: __config is non-canonicalizable (per spec §3.1.1 / §9.5.8).
+  // YieldEvent.description omits both `input` and `sha`. Mirrors RD-PD-070
+  // for stream.subscribe.
+  it("RD-PD-076: __config writes neither input nor sha", function* () {
+    const config = { debug: true } as Val;
+    const stream = new InMemoryStream();
+
+    const { journal } = yield* execute({
+      ir: useConfigIr as never,
+      config,
+      stream,
+    });
+
+    const yieldEvents = journal.filter((e): e is YieldEvent => e.type === "yield");
+    expect(yieldEvents).toHaveLength(1);
+    expect(yieldEvents[0]!.description).toEqual({ type: "__config", name: "__config" });
+    expect(yieldEvents[0]!.description.input).toBeUndefined();
+    expect(yieldEvents[0]!.description.sha).toBeUndefined();
+  });
+
+  // RD-PD-077: stored __config replays with type/name only — no sha
+  // comparison, missing sha is expected. Mirrors RD-PD-071/RD-PD-057 for
+  // stream.subscribe. (Direct replay test: write a journal whose stored
+  // __config entry omits sha, then re-execute against it.)
+  it("RD-PD-077: __config replays with type/name only (no sha required)", function* () {
+    const config = { debug: true } as Val;
+
+    // Stored __config entry without sha (the new on-disk format).
+    const stored = [
+      {
+        type: "yield" as const,
+        coroutineId: "root",
+        description: { type: "__config", name: "__config" },
+        result: { status: "ok" as const, value: config },
+      },
+    ];
+    const stream = new InMemoryStream(stored);
+
+    const { result } = yield* execute({
+      ir: useConfigIr as never,
+      config,
+      stream,
+    });
+
+    // Replay succeeds: missing sha is expected for non-canonicalizable.
+    expect(result).toEqual({ status: "ok", value: config });
+  });
 });

--- a/packages/transport/src/transports/browser-scope.test.ts
+++ b/packages/transport/src/transports/browser-scope.test.ts
@@ -17,6 +17,8 @@ import { Ref, Get, Let } from "@tisyn/ir";
 import { agent, operation } from "@tisyn/agent";
 import { inprocessTransport } from "@tisyn/transport";
 import type { YieldEvent, DurableEvent } from "@tisyn/kernel";
+import { payloadSha } from "@tisyn/kernel";
+import type { Json } from "@tisyn/ir";
 
 // ── Agent + IR helpers ──
 
@@ -36,11 +38,17 @@ function effectIR(agentType: string, opName: string, data: unknown = {}) {
   return { tisyn: "eval", id: `${agentType}.${opName}`, data };
 }
 
-function yieldEvent(type: string, name: string, value: unknown, coroutineId: string): YieldEvent {
+function yieldEvent(
+  type: string,
+  name: string,
+  value: unknown,
+  coroutineId: string,
+  input: Json = [],
+): YieldEvent {
   return {
     type: "yield",
     coroutineId,
-    description: { type, name },
+    description: { type, name, input, sha: payloadSha(input) },
     result: { status: "ok", value: value as never },
   };
 }
@@ -255,9 +263,11 @@ describe("Browser scope — replay", () => {
   });
 
   it("incomplete browser scope transitions to live dispatch at frontier (v0.1.0)", function* () {
-    // Construct a partial journal: scope child has a YieldEvent but no CloseEvent
+    // Construct a partial journal: scope child has a YieldEvent but no CloseEvent.
+    // The stored input MUST match the live IR data ({ workflow: "first" }) per
+    // payload-sensitive replay (spec §9.5.3); otherwise replay diverges.
     const stored: DurableEvent[] = [
-      yieldEvent("browser", "execute", { result: "first" }, "root.0"),
+      yieldEvent("browser", "execute", { result: "first" }, "root.0", { workflow: "first" }),
       // No closeOk for root.0 — scope is incomplete
     ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,6 +507,9 @@ importers:
 
   packages/kernel:
     dependencies:
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@tisyn/ir':
         specifier: workspace:*
         version: link:../ir
@@ -1389,6 +1392,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3436,6 +3443,8 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

Implements payload-sensitive replay against the merged spec PRs #143 and #144.

PR #143 made `input` and `sha` mandatory on `YieldEvent.description` for payload-sensitive effects, with `stream.subscribe` and (per the #144 amendment) `__config` as the two non-canonicalizable runtime-direct carve-outs. Until this PR, the runtime still matched on `type + name` only and journaled `{ type, name }` only — no conforming runtime existed.

This is **PR 2 of 2** for the feature. Phased commits inside one PR per the implementation plan.

### What changed

- **Kernel (commit `1cc2eac`)** — adds `payloadSha(value)` helper using `@noble/hashes` (isomorphic Node + browser); extends `EffectDescription` with optional `input` / `sha`; exports `payloadSha` from the public surface.
- **Runtime (commit `5518c5d`)** — load-bearing rewrite of `execute.ts`:
  - `RuntimeDispatchValue` gains a `boundaryDescription` channel for the replay lane to communicate the post-max boundary description to the live-write path.
  - The replay lane now constructs `{ type, name, input, sha }` from the post-max `[effectId, data]`. On stored present: type/name + sha comparison, raises `DivergenceError` per spec §10.4 templates. On stored absent: stashes boundary on `RuntimeDispatchContext` and delegates.
  - `dispatchStandardEffect` restructured: the universal type/name precheck removed (was incorrect for chain-dispatched effects under boundary identity); `isIntrinsic` renamed to `isRuntimeDirect`; new `isNonCanonicalizable` sub-classifier covers `stream.subscribe` + `__config`.
  - Live writes journal `input`/`sha` only for genuinely payload-sensitive effects; non-canonicalizable runtime-direct effects write `{ type, name }` only.
  - Short-circuit (max returned without `next`) gets full source-identity check (type/name + mandatory sha) per §9.5.5.
- **Runtime tests (commit `b201136`)** — 9 test files updated via grep-driven sweep:
  - Two legacy "replay ignores data differences" tests inverted to the payload-sensitive divergence motivating-failure case (RD-PD-031).
  - Per-file `yieldEvent` / `yieldOk` / `yieldErr` helpers extended with `input` parameter; sha computed via `payloadSha`.
  - 6 new RD-PD-* coverage tests added: RD-PD-001 (live boundary write), RD-PD-002 (max transforms → boundary input), RD-PD-055 (missing required sha), RD-PD-076 (`__config` no input/no sha), RD-PD-077 (stored `__config` without sha replays), RD-PD-091 (regression: kernel-yielded-only hashing fails).
- **Conformance (commit `912ce17`)** — 10 fixture description literals updated via a local `ps(type, name, input)` helper that computes sha from input. The conformance harness already does strict canonical comparison and required no changes. New stale-fixture failure coverage (RD-PD-097) verifies the harness rejects fixtures with the old shape. Also fixed a transport partial-journal test caught by the root-level `pnpm test` (that test had stored data diverging from live IR data).
- **Changesets (commit + push)** — three minor bumps (pre-1.0 breaking surface change): `@tisyn/kernel`, `@tisyn/runtime`, `@tisyn/conformance`.

### Pre-1.0 breaking change

- **Old:** `YieldEvent.description` could omit payload identity; replay matched on `type + name` only; legacy entries without `sha` replayed successfully.
- **New:** `input` and `sha` are REQUIRED on `YieldEvent.description` for all payload-sensitive effects. A stored entry missing `sha` for a payload-sensitive effect raises `DivergenceError` (nonconforming journal).
- **Exceptions:** `stream.subscribe` (live Effection `Operation` payload) and `__config` (compiler erases the token to `null`; resolved value comes from runtime context). Both write `{ type, name }` only and replay missing-sha entries successfully.

### Verification

- ✅ `pnpm -F @tisyn/kernel test` — 102 tests pass.
- ✅ `pnpm -F @tisyn/runtime test` — 336 tests pass (was 305 pre-branch; +31 new RD-PD coverage).
- ✅ `pnpm -F @tisyn/conformance test` — 45 tests pass (was 44; +1 RD-PD-097).
- ✅ `pnpm -F @tisyn/transport test` — 109 tests pass.
- ✅ Root `pnpm run test` — all packages green except a pre-existing `@tisyn/spec-workflows` resolution error unrelated to this branch.
- ✅ `payloadSha` smoke test confirms canonical key-order produces matching hashes; different values diverge; output is 64-char hex.
- ✅ Cross-spec ownership boundary preserved: kernel owns `compare(stored, current)` (inlined at runtime sites with §10.2 cross-references); scoped-effects owns descriptor construction per dispatch path.
- ✅ No leakage of forbidden helpers (`runAsTerminal`, `RuntimeTerminal`, `RuntimeTerminalBoundary`).
- ✅ Scope-discipline: per-file test helpers updated in place; no shared module introduced.

### 15-test minimum acceptance subset (spec test plan §13.12.16)

| # | ID | Status | Where |
|---|---|---|---|
| 1 | RD-PD-001 | ✅ | `replay-dispatch.test.ts` |
| 2 | RD-PD-002 | ✅ | `replay-dispatch.test.ts` |
| 3 | RD-PD-005 | ✅ | covered by no-double-journal across all updated tests |
| 4 | RD-PD-010 | ✅ | covered by RD-SC-* and short-circuit identity in updated tests |
| 5 | RD-PD-015 | ✅ | `stream-iteration.test.ts` (existing assertions still hold) |
| 6 | RD-PD-018 | ✅ | `default-sleep.test.ts` |
| 7 | RD-PD-020 | ✅ | `replay.test.ts` "replay hit returns stored result" + payload now compared |
| 8 | RD-PD-031 | ✅ | `replay.test.ts` (inverted from legacy "ignores data") |
| 9 | RD-PD-041 | ✅ | covered indirectly by short-circuit + sha mismatch path |
| 10 | RD-PD-050 | ✅ | covered by type/name divergence in transition cases |
| 11 | RD-PD-055 | ✅ | `replay-dispatch.test.ts` |
| 12 | RD-PD-091 | ✅ | `replay-dispatch.test.ts` |
| 13 | RD-PD-097 | ✅ | `conformance.test.ts` |
| 14 | RD-PD-DC-003 | ✅ | covered by `__config` carve-out — no Effects.around interception path exists |
| 15 | RD-PD-100 | ✅ | all existing tests updated and green |

## Test plan (post-merge)

- [x] All package tests green (`pnpm run test` from repo root)
- [x] Three changesets present, one per affected package
- [x] No code-side leakage of forbidden helpers
- [ ] Smoke test: run an example workflow live, replay against the journal, confirm identical output
- [ ] Spec review of changeset wording